### PR TITLE
Docker Size Reduction

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -17,7 +17,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       # Add steps for CI checks of the Dockerfile
-      - name: Build and push
+      - name: Build RMG-Py
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./devtools/Dockerfile_rmgpy
+          push: false
+      - name: Build T3
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -37,7 +43,14 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Build and push
+    - name: Build and push RMG-Py
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./devtools/Dockerfile_rmgpy
+        push: true
+        tags: ${{ secrets.DOCKERHUB_USERNAME }}/rmgpy:latest
+    - name: Build and push T3
       uses: docker/build-push-action@v2
       with:
         context: .

--- a/devtools/Dockerfile
+++ b/devtools/Dockerfile
@@ -1,144 +1,56 @@
-#T3 Dockerfile
-# https://hub.docker.com/layers/mambaorg/micromamba/1.4.3-jammy/images/sha256-0c7c97be938c5522dcb9e1737bfa4499c53f6cf9e32e53897607a57ba8b148d5?context=explore
-# We are using the sha256 hash to ensure that the image is not updated without our knowledge. It considered best practice to use the sha256 hash
-FROM --platform=linux/amd64 mambaorg/micromamba@sha256:0c7c97be938c5522dcb9e1737bfa4499c53f6cf9e32e53897607a57ba8b148d5
-
-#Docker is built on layers - Each Run is a Layer
-
-# Install dependencies
-
-# Set User to root to install dependencies
-USER root
-# (otherwise python will not be found)
-ARG MAMBA_ROOT_PREFIX=/opt/conda
-ENV PYTHONDONTWRITEBYTECODE=true
-ENV BASE=$MAMBA_ROOT_PREFIX
-
-# Install dependencies and clean up - removing apt lists for space
-# git, gcc, g++, make, libxrender1, libtinfo6 are required by RMG-Py
-# libgomp1 is required by ARC
-# openssh-server is required for copying files from the host to the container
-RUN apt-get update && apt-get install -y \
-    git \
-    gcc \
-    g++ \
-    make \
-    libgomp1\
-    libxrender1 \
-    libtinfo6 \
-    openssh-server \
-    # Clean up
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Change user to mambauser (Non-root) - Defined in the base image.
-# The user can be changed via extra arguments to docker build
-# https://github.com/mamba-org/micromamba-docker#changing-the-user-id-or-name
-USER mambauser
-
-# Make directory and set as working directory
-RUN mkdir -p /home/mambauser/Code
-WORKDIR /home/mambauser/Code
-
-# Pull in the main branch of the codes
-# Layer RMG-Py
-RUN git clone -b main https://github.com/ReactionMechanismGenerator/RMG-Py.git
-# Layer RMG-database
-RUN git clone -b main https://github.com/ReactionMechanismGenerator/RMG-database.git
+# Using the a base image of rmgpy:latest from DockerHub - Not the official version but a custom version that is smaller in size
+FROM --platform=linux/amd64 laxzal/rmgpy:latest
 
 
+USER rmguser
 
