### PR TITLE
Minor: remove refernence to tandem/_version.py which does not exist

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,6 @@ coverage:
   percision: 2
   ignore:
     - tests/**/*
-    - tandem/_version.py
 comment:
   layout: "reach, diff, flags, files"
   require_changes: false


### PR DESCRIPTION
`codecov.yml` was previously instructed to ignore a file that doesn't exist; this super minor PR removes that line.