### PR TITLE
Limit the number of RMG runs per iteration

### DIFF
--- a/t3/logger.py
+++ b/t3/logger.py
@@ -51,8 +51,8 @@ class Logger(object):
         if os.path.isfile(self.log_file):
             if not os.path.isdir(os.path.join(os.path.dirname(self.log_file), 'log_archive')):
                 os.mkdir(os.path.join(os.path.dirname(self.log_file), 'log_archive'))
-            local_time = datetime.datetime.now().strftime("%H%M%S_%b%d_%Y")
-            log_backup_name = f't3.{local_time}].log'
+            local_time = datetime.datetime.now().strftime("%b%d_%Y_%H:%M:%S")
+            log_backup_name = f't3.{local_time}.log'
             shutil.copy(self.log_file, os.path.join(os.path.dirname(self.log_file), 'log_archive', log_backup_name))
             os.remove(self.log_file)
 

--- a/t3/runners/rmg_runner.py
+++ b/t3/runners/rmg_runner.py
@@ -5,6 +5,7 @@ Should be executed locally on the head node using the t3 environment.
 
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
+import datetime
 import os
 import time
 
@@ -300,6 +301,10 @@ def rmg_runner(rmg_input_file_path: str,
             while job_id in check_running_jobs_ids(cluster_soft=LOCAL_CLUSTER_SOFTWARE):
                 time.sleep(120)
             converged, error = rmg_job_converged(project_directory=project_directory)
+            err_path = os.path.join(project_directory, 'err.txt')
+            if os.path.isfile(err_path):
+                os.rename(err_path, os.path.join(project_directory,
+                                                 f'err_{datetime.datetime.now().strftime("%b%d_%Y_%H:%M:%S")}.txt'))
             rmg_errors.append(error)
             if not converged:
                 if error is not None:

--- a/t3/runners/rmg_runner.py
+++ b/t3/runners/rmg_runner.py
@@ -225,7 +225,8 @@ def run_rmg_in_local_queue(project_directory: str,
     rmg_input_path = os.path.join(project_directory, 'input.py')
     with open(rmg_input_path, 'r') as f:
         content = f.read()
-    if restart_rmg and restart_string not in content and os.path.isdir(os.path.join(project_directory, 'seed')):
+    seed_path = os.path.join(project_directory, 'seed')
+    if restart_rmg and restart_string not in content and os.path.isdir(seed_path) and os.listdir(seed_path):
         if os.path.isfile(os.path.join(project_directory, 'restart_from_seed.py')):
             if os.path.isfile(os.path.join(project_directory, 'input.py')):
                 os.rename(src=os.path.join(project_directory, 'input.py'),
@@ -310,7 +311,8 @@ def rmg_runner(rmg_input_file_path: str,
                       and new_memory is not None \
                       and runner_counter < MAX_RMG_RUNS_PER_ITERATION \
                       and not(len(rmg_errors) >= 2 and error is not None and error == rmg_errors[-2])
-            restart_rmg = True
+            restart_rmg = False if error is not None and 'Could not find one or more of the required files/directories ' \
+                                                         'for restarting from a seed mechanism' in error else True
         return not converged
     else:
         logger.warning(f'Expected wither "incore" or "local" execution type for RMG, got {rmg_execution_type}.\n'

--- a/tests/data/rmg_convergence/1_frag_error/RMG.log
+++ b/tests/data/rmg_convergence/1_frag_error/RMG.log
@@ -1,0 +1,248 @@
+Global RMG Settings:
+   database.directory   = /home/alon/Code/RMG-database/input (Default, relative to RMG-Py source code)
+   test_data.directory  = /home/alon/Code/RMG-Py/rmgpy/test_data (Default, relative to RMG-Py source code)
+RMG execution initiated at Sat Jan 28 05:02:15 2023
+
+#########################################################
+# RMG-Py - Reaction Mechanism Generator in Python       #
+# Version: 3.1.0                                        #
+# Authors: RMG Developers (rmg_dev@mit.edu)             #
+# P.I.s:   William H. Green (whgreen@mit.edu)           #
+#          Richard H. West (r.west@neu.edu)             #
+# Website: http://reactionmechanismgenerator.github.io/ #
+#########################################################
+
+The current git HEAD for RMG-Py is:
+	b'2cdc2ea7cd53e6a09648c6c50bc936812207fc81'
+	b'Tue Dec 13 18:22:41 2022 -0800'
+
+The current git HEAD for RMG-database is:
+	b'c817bf8fd3620a208f3a650ca84626b9dcd6d6cf'
+	b'Mon Jan 2 15:35:01 2023 +0200'
+
+Reading input file "/home/alon/runs/T3/xsc2101/iteration_2/RMG/input.py"...
+restartFromSeed(path='seed')
+
+database(
+    thermoLibraries=['/home/alon/runs/T3/xsc2101/Libraries/dodecane.py', 'primaryThermoLibrary', 'BurkeH2O2', 'thermo_DFT_CCSDTF12_BAC', 'DFT_QCI_thermo', 'Spiekermann_refining_elementary_reactions', 'CurranPentane', 'C3', 'CBS_QB3_1dHR', 'FFCM1(-)', 'JetSurF2.0', 's3_5_7_ane', 'naphthalene_H', 'USC-Mech-ii', 'heavy_oil_ccsdtf12_1dHR', 'bio_oil', 'vinylCPD_H', 'Klippenstein_Glarborg2016', 'Fulvene_H', 'Chernov', 'C10H11', 'CH'],
+    reactionLibraries=['primaryH2O2', 'C2H2_init', 'C2H4+O_Klipp2017', 'CurranPentane', 'FFCM1(-)', 'NOx2018', 'JetSurF2.0', 'Klippenstein_Glarborg2016', 'C10H11', 'C12H11_pdep', 'Lai_Hexylbenzene', '1989_Stewart_2CH3_to_C2H5_H', '2001_Tokmakov_H_Toluene_to_CH3_Benzene', '2003_Miller_Propargyl_Recomb_High_P', '2005_Senosiain_OH_C2H2', 'kislovB', 'c-C5H5_CH3_Sharma', 'fascella', '2006_Joshi_OH_CO', '2009_Sharma_C5H5_CH3_highP', '2015_Buras_C2H3_C4H6_highP', 'C3', 'Methylformate', 'C6H5_C4H4_Mebel', 'vinylCPD_H', 'Mebel_Naphthyl', 'Mebel_C6H5_C2H2', 'Fulvene_H'],
+    transportLibraries=['OneDMinN2', 'PrimaryTransportLibrary', 'NOx2018', 'GRI-Mech'],
+    seedMechanisms=[],
+    kineticsDepositories='default',
+    kineticsFamilies='default',
+    kineticsEstimator='rate rules',
+)
+
+species(
+    label='fuel',
+    reactive=True,
+    structure=SMILES('CCCCCCCCCCCC'),
+)
+
+species(
+    label='N2',
+    reactive=False,
+    structure=SMILES('N#N'),
+)
+
+simpleReactor(
+    temperature=[(823.0, 'K'), (1173.0, 'K')],
+    pressure=[(1.0, 'bar'), (50.0, 'bar')],
+    initialMoleFractions={
+        'N2': 0.95,
+        'fuel': 0.05,
+    },
+    terminationRateRatio=0.05,
+    nSims=12,
+)
+
+model(
+    toleranceMoveToCore=0.1,
+    toleranceInterruptSimulation=0.1,
+    filterReactions=True,
+    filterThreshold=100000000.0,
+    maxNumObjsPerIter=1,
+    terminateAtMaxObjects=False,
+)
+
+simulator(atol=1e-16, rtol=1e-08, sens_atol=1e-06, sens_rtol=0.0001)
+
+pressureDependence(
+    method='modified strong collision',
+    maximumGrainSize=(2.0, 'kJ/mol'),
+    minimumNumberOfGrains=250,
+    temperatures=(300, 2000, 'K', 10),
+    pressures=(0.01, 100, 'bar', 10),
+    interpolation=('Chebyshev', 6, 4),
+    maximumAtoms=16,
+)
+
+options(
+    name='Seed',
+    generateSeedEachIteration=True,
+    saveSeedToDatabase=False,
+    units='si',
+    generateOutputHTML=True,
+    generatePlots=False,
+    saveSimulationProfiles=False,
+    verboseComments=False,
+    saveEdgeSpecies=False,
+    keepIrreversible=False,
+    trimolecularProductReversible=True,
+    wallTime='00:00:00:00',
+    saveSeedModulus=-1,
+)
+
+generatedSpeciesConstraints(
+    allowed=['input species', 'seed mechanisms', 'reaction libraries'],
+    maximumCarbonAtoms=13,
+    maximumOxygenAtoms=0,
+    maximumNitrogenAtoms=0,
+    maximumSiliconAtoms=0,
+    maximumSulfurAtoms=0,
+    maximumHeavyAtoms=13,
+    maximumRadicalElectrons=2,
+    maximumSingletCarbenes=1,
+    maximumCarbeneRadicals=0,
+    allowSingletO2=True,
+)
+
+    CCCCC=C[CH]CCCCC(21847) + S5XC12H25(25) <=> CCCCCC=CCCCCC(1568) + CCCCCC=CCCCCC(1568)
+    [CH2]CCCCC=CCCCCC(12923) + S5XC12H25(25) <=> CCCCCC=CCCCCC(1568) + CCCCCC=CCCCCC(1568)
+    CCCCC[C]=CCCCCC(23984) + S5XC12H25(25) <=> CCCCCC=CCCCCC(1568) + CCCCCC=CCCCCC(1568)
+
+After model enlargement:
+    The model core has 189 species and 2312 reactions
+    The model edge has 23797 species and 180809 reactions
+
+
+Saving current model core to Chemkin file...
+Chemkin file contains 2319 reactions.
+Saving annotated version of Chemkin file...
+Chemkin file contains 2319 reactions.
+Saving current model core to HTML file...
+Updating RMG execution statistics...
+    Execution time (DD:HH:MM:SS): 00:01:27:31
+    Memory used: 5496.09 MB
+
+Conducting simulation of reaction system 1...
+At time 1.6326e-03 s, species [CH2]C=[C]C=CC(17166) at 0.10017972478195425 exceeded the minimum rate for simulation interruption of 0.1
+At time 1.6326e-03 s, species [CH2]C=[C]C=CC(17166) at rate ratio 0.10017972478195425 exceeded the minimum rate for moving to model core of 0.1
+terminating simulation due to interrupt...
+conditions choosen for reactor 0 were: T = 879.4628188641341 K, P = 1.5511445401910993 bar, 
+
+
+Adding species [CH2]C=[C]C=CC(17166) to model core
+Updating 0 modified unimolecular reaction networks (out of 30)...
+
+
+Summary of Model Enlargement
+---------------------------------
+Added 1 new core species
+    [CH2]C=[C]C=CC(17166)
+Created 0 new edge species
+Moved 6 reactions from edge to core
+    C3H3(122) + C3H5-A(42) => [CH2]C=[C]C=CC(17166)
+    [CH2]C=CC=C[CH2](170) => [CH2]C=[C]C=CC(17166)
+    cC6H8-13(171) => [CH2]C=[C]C=CC(17166)
+    C=CC1C=CC1(172) => [CH2]C=[C]C=CC(17166)
+    C6H8(173) => [CH2]C=[C]C=CC(17166)
+    C=C=CC=CC(174) => [CH2]C=[C]C=CC(17166)
+Added 0 new core reactions
+Created 0 new edge reactions
+
+After model enlargement:
+    The model core has 190 species and 2318 reactions
+    The model edge has 23796 species and 180803 reactions
+
+
+At time 3.8270e+01 s, PDepNetwork #30 at 0.10052845086997901 exceeded the minimum rate for simulation interruption of 0.1
+Reached max number of objects...preparing to terminate
+At time 3.8270e+01 s, PDepNetwork #30 at 0.10052845086997901 exceeded the minimum rate for exploring of 0.1
+terminating simulation due to interrupt...
+
+For reaction generation 16 processes are used.
+For reaction CH2(S)(216) + [CH2]C=[C]C=C(5758) <=> [CH2]C=[C]C=CC(17166) Ea raised from -3.9 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) <=> CC1C=C=CC1(23986), Ea raised from 62.6 to 65.1 kJ/mol to match endothermicity of reaction.
+For reaction H(20) + C=C[C]=CC=C(17169) <=> [CH2]C=[C]C=CC(17166) Ea raised from -2.0 to 0 kJ/mol.
+For reaction CH2(200) + [CH]=C=C[CH]C(23991) <=> [CH2]C=[C]C=CC(17166) Ea raised from -1.5 to 0 kJ/mol.
+For reaction [CH]C(1366) + [CH]=C=C[CH2](23994) <=> [CH2]C=[C]C=CC(17166) Ea raised from -1.5 to 0 kJ/mol.
+For reaction NC3H7(3) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)CCC(24003) Ea raised from -1.5 to 0 kJ/mol.
+For reaction C2H5(12) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)CC(24012) Ea raised from -1.5 to 0 kJ/mol.
+For reaction CH3(13) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C)C=CC(24015) Ea raised from -1.5 to 0 kJ/mol.
+For reaction C3H6(14) + [CH2]C=[C]C=CC(17166) <=> C3H5-S(274) + [CH2]C=CC=CC(20380), Ea raised from 59.5 to 59.8 kJ/mol to match endothermicity of reaction.
+For reaction H2(21) + [CH2]C=[C]C=CC(17166) <=> H(20) + C=C[C]=CCC(24001), Ea raised from 114.4 to 115.8 kJ/mol to match endothermicity of reaction.
+For reaction C3H5-A(42) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)CC=C(24190) Ea raised from -1.5 to 0 kJ/mol.
+For reaction IC3H7(60) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)C(C)C(24399) Ea raised from -1.5 to 0 kJ/mol.
+For reaction C4H71-3(64) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)C(C)C=C(24427) Ea raised from -1.5 to 0 kJ/mol.
+For reaction C4H71-3(64) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)CC=CC(24430) Ea raised from -1.5 to 0 kJ/mol.
+For reaction C1=CCC1(69) + [CH2]C=[C]C=CC(17166) <=> [C]1=CCC1(3222) + [CH2]C=CC=CC(20380), Ea raised from 53.1 to 53.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + SAXC6H11(74) <=> [CH2]C=C(C=CC)C(C=C)CCC(24588) Ea raised from -1.5 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + SAXC6H11(74) <=> [CH2]C=C(C=CC)CC=CCCC(24591) Ea raised from -1.5 to 0 kJ/mol.
+For reaction CC1C=CC1(88) + [CH2]C=[C]C=CC(17166) <=> CC1[C]=CC1(5422) + [CH2]C=CC=CC(20380), Ea raised from 53.1 to 53.5 kJ/mol to match endothermicity of reaction.
+For reaction CC1C=CC1(88) + [CH2]C=[C]C=CC(17166) <=> CC1C=[C]C1(5423) + [CH2]C=CC=CC(20380), Ea raised from 53.1 to 53.5 kJ/mol to match endothermicity of reaction.
+For reaction CdCCdCCJ(92) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)CC=CC=C(24722) Ea raised from -1.5 to 0 kJ/mol.
+For reaction CdCCdCCJ(92) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)C(C=C)C=C(24725) Ea raised from -1.5 to 0 kJ/mol.
+For reaction C5H7(93) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)C1C=CCC1(24728) Ea raised from -1.5 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + C=CCC1C=CCC1(97) <=> [CH2]C=CC=CC(20380) + C=CCC1[C]=CCC1(7278), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CCC1C=CCC1(97) <=> [CH2]C=CC=CC(20380) + C=CCC1C=[C]CC1(7279), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction C5H5(102) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)C1C=CC=C1(24798) Ea raised from -1.5 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + C=CCC1C=CC=C1(104) <=> [CH2]C=CC=CC(20380) + C=CCC1[C]=CC=C1(8382), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CCC1=CC=CC1(105) <=> [CH2]C=CC=CC(20380) + C=CCC1=CC=[C]C1(8729), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CCC1=CCC=C1(106) <=> [CH2]C=CC=CC(20380) + C=CCC1=[C]CC=C1(9216), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CCC1=CCC=C1(106) <=> [CH2]C=CC=CC(20380) + C=CCC1=CC[C]=C1(9217), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CC=C2)C=C1(108) <=> [CH2]C=CC=CC(20380) + [C]1=CC=CC1C1C=CC=C1(9730), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2C=CC=C2)=C1(110) <=> [CH2]C=CC=CC(20380) + [C]1=CC=CC1C1=CC=CC1(9782), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2C=CC=C2)=C1(110) <=> [CH2]C=CC=CC(20380) + [C]1=CC=C(C2C=CC=C2)C1(9783), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2=CC=CC2)=C1(112) <=> [CH2]C=CC=CC(20380) + [C]1=CC=C(C2=CC=CC2)C1(10457), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2=CCC=C2)=C1(113) <=> [CH2]C=CC=CC(20380) + [C]1=C(C2=CC=CC2)C=CC1(10541), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2=CCC=C2)=C1(113) <=> [CH2]C=CC=CC(20380) + [C]1=CC=C(C2=CCC=C2)C1(10542), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2=CCC=C2)=C1(113) <=> [CH2]C=CC=CC(20380) + [C]1=CC(C2=CC=CC2)=CC1(10543), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2=CCC=C2)=CC1(114) <=> [CH2]C=CC=CC(20380) + [C]1=C(C2=CCC=C2)C=CC1(10849), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2=CCC=C2)=CC1(114) <=> [CH2]C=CC=CC(20380) + [C]1=CC(C2=CCC=C2)=CC1(10850), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2=CCC=C2)C=C1(116) <=> [CH2]C=CC=CC(20380) + [C]1=C(C2C=CC=C2)C=CC1(10920), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2=CCC=C2)C=C1(116) <=> [CH2]C=CC=CC(20380) + [C]1=CC=CC1C1=CCC=C1(10921), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2=CCC=C2)C=C1(116) <=> [CH2]C=CC=CC(20380) + [C]1=CC(C2C=CC=C2)=CC1(10922), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=CC=CC(20380) + [CH]1C=CC(C2=CCC=C2)=C1(10540) <=> [CH2]C=[C]C=CC(17166) + C1=CC(=C2C=CCC2)C=C1(117), Ea raised from 102.6 to 102.7 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(=C2C=CCC2)C=C1(117) <=> [CH2]C=CC=CC(20380) + [C]1=CC(=C2C=CC=C2)CC1(11029), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(=C2CC=CC2)C=C1(119) <=> [CH2]C=CC=CC(20380) + [C]1=CCC(=C2C=CC=C2)C1(11163), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction C3H3(122) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=C=C)C=CC(24839) Ea raised from -1.5 to 0 kJ/mol.
+For reaction C3H3(122) + [CH2]C=[C]C=CC(17166) <=> C#CCC(C=CC)=C[CH2](24842) Ea raised from -1.5 to 0 kJ/mol.
+For reaction C=C1CCC1=C(127) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)C[C]1CCC1=C(24884) Ea raised from -3.2 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC=CCC1C=CC=C1(130) <=> [CH2]C=CC=CC(20380) + C=CC=CCC1[C]=CC=C1(12673), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC=CCC1=CC=CC1(131) <=> [CH2]C=CC=CC(20380) + C=CC=CCC1=CC=[C]C1(12834), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC=CCC1=CCC=C1(134) <=> [CH2]C=CC=CC(20380) + C=CC=CCC1=[C]CC=C1(13124), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC=CCC1=CCC=C1(134) <=> [CH2]C=CC=CC(20380) + C=CC=CCC1=CC[C]=C1(13126), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC(C)C1C=CC=C1(136) <=> [CH2]C=CC=CC(20380) + C=CC(C)C1[C]=CC=C1(13304), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC(C)C1=CC=CC1(137) <=> [CH2]C=CC=CC(20380) + C=CC(C)C1=CC=[C]C1(13454), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC(C)C1=CC=CC1(137) <=> C=C[C]=CCC(24001) + C=CC(C)[C]1C=CC=C1(13303), Ea raised from 31.8 to 32.3 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC(C)C1=CCC=C1(138) <=> [CH2]C=CC=CC(20380) + C=CC(C)C1=[C]CC=C1(13669), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC(C)C1=CCC=C1(138) <=> [CH2]C=CC=CC(20380) + C=CC(C)C1=CC[C]=C1(13671), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=CC(C)C1=CCC=C1(138) <=> C=C[C]=CCC(24001) + C=CC(C)[C]1C=CC=C1(13303), Ea raised from 30.4 to 30.8 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + CC=CCC1C=CC=C1(143) <=> [CH2]C=CC=CC(20380) + CC=CCC1[C]=CC=C1(14887), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + CC=CCC1=CC=CC1(144) <=> [CH2]C=CC=CC(20380) + CC=CCC1=CC=[C]C1(15115), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + CC=CCC1=CCC=C1(145) <=> [CH2]C=CC=CC(20380) + CC=CCC1=[C]CC=C1(15351), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + CC=CCC1=CCC=C1(145) <=> [CH2]C=CC=CC(20380) + CC=CCC1=CC[C]=C1(15353), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CCC2)C=C1(151) <=> [CH2]C=CC=CC(20380) + [C]1=CCCC1C1C=CC=C1(16991), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CCC2)C=C1(151) <=> [CH2]C=CC=CC(20380) + [C]1=CC=CC1C1C=CCC1(16992), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CCC2)C=C1(151) <=> [CH2]C=CC=CC(20380) + [C]1=CC(C2C=CC=C2)CC1(16993), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2C=CCC2)=C1(153) <=> [CH2]C=CC=CC(20380) + [C]1=CCCC1C1=CC=CC1(17101), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2C=CCC2)=C1(153) <=> [CH2]C=CC=CC(20380) + [C]1=CC(C2=CC=CC2)CC1(17102), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2C=CCC2)=C1(153) <=> [CH2]C=CC=CC(20380) + [C]1=CC=C(C2C=CCC2)C1(17103), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CCC(C2C=CCC2)=C1(153) <=> C=C[C]=CCC(24001) + C1=C[C](C2C=CCC2)C=C1(11043), Ea raised from 31.8 to 32.3 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CCC2)=CC1(154) <=> [CH2]C=CC=CC(20380) + [C]1=CCCC1C1=CCC=C1(17147), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CCC2)=CC1(154) <=> [CH2]C=CC=CC(20380) + [C]1=C(C2C=CCC2)C=CC1(17148), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CCC2)=CC1(154) <=> [CH2]C=CC=CC(20380) + [C]1=CC(C2=CCC=C2)CC1(17149), Ea raised from 58.2 to 58.5 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CCC2)=CC1(154) <=> [CH2]C=CC=CC(20380) + [C]1=CC(C2C=CCC2)=CC1(17150), Ea raised from 71.5 to 71.9 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C1=CC(C2C=CCC2)=CC1(154) <=> C=C[C]=CCC(24001) + C1=C[C](C2C=CCC2)C=C1(11043), Ea raised from 30.4 to 30.8 kJ/mol to match endothermicity of reaction.
+For reaction [CH2]C=[C]C=CC(17166) + C=C1CCC1=CC(166) <=> [CH2]C=C(C=CC)C[C]1CCC1=CC(25088) Ea raised from -3.2 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + C=C1CC(C)C1=C(19712) <=> [CH2]C=C(C=CC)C[C]1C(=C)CC1C(25238) Ea raised from -3.2 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + C=C1CC(C)C1=C(19712) <=> [CH2]C=C(C=CC)C[C]1CC(C)C1=C(25240) Ea raised from -3.2 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)CC=[C]C=CC(25274) Ea raised from -1.5 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C(C=CC)C(C=CC)=C[CH2](25275) Ea raised from -1.5 to 0 kJ/mol.
+For reaction [CH2]C=[C]C=CC(17166) + [CH2]C=[C]C=CC(17166) <=> [CH2]C=C=CC(C)C(C=CC)=C[CH2](25277) Ea raised from -1.5 to 0 kJ/mol.
+Generating thermo for new species...
+Updating 1 modified unimolecular reaction networks (out of 31)...
+Updating PDepNetwork #31
+Warning: Statmech node 'C_R0' and all its parents have data = None
+Warning: Statmech node 'C_R2' and all its parents have data = None

