### PR TITLE
Added a try-except block for rmg_constantTP when calling plot_sensitivity()

### DIFF
--- a/t3/simulate/rmg_constantTP.py
+++ b/t3/simulate/rmg_constantTP.py
@@ -218,7 +218,10 @@ class RMGConstantTP(SimulateAdapter):
                 self.logger.warning(f'Cannot simulate reaction system, got:\n{e}')
 
             if reaction_system.sensitive_species:
-                plot_sensitivity(self.rmg_model.output_directory, index, reaction_system.sensitive_species)
+                try:
+                    plot_sensitivity(self.rmg_model.output_directory, index, reaction_system.sensitive_species)
+                except FileNotFoundError as e:
+                    self.logger.warning(f'Cannot plot sensitivity, got:\n{e}')
 
             if self.rmg_model.uncertainty is not None:
                 self.rmg_model.run_uncertainty_analysis()


### PR DESCRIPTION
Making the RMG adapter a bit more robust. If a SA run was unsuccessful, the corresponding .csv file will not be created, and the subsequent call to `plot_sensitivity()` within the adapter crashes. Here a fix was added.