### PR TITLE
Bumped up the numpy version to align with ARC and RMG

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - cairo
   - cairocffi
-  - rmg::cantera >=2.3.0
+  - cantera::cantera=2.6
   - conda-forge::cclib >=1.7.0
   - rmg::chemprop
   - coolprop
@@ -28,7 +28,7 @@ dependencies:
   - rmg::muq2
   - networkx
   - rmg::numdifftools
-  - numpy >=1.15.4
+  - numpy =1.20.1
   - conda-forge::openbabel >= 3
   - pandas
   - psutil


### PR DESCRIPTION
RMG and ARC are both updating their numpy package version. We shall do the same for T3