--- a/tests/data/rmg_convergence/1_frag_error/err.txt
+++ b/tests/data/rmg_convergence/1_frag_error/err.txt
@@ -1,0 +1,36 @@
+:root:Removing old /home/alon/runs/T3/xsc2101/iteration_2/RMG/RMG_backup.log
+:root:Moving /home/alon/runs/T3/xsc2101/iteration_2/RMG/RMG.log to /home/alon/runs/T3/xsc2101/iteration_2/RMG/RMG_backup.log
+
+/home/alon/anaconda3/envs/rmg_env/lib/python3.7/site-packages/scipy/optimize/optimize.py:1978: LinAlgWarning: Ill-conditioned matrix (rcond=9.79183e-18): result may not be accurate.
+  fu = func(x, *args)
+Traceback (most recent call last):
+  File "/home/alon/anaconda3/envs/rmg_env/lib/python3.7/site-packages/julia/pseudo_python_cli.py", line 308, in main
+    python(**vars(ns))
+  File "/home/alon/anaconda3/envs/rmg_env/lib/python3.7/site-packages/julia/pseudo_python_cli.py", line 59, in python
+    scope = runpy.run_path(script, run_name="__main__")
+  File "/home/alon/anaconda3/envs/rmg_env/lib/python3.7/runpy.py", line 263, in run_path
+    pkg_name=pkg_name, script_name=fname)
+  File "/home/alon/anaconda3/envs/rmg_env/lib/python3.7/runpy.py", line 96, in _run_module_code
+    mod_name, mod_spec, pkg_name, script_name)
+  File "/home/alon/anaconda3/envs/rmg_env/lib/python3.7/runpy.py", line 85, in _run_code
+    exec(code, run_globals)
+  File "/home/alon/Code/RMG-Py/rmg.py", line 118, in <module>
+    main()
+  File "/home/alon/Code/RMG-Py/rmg.py", line 112, in main
+    rmg.execute(**kwargs)
+  File "/home/alon/Code/RMG-Py/rmgpy/rmg/main.py", line 1026, in execute
+    trimolecular_react=self.trimolecular_react)
+  File "/home/alon/Code/RMG-Py/rmgpy/rmg/model.py", line 709, in enlarge
+    self.update_unimolecular_reaction_networks()
+  File "/home/alon/Code/RMG-Py/rmgpy/rmg/model.py", line 1918, in update_unimolecular_reaction_networks
+    network.update(self, self.pressure_dependence)
+  File "/home/alon/Code/RMG-Py/rmgpy/rmg/pdep.py", line 808, in update
+    spec.generate_statmech()
+  File "rmgpy/species.py", line 821, in rmgpy.species.Species.generate_statmech
+  File "/home/alon/Code/RMG-Py/rmgpy/data/statmech.py", line 679, in get_statmech_data
+    statmech_model = self.get_statmech_data_from_groups(molecule, thermo_model)
+  File "/home/alon/Code/RMG-Py/rmgpy/data/statmech.py", line 713, in get_statmech_data_from_groups
+    return self.groups['groups'].get_statmech_data(molecule, thermo_model)
+  File "/home/alon/Code/RMG-Py/rmgpy/data/statmech.py", line 384, in get_statmech_data
+    num_rotors = molecule.count_internal_rotors()
+AttributeError: 'Fragment' object has no attribute 'count_internal_rotors'

