### PR TITLE
Report the reaction for which a PDep SA is executed

### DIFF
--- a/t3/main.py
+++ b/t3/main.py
@@ -891,8 +891,8 @@ class T3(object):
                 arkane = Arkane(input_file=os.path.join(self.paths['PDep SA'], network_name, method, 'input.py'),
                                 output_directory=os.path.join(self.paths['PDep SA'], network_name, method))
                 arkane.plot = True
-                self.logger.info(f'\nRunning PDep SA for network {network_name} using the {method} method '
-                                 f'(iteration {self.iteration})...')
+                self.logger.info(f'\nRunning PDep SA for network {network_name} using the {method} method\n'
+                                 f'to examine reaction {reaction} (iteration {self.iteration})...')
                 try:
                     arkane.execute()
                 except (AttributeError,


### PR DESCRIPTION
This assists in manually improving models if the PDep SA fails by providing the reaction information