### PR TITLE
Don't crush if RMG's reaction_system.simulate() fails

### DIFF
--- a/t3/main.py
+++ b/t3/main.py
@@ -38,7 +38,12 @@ from rmgpy.rmg.pdep import PDepReaction
 from rmgpy.species import Species
 from rmgpy.thermo import NASAPolynomial, NASA, ThermoData, Wilhoit
 
-from arc.common import get_ordinal_indicator, key_by_val, read_yaml_file, save_yaml_file
+from arc.common import (get_number_with_ordinal_indicator,
+                        get_ordinal_indicator,
+                        key_by_val,
+                        read_yaml_file,
+                        save_yaml_file,
+                        )
 from arc.exceptions import ConverterError
 from arc.main import ARC
 from arc.species.species import ARCSpecies, check_label
@@ -637,13 +642,14 @@ class T3(object):
         if rmg_exception_encountered:
             self.rmg_exceptions_counter += 1
             if self.rmg_exceptions_counter > max_rmg_exceptions_allowed:
-                self.logger.error(f'This is the {self.rmg_exceptions_counter} exception raised by RMG.\n'
-                                  f'Cannot allow more than {max_rmg_exceptions_allowed} RMG exceptions during a T3 run.\n'
-                                  f'Not allowing additional exceptions, terminating.')
+                self.logger.error(f'This is the {get_number_with_ordinal_indicator(self.rmg_exceptions_counter)} '
+                                  f'exception raised by RMG.\nCannot allow more than {max_rmg_exceptions_allowed} '
+                                  f'RMG exceptions during a T3 run.\nNot allowing additional exceptions, terminating.')
                 raise ValueError('Terminating due to RMG exceptions.')
             else:
                 self.logger.warning(f'RMG did not converge. '
-                                    f'This is the {self.rmg_exceptions_counter} exception raised by RMG.\n'
+                                    f'This is the {get_number_with_ordinal_indicator(self.rmg_exceptions_counter)} '
+                                    f'exception raised by RMG.\n'
                                     f'The maximum number of exceptions allowed is {max_rmg_exceptions_allowed}.')
 
         elapsed_time = time_lapse(tic)

--- a/t3/simulate/rmg_constantTP.py
+++ b/t3/simulate/rmg_constantTP.py
@@ -198,21 +198,24 @@ class RMGConstantTP(SimulateAdapter):
             if reaction_system.const_spc_names is not None:
                 reaction_system.get_const_spc_indices(self.rmg_model.reaction_model.core.species)
 
-            reaction_system.simulate(
-                core_species=self.rmg_model.reaction_model.core.species,
-                core_reactions=self.rmg_model.reaction_model.core.reactions,
-                edge_species=self.rmg_model.reaction_model.edge.species,
-                edge_reactions=self.rmg_model.reaction_model.edge.reactions,
-                surface_species=[],
-                surface_reactions=[],
-                pdep_networks=pdep_networks,
-                sensitivity=True if reaction_system.sensitive_species else False,
-                sens_worksheet=sens_worksheet,
-                model_settings=model_settings,
-                simulator_settings=simulator_settings,
-                conditions={'T': reaction_system.sens_conditions['T'], 'P': reaction_system.sens_conditions['P']},
-                prune=False,
-            )
+            try:
+                reaction_system.simulate(
+                    core_species=self.rmg_model.reaction_model.core.species,
+                    core_reactions=self.rmg_model.reaction_model.core.reactions,
+                    edge_species=self.rmg_model.reaction_model.edge.species,
+                    edge_reactions=self.rmg_model.reaction_model.edge.reactions,
+                    surface_species=[],
+                    surface_reactions=[],
+                    pdep_networks=pdep_networks,
+                    sensitivity=True if reaction_system.sensitive_species else False,
+                    sens_worksheet=sens_worksheet,
+                    model_settings=model_settings,
+                    simulator_settings=simulator_settings,
+                    conditions={'T': reaction_system.sens_conditions['T'], 'P': reaction_system.sens_conditions['P']},
+                    prune=False,
+                )
+            except ZeroDivisionError as e:
+                self.logger.warning(f'Cannot simulate reaction system, got:\n{e}')
 
             if reaction_system.sensitive_species:
                 plot_sensitivity(self.rmg_model.output_directory, index, reaction_system.sensitive_species)


### PR DESCRIPTION
Got the following traceback in an RMG run:
```
Traceback (most recent call last):
  File "/home/alongd/Code/T3/T3.py", line 79, in <module>
    main()
  File "/home/alongd/Code/T3/T3.py", line 75, in main
    t3_object.execute()
  File "/home/alongd/Code/T3/t3/main.py", line 305, in execute
    simulate_adapter.simulate()
  File "/home/alongd/Code/T3/t3/simulate/rmg_constantTP.py", line 214, in simulate
    prune=False,
  File "rmgpy/solver/base.pyx", line 572, in rmgpy.solver.base.ReactionSystem.simulate
  File "rmgpy/solver/base.pyx", line 669, in rmgpy.solver.base.ReactionSystem.simulate
  File "rmgpy/solver/simple.pyx", line 220, in rmgpy.solver.simple.SimpleReactor.initialize_model
  File "rmgpy/solver/base.pyx", line 475, in rmgpy.solver.base.ReactionSystem.set_initial_derivative
  File "rmgpy/solver/simple.pyx", line 552, in rmgpy.solver.simple.SimpleReactor.residual
  File "rmgpy/solver/base.pyx", line 1358, in rmgpy.solver.base.ReactionSystem.compute_rate_derivative
ZeroDivisionError: float division
```

It occurred when computing SA after an RMG run, and caused T3 to crush.
If T3 (or RMG) cannot compute SA for one of the reaction systems, T3 shouldn't crash. Here we conveniently ignore the error, though it might be nice to also dive in and see why we get this error in RMG and try to fix it.