--- a/tests/data/rmg_convergence/2_converged/RMG.log
+++ b/tests/data/rmg_convergence/2_converged/RMG.log
@@ -1,0 +1,230 @@
+Global RMG Settings:
+   database.directory   = /home/alon/Code/RMG-database/input (Default, relative to RMG-Py source code)
+   test_data.directory  = /home/alon/Code/RMG-Py/rmgpy/test_data (Default, relative to RMG-Py source code)
+RMG execution initiated at Sat Jan 21 16:14:10 2023
+
+#########################################################
+# RMG-Py - Reaction Mechanism Generator in Python       #
+# Version: 3.1.0                                        #
+# Authors: RMG Developers (rmg_dev@mit.edu)             #
+# P.I.s:   William H. Green (whgreen@mit.edu)           #
+#          Richard H. West (r.west@neu.edu)             #
+# Website: http://reactionmechanismgenerator.github.io/ #
+#########################################################
+
+The current git HEAD for RMG-Py is:
+	b'2cdc2ea7cd53e6a09648c6c50bc936812207fc81'
+	b'Tue Dec 13 18:22:41 2022 -0800'
+
+The current git HEAD for RMG-database is:
+	b'c817bf8fd3620a208f3a650ca84626b9dcd6d6cf'
+	b'Mon Jan 2 15:35:01 2023 +0200'
+
+Reading input file "/home/alon/runs/T3/xsc2101/iteration_1/RMG/input.py"...
+database(
+    thermoLibraries=['primaryThermoLibrary', 'BurkeH2O2', 'thermo_DFT_CCSDTF12_BAC', 'DFT_QCI_thermo', 'Spiekermann_refining_elementary_reactions', 'CurranPentane', 'C3', 'CBS_QB3_1dHR', 'FFCM1(-)', 'JetSurF2.0', 's3_5_7_ane', 'naphthalene_H', 'USC-Mech-ii', 'heavy_oil_ccsdtf12_1dHR', 'bio_oil', 'vinylCPD_H', 'Klippenstein_Glarborg2016', 'Fulvene_H', 'Chernov', 'C10H11', 'CH'],
+    reactionLibraries=['primaryH2O2', 'C2H2_init', 'C2H4+O_Klipp2017', 'CurranPentane', 'FFCM1(-)', 'NOx2018', 'JetSurF2.0', 'Klippenstein_Glarborg2016', 'C10H11', 'C12H11_pdep', 'Lai_Hexylbenzene', '1989_Stewart_2CH3_to_C2H5_H', '2001_Tokmakov_H_Toluene_to_CH3_Benzene', '2003_Miller_Propargyl_Recomb_High_P', '2005_Senosiain_OH_C2H2', 'kislovB', 'c-C5H5_CH3_Sharma', 'fascella', '2006_Joshi_OH_CO', '2009_Sharma_C5H5_CH3_highP', '2015_Buras_C2H3_C4H6_highP', 'C3', 'Methylformate', 'C6H5_C4H4_Mebel', 'vinylCPD_H', 'Mebel_Naphthyl', 'Mebel_C6H5_C2H2', 'Fulvene_H'],
+    transportLibraries=['OneDMinN2', 'PrimaryTransportLibrary', 'NOx2018', 'GRI-Mech'],
+    seedMechanisms=[],
+    kineticsDepositories='default',
+    kineticsFamilies='default',
+    kineticsEstimator='rate rules',
+)
+
+species(
+    label='fuel',
+    reactive=True,
+    structure=SMILES('CCCCCCCCCCCC'),
+)
+
+species(
+    label='N2',
+    reactive=False,
+    structure=SMILES('N#N'),
+)
+
+simpleReactor(
+    temperature=[(823.0, 'K'), (1173.0, 'K')],
+    pressure=[(1.0, 'bar'), (50.0, 'bar')],
+    initialMoleFractions={
+        'N2': 0.95,
+        'fuel': 0.05,
+    },
+    terminationRateRatio=0.05,
+    nSims=12,
+)
+
+model(
+    toleranceMoveToCore=0.25,
+    toleranceInterruptSimulation=0.25,
+    filterReactions=True,
+    filterThreshold=100000000.0,
+    maxNumObjsPerIter=1,
+    terminateAtMaxObjects=False,
+)
+
+simulator(atol=1e-16, rtol=1e-08, sens_atol=1e-06, sens_rtol=0.0001)
+
+pressureDependence(
+    method='modified strong collision',
+    maximumGrainSize=(2.0, 'kJ/mol'),
+    minimumNumberOfGrains=250,
+    temperatures=(300, 2000, 'K', 10),
+    pressures=(0.01, 100, 'bar', 10),
+    interpolation=('Chebyshev', 6, 4),
+    maximumAtoms=16,
+)
+
+options(
+    name='Seed',
+    generateSeedEachIteration=True,
+    saveSeedToDatabase=False,
+    units='si',
+    generateOutputHTML=True,
+    generatePlots=False,
+    saveSimulationProfiles=False,
+    verboseComments=False,
+    saveEdgeSpecies=False,
+    keepIrreversible=False,
+    trimolecularProductReversible=True,
+    wallTime='00:00:00:00',
+    saveSeedModulus=-1,
+)
+
+generatedSpeciesConstraints(
+    allowed=['input species', 'seed mechanisms', 'reaction libraries'],
+    maximumCarbonAtoms=13,
+    maximumOxygenAtoms=0,
+    maximumNitrogenAtoms=0,
+    maximumSiliconAtoms=0,
+    maximumSulfurAtoms=0,
+    maximumHeavyAtoms=13,
+    maximumRadicalElectrons=2,
+    maximumSingletCarbenes=1,
+    maximumCarbeneRadicals=0,
+    allowSingletO2=True,
+)
+
+
+
+
+Saving current model core to Chemkin file...
+Chemkin file contains 2649 reactions.
+Saving annotated version of Chemkin file...
+Chemkin file contains 2649 reactions.
+Saving current model core to HTML file...
+Updating RMG execution statistics...
+    Execution time (DD:HH:MM:SS): 00:22:00:32
+    Memory used: 4092.21 MB
+
+Conducting simulation of reaction system 1...
+At time 9.8554e-02 s, reached target termination RateRatio: 0.049496999715614186
+conditions choosen for reactor 0 were: T = 880.0242327924144 K, P = 1.2625426732636178 bar, 
+
+
+At time 4.7498e+01 s, reached target termination RateRatio: 0.049883702700754144
+
+For reaction generation 16 processes are used.
+Updating 0 modified unimolecular reaction networks (out of 235)...
+
+
+Summary of Secondary Model Edge Enlargement
+---------------------------------
+Added 0 new core species
+Created 0 new edge species
+Added 0 new core reactions
+Created 0 new edge reactions
+
+After model enlargement:
+    The model core has 168 species and 2642 reactions
+    The model edge has 13055 species and 61477 reactions
+
+
+Saving current model core to Chemkin file...
+Chemkin file contains 2649 reactions.
+Saving annotated version of Chemkin file...
+Chemkin file contains 2649 reactions.
+Saving current model core to HTML file...
+Updating RMG execution statistics...
+    Execution time (DD:HH:MM:SS): 00:22:01:35
+    Memory used: 4092.21 MB
+
+Conducting simulation of reaction system 1...
+At time 4.7498e+01 s, reached target termination RateRatio: 0.049883702700754144
+conditions choosen for reactor 0 were: T = 993.7763717377686 K, P = 12.321103375267773 bar, 
+
+
+At time 3.5882e-01 s, reached target termination RateRatio: 0.04963580171103388
+
+For reaction generation 16 processes are used.
+Updating 0 modified unimolecular reaction networks (out of 235)...
+
+
+Summary of Secondary Model Edge Enlargement
+---------------------------------
+Added 0 new core species
+Created 0 new edge species
+Added 0 new core reactions
+Created 0 new edge reactions
+
+After model enlargement:
+    The model core has 168 species and 2642 reactions
+    The model edge has 13055 species and 61477 reactions
+
+
+Saving current model core to Chemkin file...
+Chemkin file contains 2649 reactions.
+Saving annotated version of Chemkin file...
+Chemkin file contains 2649 reactions.
+Saving current model core to HTML file...
+Updating RMG execution statistics...
+    Execution time (DD:HH:MM:SS): 00:22:02:40
+    Memory used: 4092.21 MB
+
+Conducting simulation of reaction system 1...
+At time 3.5882e-01 s, reached target termination RateRatio: 0.04963580171103388
+conditions choosen for reactor 0 were: T = 1028.070290299898 K, P = 41.612284634945645 bar, 
+
+
+At time 8.8833e-02 s, reached target termination RateRatio: 0.04900900959716824
+
+For reaction generation 16 processes are used.
+Updating 0 modified unimolecular reaction networks (out of 235)...
+
+
+Summary of Secondary Model Edge Enlargement
+---------------------------------
+Added 0 new core species
+Created 0 new edge species
+Added 0 new core reactions
+Created 0 new edge reactions
+
+After model enlargement:
+    The model core has 168 species and 2642 reactions
+    The model edge has 13055 species and 61477 reactions
+
+
+Saving current model core to Chemkin file...
+Chemkin file contains 2649 reactions.
+Saving annotated version of Chemkin file...
+Chemkin file contains 2649 reactions.
+Saving current model core to HTML file...
+Updating RMG execution statistics...
+    Execution time (DD:HH:MM:SS): 00:22:03:41
+    Memory used: 4092.21 MB
+
+Making seed mechanism...
+Performing final model checks...
+
+
+Warning: 38 CORE reactions violate the collision rate limit!
+See the 'collision_rate_violators.log' for details.
+
+
+
+MODEL GENERATION COMPLETED
+
+The final model core has 168 species and 2642 reactions
+The final model edge has 13055 species and 61477 reactions
+
+RMG execution terminated at Sun Jan 22 14:20:15 2023