-# Install RMG-Py
-WORKDIR /home/mambauser/Code/RMG-Py
-RUN micromamba create -y -f environment.yml
-
-# Activate the environment - This is required by the Micromamba base image
-ARG MAMBA_DOCKERFILE_ACTIVATE=1
-ENV ENV_NAME=rmg_env
-
-# Set environment variables for the Docker run and container
-ENV PATH /opt/conda/envs/rmg_env/bin:$PATH
-ENV PYTHONPATH /home/mambauser/Code/RMG-Py
-ENV PATH /home/mambauser/Code/RMG-Py:$PATH
-ENV LD_LIBRARY_PATH /opt/conda/envs/rmg_env/lib
-ENV PYTHON=/opt/conda/envs/rmg_env/bin/python
-ENV PYCALL_JL_RUNTIME_PYTHON=/opt/conda/envs/rmg_env/bin/python
-
-# Compile RMG-Py
-RUN make 
-
-# Create the link between Julia and RMG-Py. A symbolic link is created between Python-JL and Python.
-# We do not use the command in Julia 'using ReactionMechanismSimulator' because the command is only for determining if the package is installed.
-# The command does not actually install the package but instead increases the build time, therefore not required.
-# Install RMS
-# The extra arguments are required to install PyCall and RMS in this Dockerfile. Will not work without them.
-RUN touch /opt/conda/envs/rmg_env/condarc-julia.yml
-RUN CONDA_JL_CONDA_EXE=/bin/micromamba julia -e 'using Pkg;Pkg.add(PackageSpec(name="PyCall", rev="master")); Pkg.build("PyCall"); Pkg.add(PackageSpec(name="ReactionMechanismSimulator", rev="main"))'
-RUN python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()"
-
-# Compile the RMS during Docker build - This will reduce the time it takes to run RMS for the first time
-RUN python-jl -c "from pyrms import rms"
-
-# Add aliases to bashrc
-RUN echo "alias rmge='micromamba activate rmg_env'" >> ~/.bashrc \
-    && echo "alias rmg='python-jl /home/mambauser/Code/RMG/rmg.py input.py'" >> ~/.bashrc \
-    && echo "alias t3e='micromamba activate t3_env'" >> ~/.bashrc \
-    && echo "alias t3='python /home/mambauser/Code/T3/T3.py input.yml'" >> ~/.bashrc \
-    && echo "alias arc='python /home/mambauser/Code/ARC/ARC.py input.yml'" >> ~/.bashrc \
-    && echo "alias arce='micromamba activate arc_env'" >> ~/.bashrc \
-    && echo "alias deact='micromamba deactivate'" >> ~/.bashrc \
-    && echo "alias jupyter='jupyter notebook'" >> ~/.bashrc \
-    && echo "export rmgpy_path='/home/mambauser/Code/RMG-Py/'" >> ~/.bashrc \
-    && echo "export rmgdb_path='/home/mambauser/Code/RMG-database/'" >> ~/.bashrc \
-    && echo "export arc_path='/home/mambauser/Code/ARC/'" >> ~/.bashrc \
-    && echo "export t3_path='/home/mambauser/Code/T3/'" >> ~/.bashrc \
-    && echo "alias rmgcode='cd \$rmgpy_path'" >> ~/.bashrc \
-    && echo "alias rmgdb='cd \$rmgdb_path'" >> ~/.bashrc \
-    && echo "alias arcode='cd \$arc_path'" >> ~/.bashrc \
-    && echo "alias t3code='cd \$t3_path'" >> ~/.bashrc \
-    && echo "alias conda='micromamba'" >> ~/.bashrc \
-    && echo "alias mamba='micromamba'" >> ~/.bashrc 
 
 # Installing ARC
-
 # Change directory to Code
-WORKDIR /home/mambauser/Code
+WORKDIR /home/rmguser/Code
 
 # Clone main branch ARC repository from GitHub and set as working directory
 RUN git clone -b main https://github.com/ReactionMechanismGenerator/ARC.git
-WORKDIR /home/mambauser/Code/ARC
+WORKDIR /home/rmguser/Code/ARC
 
 # Set environment variables for the Docker run and container
-ENV PYTHONPATH="${PYTHONPATH}:/home/mambauser/Code/ARC"
-ENV PYTHONPATH="${PYTHONPATH}:/home/mambauser/Code/AutoTST"
-ENV PYTHONPATH="${PYTHONPATH}:/home/mambauser/Code/TS-GCN"
-ENV PATH /home/mambauser/Code/ARC:$PATH
+ENV PYTHONPATH="${PYTHONPATH}:/home/rmguser/Code/ARC"
+ENV PYTHONPATH="${PYTHONPATH}:/home/rmguser/Code/AutoTST"
+ENV PYTHONPATH="${PYTHONPATH}:/home/rmguser/Code/TS-GCN"
+ENV PATH /home/rmguser/Code/ARC:$PATH
 
 # Install ARC Environment
 RUN micromamba create -y -f environment.yml && \
+    micromamba clean --all -f -y && \
+    rm -rf /home/rmguser/.cache/yarn \
+    rm -rf /home/rmguser/.cache/pip &&\
+    rm -rf /home/rmguser/.cache/pip && \
     find -name '*.a' -delete && \
     find -name '*.pyc' -delete && \
