### PR TITLE
Only add a species to the thermo library if requested

### DIFF
--- a/t3/main.py
+++ b/t3/main.py
@@ -1278,6 +1278,7 @@ class T3(object):
                             qm_species = ARCSpecies(label=qm_species.label,
                                                     rmg_species=qm_species,
                                                     xyz=xyzs,
+                                                    include_in_thermo_lib=self.species_requires_refinement(qm_species),
                                                     )
                         else:
                             raise NotImplementedError(f"Passing XYZ information to {self.qm['adapter']} "

--- a/t3/main.py
+++ b/t3/main.py
@@ -1234,9 +1234,7 @@ class T3(object):
                     ) -> Optional[int]:
         """
         Add a species to self.species and to self.qm['species'].
-        If the species already exists in self.species, only the reasons
-        will be updated (extended), and the species will not be considered
-        in self.qm['species'].
+        If the species already exists in self.species, only the reasons to compute will be appended.
 
         Args:
             species (Species): The species to consider.
@@ -1298,10 +1296,8 @@ class T3(object):
                      reasons: Union[List[str], str],
                      ) -> Optional[int]:
         """
-        Add a species to self.species and to self.qm['species'].
-        If the species already exists in self.species, only the reasons
-        will be updated (extended), and the species will not be considered
-        in self.qm['species'].
+        Add a reaction to self.reactions and to self.qm['reactions'].
+        If the reaction already exists in self.reactions, only the reasons to compute will be appended.
 
         Args:
             reaction (Reaction): The reaction to consider.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,6 @@ import datetime
 import os
 import shutil
 
-from rmgpy import settings as rmg_settings
 from rmgpy.data.thermo import ThermoLibrary
 from rmgpy.reaction import Reaction
 from rmgpy.rmg.pdep import PDepNetwork, PDepReaction
@@ -811,6 +810,8 @@ def test_add_species():
     spc_1 = Species(label='OH', smiles='[OH]')
     spc_2 = Species(label='hydrazine', smiles='NN')
     spc_3 = Species(label='H2', smiles='[H][H]')
+    for spc in [spc_1, spc_2, spc_3]:
+        spc.thermo = ThermoData()
 
     assert t3.get_species_key(species=spc_1) == 0
     assert t3.species[0]['RMG label'] == 'OH'


### PR DESCRIPTION
Species that participate in reactions we intend to compute and their thermo data originates from libraries should not end up in ARC's thermo library output. However, for post-analysis purposes, it could still be beneficial to have the thermo data already process by ARC/Arkane.
Here we transmit this info into ARC via the new `include_in_thermo_lib` ARCSpecies argument implemented in https://github.com/ReactionMechanismGenerator/ARC/pull/612