--- a/tests/data/rmg_convergence/2_converged/err.txt
+++ b/tests/data/rmg_convergence/2_converged/err.txt
@@ -1,0 +1,6 @@
+/home/alon/anaconda3/envs/rmg_env/lib/python3.7/site-packages/scipy/optimize/optimize.py:1978: LinAlgWarning: Ill-conditioned matrix (rcond=9.79183e-18): result may not be accurate.
+  fu = func(x, *args)
+/home/alon/Code/RMG-Py/rmgpy/rmg/main.py:907: RuntimeWarning: invalid value encountered in true_divide
+  conditions=self.rmg_memories[index].get_cond()
+/home/alon/Code/RMG-Py/rmgpy/rmg/main.py:907: RuntimeWarning: divide by zero encountered in true_divide
+  conditions=self.rmg_memories[index].get_cond()

--- a/tests/test_rmg_runner.py
+++ b/tests/test_rmg_runner.py
@@ -7,7 +7,7 @@ t3 tests test_rmg_runner module
 
 import os
 from t3.common import DATA_BASE_PATH, EXAMPLES_BASE_PATH
-from t3.runners.rmg_runner import write_submit_script
+from t3.runners.rmg_runner import rmg_job_converged, write_submit_script
 
 
 class TestWriteSubmitScript(object):
