### PR TITLE
Use the RMG source code instead of binaries for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,12 @@ jobs:
         - cd ARC
         - export PYTHONPATH=$PYTHONPATH:$(pwd)
         - cd ..
-        - conda install -y -c conda-forge codecov
+        - git clone https://github.com/ReactionMechanismGenerator/RMG-database
+        - git clone https://github.com/ReactionMechanismGenerator/RMG-Py
+        - cd RMG-Py
+        - export PYTHONPATH=$PYTHONPATH:$(pwd)
+        - make
+        - cd ..
         - conda list
         - cd T3
       script:

--- a/environment.yml
+++ b/environment.yml
@@ -22,5 +22,4 @@ dependencies:
   - pyyaml
   - qcelemental
   - rdkit >=2019.09.2.0
-  - rmg >=3.0.0
   - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -5,21 +5,56 @@ channels:
   - rdkit
   - cantera
   - anaconda
+  - omnia
   - pytorch
   - conda-forge
 dependencies:
+  - ase >=3.15.0
+  - cairo
+  - cairocffi
+  - cantera >=2.3.0
+  - cclib >=1.6
+  - chemprop
+  - codecov
+  - coolprop
   - coverage
+  - cython >=0.25.2
+  - ffmpeg
+  - gprof2dot
+  - graphviz
+  - h5py
   - ipython
+  - jinja2
   - jupyter
+  - lpsolve55
+  - markupsafe
   - matplotlib >=2.2.2
+  - mock
+  - mopac
+  - mpmath
+  - networkx
+  - nose
+  - numdifftools
   - numpy >=1.15.4
+  - openbabel
   - paramiko >=2.6.0
   - pandas
+  - psutil
   - py3dmol >= 0.8.0
+  - pydas >=1.0.1
+  - pydot
+  - pydqed >=1.0.0
+  - pymongo
   - pyparsing
-  - pytest
+  - pyrdl
   - python >=3.7
+  - pytest
   - pyyaml
   - qcelemental
+  - quantities
   - rdkit >=2019.09.2.0
+  - scikit-learn
+  - scipy
   - sphinx
+  - symmetry
+  - xlwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,18 @@
 # Required python packages
 
+ase>=3.15.0
+cclib>=1.6
 coverage
-numpy
-paramiko
+cython >=0.25.2
+matplotlib>=2.2.2
+numpy==1.15.4
+openbabel
+paramiko==2.6.0
 pandas
+py3Dmol==0.8.0
+pyyaml
 pydantic
+pydas >=1.0.1
 pytest
 qcelemental
 rdkit >=2019.09.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ pydantic
 pytest
 qcelemental
 rdkit >=2019.09.2.0
-rmg >=3.0.0


### PR DESCRIPTION
Since T3 still requires modifications to both RMG and ARC, for now it requires the updated source code of both repos and not binaries.