### PR TITLE
Separate pyrms tests

### DIFF
--- a/.github/workflows/cont_int.yml
+++ b/.github/workflows/cont_int.yml
@@ -41,5 +41,6 @@ jobs:
         cd ..
         cd T3
         conda activate t3_env
-        make test
+        make test-no-pyrms
+        make test-pyrms
         codecov

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,9 @@ test-main:
 
 test-functional:
 	pytest tests/test_functional.py -ra -vv
+
+test-no-pyrms:
+	pytest -ra -vv -m "not skip"
+
+test-pyrms:
+	pytest -ra -vv -m "skip"

--- a/tests/test_simulate_adapters/test_rms_constantHP.py
+++ b/tests/test_simulate_adapters/test_rms_constantHP.py
@@ -6,6 +6,7 @@ t3 tests test_rms_constantHP module
 """
 
 import os
+import pytest
 import shutil
 
 from t3.common import SIMULATE_DATA_BASE_PATH
@@ -15,7 +16,7 @@ from t3.simulate.rms_constantHP import RMSConstantHP
 
 TEST_DIR = os.path.join(SIMULATE_DATA_BASE_PATH, 'rms_simulator_test')
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_set_up_no_sa():
     """
     Run RMG's minimal example without SA by testing the `set_up` method within the RMSSimulator init method.
@@ -36,7 +37,7 @@ def test_set_up_no_sa():
     # check that there are over 20 time steps (as an arbitrary number) to indicate that the solver completed
     assert len(rms_simulator_adapter.sol.t) > 20
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_get_sa_coefficients():
     """
     Run RMG's minimal example with SA.
@@ -65,7 +66,7 @@ def test_get_sa_coefficients():
     assert len(sa_dict['kinetics']) == 2
     assert len(sa_dict['thermo']) == 2
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_get_idt_by_T():
     """
     Calculate the ignition delay time for RMG's minimal example.
@@ -87,7 +88,7 @@ def test_get_idt_by_T():
     assert len(idt_dict['idt']) == 1
     assert len(idt_dict['idt_index']) == 1
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def teardown_module():
     """
     A method that is run after all unit tests in this class.

--- a/tests/test_simulate_adapters/test_rms_constantTP.py
+++ b/tests/test_simulate_adapters/test_rms_constantTP.py
@@ -15,7 +15,7 @@ from t3.simulate.rms_constantTP import RMSConstantTP
 
 TEST_DIR = os.path.join(SIMULATE_DATA_BASE_PATH, 'rms_simulator_test')
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_set_up_no_sa():
     """
     Run RMG's minimal example without SA by testing the `set_up` method within the RMSSimulator init method.
@@ -36,7 +36,7 @@ def test_set_up_no_sa():
     # check that there are over 20 time steps (as an arbitrary number) to indicate that the solver completed
     assert len(rms_simulator_adapter.sol.t) > 20
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_get_sa_coefficients():
     """
     Run RMG's minimal example with SA.
@@ -65,7 +65,7 @@ def test_get_sa_coefficients():
     assert len(sa_dict['kinetics']) == 2
     assert len(sa_dict['thermo']) == 2
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_get_idt_by_T():
     """
     Calculate the ignition delay time for RMG's minimal example.
@@ -87,7 +87,7 @@ def test_get_idt_by_T():
     assert len(idt_dict['idt']) == 0
     assert len(idt_dict['idt_index']) == 0
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def teardown_module():
     """
     A method that is run after all unit tests in this class.

--- a/tests/test_simulate_adapters/test_rms_constantUV.py
+++ b/tests/test_simulate_adapters/test_rms_constantUV.py
@@ -15,7 +15,7 @@ from t3.simulate.rms_constantUV import RMSConstantUV
 
 TEST_DIR = os.path.join(SIMULATE_DATA_BASE_PATH, 'rms_simulator_test')
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_set_up_no_sa():
     """
     Run RMG's minimal example without SA by testing the `set_up` method within the RMSSimulator init method.
@@ -36,7 +36,7 @@ def test_set_up_no_sa():
     # check that there are over 20 time steps (as an arbitrary number) to indicate that the solver completed
     assert len(rms_simulator_adapter.sol.t) > 20
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_get_sa_coefficients():
     """
     Run RMG's minimal example with SA.
@@ -65,7 +65,7 @@ def test_get_sa_coefficients():
     assert len(sa_dict['kinetics']) == 2
     assert len(sa_dict['thermo']) == 2
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def test_get_idt_by_T():
     """
     Calculate the ignition delay time for RMG's minimal example.
@@ -87,7 +87,7 @@ def test_get_idt_by_T():
     assert len(idt_dict['idt']) == 1
     assert len(idt_dict['idt_index']) == 1
 
-
+@pytest.mark.skip(reason="Skipping pyrms tests.")
 def teardown_module():
     """
     A method that is run after all unit tests in this class.


### PR DESCRIPTION
Since we often spend a lot of time resolving pyrms errors, one possible solution is to temporarily separate tests for the pyrms simulate adapters from the other tests in T3. This would allow us to more easily focus on developing features of T3

We could also consider the `xfail` [decorator](https://docs.pytest.org/en/reorganize-docs/new-docs/user/xfail.html) if we expect these tests to frequently fail. However, "having the xfail marker will still run the test but won’t report a traceback once it fails" and the traceback is useful in case we can fix the error.