@@ -135,6 +135,18 @@ touch final_time
         with open(os.path.join(project_directory_path, "submit.sh"), "r") as submit_file:
             content_submit = submit_file.read()
         assert content_submit == expected_submit
+
+    def test_rmg_job_converged(self):
+        """Test correctly identifying whether an RMG job converged ot not, and if not which error was received."""
+        rmg_folder_1 = os.path.join(DATA_BASE_PATH, 'rmg_convergence', '1_frag_error')
+        converged, error = rmg_job_converged(project_directory=rmg_folder_1)
+        assert not converged
+        assert error == "AttributeError: 'Fragment' object has no attribute 'count_internal_rotors'"
+
+        rmg_folder_2 = os.path.join(DATA_BASE_PATH, 'rmg_convergence', '2_converged')
+        converged, error = rmg_job_converged(project_directory=rmg_folder_2)
+        assert converged
+        assert error is None
 
 
 def teardown_module():

--- a/tests/test_rmg_runner.py
+++ b/tests/test_rmg_runner.py
@@ -13,10 +13,12 @@ from t3.runners.rmg_runner import write_submit_script
 class TestWriteSubmitScript(object):
 
     def test_minimal_write_submit_script(self):
-        """Test the write_submit_script() function with minimal input.
-            write_submit_script params are set as their default values
-            This test will create a job.sh file in the project directory path and the assertion will check if the file exists
-            and matches the expected file"""
+        """
+        Test the write_submit_script() function with minimal input.
+        write_submit_script params are set as their default values
+        This test will create a job.sh file in the project directory path and the assertion will check if the file exists
+        and matches the expected file
+        """
         project_directory_path = os.path.join(EXAMPLES_BASE_PATH, "minimal")
 
         write_submit_script(project_directory_path,
@@ -54,6 +56,7 @@ touch final_time
         assert content == expected
 
     def test_minimal_project_name_included(self):
+        """Test that thew minimal project name is included in the PBS submit script."""
         project_directory_path = os.path.join(EXAMPLES_BASE_PATH, "minimal")
         t3_proj_name = "T3_test_name"
         write_submit_script(project_directory_path,
@@ -90,9 +93,10 @@ touch final_time
         assert content_submit == expected_submit
 
     def test_minimal_parameters_set(self):
+        """Test creating a submit script for the minimal example."""
         project_directory_path = os.path.join(EXAMPLES_BASE_PATH, "minimal")
         
-        ####To be edited by user if required####
+        # To be edited by user if required:
         t3_proj_name = "T3_test_name"
         cpus = 8
         max_iter = "-m 100"

--- a/tests/test_rmg_runner.py
+++ b/tests/test_rmg_runner.py
@@ -151,4 +151,7 @@ touch final_time
 
 def teardown_module():
     """teardown any state that was previously setup with a setup_module method."""
-    os.remove(os.path.join(EXAMPLES_BASE_PATH, "minimal", "submit.sh"))
+    file_paths = [os.path.join(EXAMPLES_BASE_PATH, 'minimal', 'submit.sh')]
+    for file_path in file_paths:
+        if os.path.isfile(file_path):
+            os.remove(file_path)


### PR DESCRIPTION
T3 will rerun RMG in each iteration until it converges. This is not recommended, as a persistent bug/error in RMG may cause T3 to loop forever.
Here we let the RMG runner to read the crash error, report it in T3's log, and we limit the number of RMG reruns per iteration using a counter as well as checking that RMG did not crash with the same error twice in a row.
The hope is that T3 will run SA anyway, even if the RMG model did not converge, and with the updated thermo-kinetic values the new RMG model will have better chances of converging. This is still not bullet proof, and additional RMG troubleshooting should be added (e.g., compute species from the pdep network that made RMG crash). However, this addition avoids running RMG in an infinite loop which is a good start.
A test was added for properly reading RMG errors.