### PR TITLE
Misc modifications, mostly PDep related

### DIFF
--- a/t3/main.py
+++ b/t3/main.py
@@ -1002,7 +1002,8 @@ class T3(object):
                     if species is None:
                         self.logger.error(f'Could not identify species {label}!')
                     if self.species_requires_refinement(species=species):
-                        reason = f'Species participates in collision rate violating reaction: {rxn_to_log}'
+                        reason = f'(i {self.iteration}) Species participates in collision rate violating ' \
+                                 f'reaction: {rxn_to_log}'
                         species_keys.append(self.add_species(species=species, reasons=reason))
         return species_keys
 

--- a/t3/main.py
+++ b/t3/main.py
@@ -832,7 +832,6 @@ class T3(object):
         """
         Determine species to calculate based on a pressure dependent network
         by spawning network sensitivity analyses.
-        First tries the CSE method, if unsuccessful tries the MSC method.
 
         Args:
             pdep_rxns_to_explore (List[Tuple[Reaction, int, str]]):

--- a/t3/main.py
+++ b/t3/main.py
@@ -710,10 +710,10 @@ class T3(object):
                     species_keys.append(self.add_species(species=species, reasons=['All core species']))
         else:
             # 1. SA observables
-            sa_obserables_exist = False
+            sa_observables_exist = False
             for input_species in self.rmg['species']:
                 if input_species['observable'] or input_species['SA_observable']:
-                    sa_obserables_exist = True
+                    sa_observables_exist = True
                     if self.species_requires_refinement(species=get_species_by_label(input_species['label'],
                                                                                      self.rmg_species)):
                         species_keys.append(self.add_species(
@@ -721,7 +721,7 @@ class T3(object):
                             reasons=['SA observable'],
                         ))
             # 2. SA
-            if sa_obserables_exist:
+            if sa_observables_exist:
                 species_keys.extend(self.determine_species_based_on_sa())
             # 3. collision violators
             if self.t3['options']['collision_violators_thermo']:

--- a/t3/main.py
+++ b/t3/main.py
@@ -1100,7 +1100,7 @@ class T3(object):
                     check_duplicates=False,
                 )
             except ChemkinError:
-                self.logger.error(f"Could still not read the Chemkin file {self.paths['chem annotated']}!")
+                self.logger.error(f"Still could not read the Chemkin file {self.paths['chem annotated']}!")
                 raise
             else:
                 self.logger.warning(f"Read the Chemkin file\n{self.paths['chem annotated']}\n"

--- a/t3/main.py
+++ b/t3/main.py
@@ -871,7 +871,7 @@ class T3(object):
                                    for network_file_name in network_file_names])
             network_name = f'network{reaction.network.index}_{network_version}'  # w/o the '.py' extension
 
-            # try running this network using either the CSE or the MSC method
+            # Try running this network using user-specified methods by order.
             sa_coefficients_path, arkane = None, None
             errors = list()
             for method in PDEP_SA_ME_METHODS:
@@ -884,7 +884,7 @@ class T3(object):
                 arkane = Arkane(input_file=os.path.join(self.paths['PDep SA'], network_name, method, 'input.py'),
                                 output_directory=os.path.join(self.paths['PDep SA'], network_name, method))
                 arkane.plot = True
-                self.logger.info(f'\nRuning Pdep SA for network {network_name} using the {method} method...')
+                self.logger.info(f'\nRunning PDep SA for network {network_name} using the {method} method...')
                 try:
                     arkane.execute()
                 except (ChemicallySignificantEigenvaluesError,
@@ -894,15 +894,15 @@ class T3(object):
                         TypeError) as e:
                     errors.append(e)
                 else:
-                    # network execution was successful, mark network as executed and don't run the next method
-                    self.logger.info(f'Successfully executed a Pdep SA for network {network_name} '
+                    # Network execution was successful, mark network as executed and don't run the next method.
+                    self.logger.info(f'Successfully executed a PDep SA for network {network_name} '
                                      f'using the {method} method.\n')
                     self.executed_networks.append(isomer_labels)
                     sa_coefficients_path = os.path.join(self.paths['PDep SA'], network_name, method,
                                                         'sensitivity', 'sa_coefficients.yml')
                     break
             else:
-                self.logger.error(f'Could not execute a Pdep SA for network {network_name} using '
+                self.logger.error(f'Could not execute a PDep SA for network {network_name} using '
                                   f'{PDEP_SA_ME_METHODS}.\nGot the following errors:')
                 for method, e in zip(PDEP_SA_ME_METHODS, errors):
                     self.logger.info(f'{e.__class__} for method {method}:\n{e}\n')
@@ -912,7 +912,7 @@ class T3(object):
                 reactants_label = ' + '.join([reactant.to_chemkin() for reactant in reaction.reactants])
                 products_label = ' + '.join([product.to_chemkin() for product in reaction.products])
                 chemkin_reaction_str = f'{reactants_label} <=> {products_label}'
-                labels_map = dict()  # keys are network species labels, values are Chemkin labels of the RMG species
+                labels_map = dict()  # Keys are network species labels, values are Chemkin labels of the RMG species.
                 for network_label, adj in sa_dict['structures'].items():
                     labels_map[network_label] = get_species_label_by_structure(adj=adj, species_list=self.rmg_species)
 

--- a/t3/main.py
+++ b/t3/main.py
@@ -714,10 +714,12 @@ class T3(object):
             for input_species in self.rmg['species']:
                 if input_species['observable'] or input_species['SA_observable']:
                     sa_obserables_exist = True
-                    species_keys.append(self.add_species(
-                        species=get_species_by_label(input_species['label'], self.rmg_species),
-                        reasons=['SA observable'],
-                    ))
+                    if self.species_requires_refinement(species=get_species_by_label(input_species['label'],
+                                                                                     self.rmg_species)):
+                        species_keys.append(self.add_species(
+                            species=get_species_by_label(input_species['label'], self.rmg_species),
+                            reasons=['SA observable'],
+                        ))
             # 2. SA
             if sa_obserables_exist:
                 species_keys.extend(self.determine_species_based_on_sa())

--- a/t3/schema.py
+++ b/t3/schema.py
@@ -172,7 +172,7 @@ class RMGReactor(BaseModel):
     """
     type: str
     T: Union[confloat(gt=0), List[confloat(gt=0)]]
