### PR TITLE
Control rmg cpus

### DIFF
--- a/examples/commented/input.yml
+++ b/examples/commented/input.yml
@@ -67,6 +67,7 @@ rmg:
   # general
   rmg_execution_type: incore  # optional, determines how to execute RMG. Currently, `incore` (running in the same process) and `local` (submitting to the local server queue, not via SSH) are supported. This argument is set from T3's settings.py file unless explicitly given here, default: ``None``
   memory: 15  # optional, specifies the RMG memory to be used when executing on a server, units are GB. This argument is set from T3's settings.py file unless explicitly given here, default: ``None``
+  cpus: 16  # optional, specifies the number of processes to use for an RMG job. Could also be set from T3's settings.py file if not explicitly given here, default: 16
 
   # database (a required block)
   database:

--- a/t3/main.py
+++ b/t3/main.py
@@ -634,6 +634,7 @@ class T3(object):
                                                job_log_path=self.paths['RMG job log'],
                                                logger=self.logger,
                                                memory=self.rmg['memory'] * 1000 if self.rmg['memory'] is not None else None,
+                                               cpus=self.rmg['cpus'],
                                                max_iterations=self.t3['options']['max_rmg_iterations'],
                                                verbose=self.verbose,
                                                t3_project_name=self.project,

--- a/t3/schema.py
+++ b/t3/schema.py
@@ -526,6 +526,7 @@ class RMG(BaseModel):
     """
     rmg_execution_type: Optional[str] = None
     memory: Optional[conint(ge=0)] = None
+    cpus: Optional[conint(gt=0)] = None
     database: RMGDatabase
     reactors: List[RMGReactor]
     species: List[RMGSpecies]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -68,6 +68,7 @@ t3_minimal = {'options': {'all_core_reactions': False,
               }
 
 rmg_minimal = {'memory': None,
+               'cpus': None,
                'rmg_execution_type': None,
                'database': {'kinetics_depositories': 'default',
                             'kinetics_estimator': 'rate rules',


### PR DESCRIPTION
Allow users to specify in T3's input file the number of CPUs to use when running RMG