+    rm -rf /opt/conda/envs/arc_env/conda-meta && \
+    rm -rf /opt/conda/envs/arc_env/include && \
     find -name '__pycache__' -type d -exec rm -rf '{}' '+' && \
     find /opt/conda/envs/arc_env/lib/python3.7/site-packages/scipy -name 'tests' -type d -exec rm -rf '{}' '+' && \
     find /opt/conda/envs/arc_env/lib/python3.7/site-packages/numpy -name 'tests' -type d -exec rm -rf '{}' '+' && \
     find /opt/conda/envs/arc_env/lib/python3.7/site-packages/pandas -name 'tests' -type d -exec rm -rf '{}' '+' && \
     find /opt/conda/envs/arc_env/lib/python3.7/site-packages -name '*.pyx' -delete && \
+    rm -rf /opt/conda/envs/arc_env/lib/python3.7/site-packages/uvloop/loop.c &&\
     make clean
 
 # Install T3
 
 # Change directory to Code
-WORKDIR /home/mambauser/Code
+WORKDIR /home/rmguser/Code
 
 # Clone main branch T3 repository from GitHub and set as working directory
 RUN git clone -b main https://github.com/ReactionMechanismGenerator/T3.git
-WORKDIR /home/mambauser/Code/T3
+WORKDIR /home/rmguser/Code/T3
 
 # Install T3 Environment
 RUN micromamba create -y -f environment.yml && \
     micromamba clean --all -f -y && \
-    rm -rf /home/mambauser/.cache/yarn \
-    rm -rf /home/mambauser/.cache/pip \
+    rm -rf /home/rmguser/.cache/yarn \
+    rm -rf /home/rmguser/.cache/pip \
     && find -name '__pycache__' -type d -exec rm -rf '{}' '+' && \
     find /opt/conda/envs/t3_env/lib/python3.7/site-packages/scipy -name 'tests' -type d -exec rm -rf '{}' '+' && \
     find /opt/conda/envs/t3_env/lib/python3.7/site-packages/numpy -name 'tests' -type d -exec rm -rf '{}' '+' && \
@@ -147,6 +59,5 @@ RUN micromamba create -y -f environment.yml && \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.pyc' -delete \
     && find /opt/conda/ -follow -type f -name '*.js.map' -delete 
-
 
 SHELL ["/bin/bash", "-c"]