-    P: Optional[Union[confloat(gt=0), List[confloat(gt=0)]]]
+    P: Optional[Union[confloat(gt=0), List[confloat(gt=0)]]] = None
     termination_conversion: Optional[Dict[str, confloat(gt=0, lt=1)]] = None
     termination_time: Optional[List[Union[confloat(gt=0), TerminationTimeEnum]]] = None
     termination_rate_ratio: Optional[confloat(gt=0, lt=1)] = None
@@ -618,6 +618,7 @@ class InputBase(BaseModel):
             # check core_tolerance and max_T3_iterations
             if 'model' in values['rmg'] and 'core_tolerance' in values['rmg']['model'] \
                     and 'options' in values['t3'] and 'max_T3_iterations' in values['t3']['options'] \
+                    and not isinstance(values['rmg']['model']['core_tolerance'], float) \
                     and len(values['rmg']['model']['core_tolerance']) > values['t3']['options']['max_T3_iterations']:
                 raise ValueError(f'The number of RMG core tolerances ({len(values["rmg"]["model"]["core_tolerance"])}) '
                                  f'cannot be greater than the max number of T3 iterations '

--- a/t3/utils/writer.py
+++ b/t3/utils/writer.py
@@ -246,7 +246,7 @@ pressureDependence(
     maximumAtoms=${max_atoms},
 )
 """
-        pdep['method'] = METHOD_MAP[pdep['method']]
+        pdep['method'] = METHOD_MAP[pdep['method']] if pdep['method'] not in METHOD_MAP.values() else pdep['method']
         pdep['T_min'], pdep['T_max'], pdep['T_count'] = pdep['T']
         pdep['P_min'], pdep['P_max'], pdep['P_count'] = pdep['P']
         del pdep['T']

--- a/t3/utils/writer.py
+++ b/t3/utils/writer.py
@@ -233,8 +233,8 @@ liquidReactor(
                                                          )
 
     # pressureDependence
-    pdep = rmg['pdep']
-    if pdep is not None:
+    if rmg['pdep'] is not None:
+        pdep = rmg['pdep'].copy()
         pdep_template = """
 pressureDependence(
     method='${method}',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -536,10 +536,10 @@ def test_determine_species_to_calculate():
     # 4. SA observables
     assert t3.species[0]['RMG label'] == 'CC=[C]CCCC'
     assert t3.species[0]['reasons'] == \
-           ['Species participates in collision rate violating reaction: H(3)+C7H13(920)=C7H14(323)']
+           ['(i 3) Species participates in collision rate violating reaction: H(3)+C7H13(920)=C7H14(323)']
     assert t3.species[1]['RMG label'] == '[CH2]CC(=C)C=C'
     assert t3.species[1]['reasons'] == \
-           ['Species participates in collision rate violating reaction: HO2(10)+C6H9(1933)=H2O2(11)+C6H8(2025)']
+           ['(i 3) Species participates in collision rate violating reaction: HO2(10)+C6H9(1933)=H2O2(11)+C6H8(2025)']
 
 
 def test_species_requires_refinement():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -939,12 +939,32 @@ def test_get_species_label_by_structure():
                      iteration=1,
                      set_paths=True,
                      )
-    rmg_species, rmg_reactions = t3.load_species_and_reactions_from_chemkin_file()
+    rmg_species = t3.load_species_and_reactions_from_chemkin_file()[0]
     adj = """1 O u0 p2 c0 {2,S} {3,S}
 2 H u0 p0 c0 {1,S}
 3 H u0 p0 c0 {1,S}"""
     label = get_species_label_by_structure(adj, rmg_species)
     assert label == 'H2O'
+
+    spc_1 = Species(label='CH2')
+    adj_1 = """CH2
+multiplicity 3
+1 C u2 p0 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}"""
+    spc_1.from_adjacency_list(adj_1)
+    spc_2 = Species(label='CH2(S)')
+    adj_2 = """CH2(S)
+multiplicity 1
+1 C u0 p1 c0 {2,S} {3,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}"""
+    spc_2.from_adjacency_list(adj_2)
+    species_list = [spc_1, spc_2]
+    label_1 = get_species_label_by_structure(adj_1, species_list)
+    assert label_1 == 'CH2'
+    label_2 = get_species_label_by_structure(adj_2, species_list)
+    assert label_2 == 'CH2(S)'
 
 
 def test_check_overtime():


### PR DESCRIPTION
Several enhancements related to PDep:
-  Don't look in METHOD_MAP a second time: When writing an RMG input file, pdep['method'] is being assigned a value according to the respective acronym. After assigning the value, we should not look again in the METHOD_MAP dict.
- Only compute thermo for an SA observable if it requires refinement
- Check that core_tolerance is not a float before determining its length
- BugFix: Modify a copy of pdep in writer
- Check multiplicity as well when performing isomorphism check (test added)