### PR TITLE
Constrain conda channels in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,64 +2,61 @@ name: t3_env
 channels:
   - defaults
   - rmg
-  - rdkit
-  - cantera
   - anaconda
   - omnia
-  - pytorch
   - conda-forge
   - mjohnson541
 dependencies:
   - ase >=3.15.0
   - cairo
   - cairocffi
-  - cantera >=2.3.0
+  - rmg::cantera >=2.3.0
   - cclib >=1.6
-  - chemprop
+  - rmg::chemprop
   - codecov
   - coolprop
   - coverage
   - cython >=0.25.2
   - ffmpeg
-  - gprof2dot
+  - rmg::gprof2dot
   - graphviz
   - h5py
   - ipython
   - jinja2
   - jupyter
-  - lpsolve55
+  - rmg::lpsolve55
   - mako
   - markupsafe
   - matplotlib >=2.2.2
   - mkdocs-material >=5.1.7
   - mkdocs-material-extensions
   - mock
-  - mopac
+  - rmg::mopac
   - mpmath
   - networkx
   - nose
-  - numdifftools
+  - rmg::numdifftools
   - numpy >=1.15.4
   - openbabel
   - paramiko >=2.6.0
   - pandas
   - psutil
   - py3dmol >= 0.8.0
-  - pydas
+  - rmg::pydas >=1.0.2
   - pydot
-  - pydqed >=1.0.0
+  - rmg::pydqed >=1.0.1
   - pymongo
   - pyparsing
-  - pyrdl
+  - rmg::pyrdl
   - pyrms
   - python >=3.7
   - pytest
   - pyyaml
   - qcelemental
-  - quantities
-  - rdkit >=2019.09.2.0
+  - rmg::quantities
+  - rmg::rdkit >=2020.03.3.0
   - scikit-learn
   - scipy
   - sphinx
-  - symmetry
+  - rmg::symmetry
   - xlwt


### PR DESCRIPTION
Recently, the `environment.yml` file was updated for RMG-Py and for ARC to avoid excessive wait times while conda resolves the environment. This PR similarly constrains the conda channels when creating the `t3_env` in hopes of avoiding the excessive wait times. Thanks to Professor West for making the initial changes on RMG-Py in [PR #2089](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2089). 