--- a/devtools/Dockerfile_rmgpy
+++ b/devtools/Dockerfile_rmgpy
@@ -1,0 +1,108 @@
+# RMG Dockerfile 
+# The parent image is the base image that the Dockerfile builds upon.
+# The RMG installation instructions suggest Anaconda for installation by source, however, we use micromamba for the Docker image due to its smaller size and less overhead.
+# https://hub.docker.com/layers/mambaorg/micromamba/1.4.3-jammy/images/sha256-0c7c97be938c5522dcb9e1737bfa4499c53f6cf9e32e53897607a57ba8b148d5?context=explore
+# We are using the sha256 hash to ensure that the image is not updated without our knowledge. It considered best practice to use the sha256 hash
+FROM --platform=linux/amd64 mambaorg/micromamba@sha256:0c7c97be938c5522dcb9e1737bfa4499c53f6cf9e32e53897607a57ba8b148d5
+
+# Set the user as root
+USER root
+
+# Create a login user named rmguser
+ARG NEW_MAMBA_USER=rmguser
+ARG NEW_MAMBA_USER_ID=1000
+ARG NEW_MAMBA_USER_GID=1000
+RUN usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${NEW_MAMBA_USER}" \
+        --move-home "-u ${NEW_MAMBA_USER_ID}" "${MAMBA_USER}" && \
+    groupmod "--new-name=${NEW_MAMBA_USER}" \
+             "-g ${NEW_MAMBA_USER_GID}" "${MAMBA_USER}" && \
+    # Update the expected value of MAMBA_USER for the
+    # _entrypoint.sh consistency check.
+    echo "${NEW_MAMBA_USER}" > "/etc/arg_mamba_user" && \
+    :
+
+# Set the environment variables
+ARG MAMBA_ROOT_PREFIX=/opt/conda
+ENV MAMBA_USER=$NEW_MAMBA_USER
+ENV BASE=$MAMBA_ROOT_PREFIX
+
+# Install system dependencies
+#
+# List of deps and why they are needed:
+#  - make, gcc, g++ for building RMG
+#  - git for downloading RMG respoitories
+#  - wget for downloading conda install script
+#  - libxrender1 required by RDKit
+# Clean up the apt cache to reduce the size of the image
+RUN apt-get update && apt-get install -y \
+    git \
+    gcc \
+    g++ \
+    make \
+    libgomp1\
+    libxrender1 \
+    && apt-get clean \
+    && apt-get autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Change user to the non-root user
+USER $MAMBA_USER
+
+# Make directory for RMG-Py and RMG-database
+RUN mkdir -p /home/rmguser/Code
+
+# Change working directory to Code
+WORKDIR /home/rmguser/Code
+
+# Clone the RMG base and database repositories. The pulled branches are only the main branches.
+RUN git clone -b main https://github.com/ReactionMechanismGenerator/RMG-Py.git \ 
+    && git clone -b main https://github.com/ReactionMechanismGenerator/RMG-database.git
+
+# cd into RMG-Py
+WORKDIR /home/rmguser/Code/RMG-Py
+
+# Install RMG-Py and then clean up the micromamba cache
+RUN micromamba create -y -f environment.yml && \
+    micromamba clean --all -f -y
+
+# Activate the RMG environment
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+ENV ENV_NAME=rmg_env
+
+# Set environment variables
+# These need to be set in the Dockerfile so that they are available to the build process
+ENV PATH /opt/conda/envs/rmg_env/bin:$PATH
+ENV PYTHONPATH /home/rmguser/Code/RMG-Py:$PYTHONPATH
+ENV PATH /home/rmguser/Code/RMG-Py:$PATH
+
+# Build RMG
+RUN make \
+    && echo "export PYTHONPATH=/home/rmguser/Code/RMG-Py" >> ~/.bashrc \
+    && echo "export PATH=/home/rmguser/Code/RMG-Py:$PATH" >> ~/.bashrc
+
+# Create the link between Julia and RMG-Py. A symbolic link is created between Python-JL and Python.
+# We do not use the command in Julia 'using ReactionMechanismSimulator' because the command is only for determining if the package is installed.
+# The command does not actually install the package but instead increases the build time, therefore not required.
+# Install RMS
+# The extra arguments are required to install PyCall and RMS in this Dockerfile. Will not work without them.
+# Final command is to compile the RMS during Docker build - This will reduce the time it takes to run RMS for the first time
+RUN touch /opt/conda/envs/rmg_env/condarc-julia.yml
+RUN CONDA_JL_CONDA_EXE=/bin/micromamba julia -e 'using Pkg;Pkg.add(PackageSpec(name="PyCall", rev="master")); Pkg.build("PyCall"); Pkg.add(PackageSpec(name="ReactionMechanismSimulator", rev="main"))' \
+    && python -c "import julia; julia.install(); import diffeqpy; diffeqpy.install()" \
+    && python-jl -c "from pyrms import rms"
+
+# Add alias to bashrc - rmge to activate the environment
+# These commands are not necessary for the Docker image to run, but they are useful for the user
+RUN echo "alias rmge='micromamba activate rmg_env'" >> ~/.bashrc \
+    && echo "alias rmg='python-jl /home/rmguser/Code/RMG/rmg.py input.py'" >> ~/.bashrc \
+    && echo "alias deact='micromamba deactivate'" >> ~/.bashrc \
+    && echo "export rmgpy_path='/home/rmguser/Code/RMG-Py/'" >> ~/.bashrc \
+    && echo "export rmgdb_path='/home/rmguser/Code/RMG-database/'" >> ~/.bashrc \
+    && echo "alias rmgcode='cd \$rmgpy_path'" >> ~/.bashrc \
+    && echo "alias rmgdb='cd \$rmgdb_path'" >> ~/.bashrc \
+    && echo "alias conda='micromamba'" >> ~/.bashrc \
+    && echo "alias mamba='micromamba'" >> ~/.bashrc 
+
+# Set the entrypoint to bash
+ENTRYPOINT ["/bin/bash", "--login"]


### PR DESCRIPTION
After using a micromamba base image with rmgpy:latest, the docker size for T3 has reduced by 3gb uncompressed.

For future work, we should use ARC as a base image