### PR TITLE
Minor update to the update cache

### DIFF
--- a/.github/workflows/cont_int.yml
+++ b/.github/workflows/cont_int.yml
@@ -70,6 +70,7 @@ jobs:
             path: ARC
             ref: main
             fetch-depth: 1
+
         - name: Cache Conda Packages
           uses: actions/cache@v2
           env:
@@ -87,17 +88,13 @@ jobs:
               miniforge-version: latest
               activate-environment: rmg_env
               use-mamba: true
-        - name: Get Date
-          id: get-date
-          run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-          shell: bash
 
         - name: Cache RMG-Py env
           uses: actions/cache@v2
           with:
             path: ${{ env.CONDA }}/envs/rmg_env
             key:
-              conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles('RMG-Py/environment.yml') }}-${{ env.CACHE_NUMBER}}
+              conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('RMG-Py/environment.yml') }}-${{ env.CACHE_NUMBER}}
           env:
             # Increase this value to reset cache if etc/example-environment.yml has not changed
             CACHE_NUMBER: 0

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -69,24 +69,19 @@ jobs:
               miniforge-version: latest
               activate-environment: rmg_env
               use-mamba: true
-        - name: Get Date
-          id: get-date
-          run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-          shell: bash
 
         - name: Cache RMG-Py env
           uses: actions/cache@v2
           with:
             path: ${{ env.CONDA }}/envs/rmg_env
             key:
-              conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles('RMG-Py/environment.yml') }}-${{ env.CACHE_NUMBER}}
+              conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('RMG-Py/environment.yml') }}-${{ env.CACHE_NUMBER}}
           env:
             # Increase this value to reset cache if etc/example-environment.yml has not changed
             CACHE_NUMBER: 0
           id: cache
         - name: Update environment
           run: mamba env update -n rmg_env -f RMG-Py/environment.yml
-
 
         - name: Cythonize RMG-Py
           run: |


### PR DESCRIPTION
-  Removed the date as part of the key for RMG-Py enve. Since we are updating every 7 days, it is not something we should worry about requiring.