### PR TITLE
Added auto-completion for RMG thermo and kinetics libraries based on the chemistry set

### DIFF
--- a/data/libraries.yml
+++ b/data/libraries.yml
@@ -1,0 +1,153 @@
+# Recommended RMG libraries per application
+
+primary:
+  thermo:
+    - primaryThermoLibrary
+    - BurkeH2O2
+    - Spiekermann_refining_elementary_reactions
+    - thermo_DFT_CCSDTF12_BAC
+    - DFT_QCI_thermo
+    - CBS_QB3_1dHR
+  kinetics:
+    - primaryH2O2
+
+nitrogen:
+  thermo:
+    - NH3
+    - NitrogenCurran
+    - CHON_G4
+    - CN
+    - NOx2018
+    - name: primaryNS
+      credence: low
+    - name: CHN
+      credence: low
+    - name: CHON
+      credence: low
+    - name: BurcatNS
+      credence: low
+  kinetics:
+    - primaryNitrogenLibrary
+    - HydrazinePDep
+    - Ethylamine
+
+sulfur:
+  thermo:
+    - name: primaryNS
+      credence: low
+    - name: SulfurGlarborgH2S
+      credence: low
+    - name: SulfurGlarborgBozzeli
+      credence: low
+    - name: BurcatNS
+      credence: low
+  kinetics:
+    - primarySulfurLibrary
+    - Sulfur/DMDS
+    - Sulfur/DMS
+
+combustion:
+  thermo:
+    - FFCM1(-)
+    - NOx2018
+    - name: CHO
+      credence: low
+  kinetics:
+    - FFCM1(-)
+    - 2006_Joshi_OH_CO
+    - 2005_Senosiain_OH_C2H2
+    - NOx2018
+
+CH_pyrolysis:
+  thermo:
+    - NOx2018
+    - Butadiene_Dimerization
+    - C10H11
+    - s3_5_7_ane
+    - Fulvene_H
+    - naphthalene_H
+    - vinylCPD_H
+    - Lai_Hexylbenzene
+    - Narayanaswamy
+    - SABIC_aromatics_1dHR_extended
+    - SABIC_aromatics_1dHR
+    - SABIC_aromatics
+    - heavy_oil_ccsdtf12_1dHR
+    - bio_oil
+    - Chernov
+    - CurranPentane
+    - Klippenstein_Glarborg2016
+    - name: CH
+      credence: low
+  kinetics:
+    - 2001_Tokmakov_H_Toluene_to_CH3_Benzene
+    - 2003_Miller_Propargyl_Recomb_High_P
+    - 2009_Sharma_C5H5_CH3_highP
+    - 2015_Buras_C2H3_C4H6_highP
+    - Butadiene_Dimerization
+    - C10H11
+    - C12H11_pdep
+    - C2H2_init
+    - C6H5_C4H4_Mebel
+    - Fulvene_H
+    - Mebel_Naphthyl
+    - Mebel_C6H5_C2H2
+    - biCPD_H_shift
+    - c-C5H5_CH3_Sharma
+    - fascella
+    - kislovB
+    - naphthalene_H
+    - vinylCPD_H
+    - First_to_Second_Aromatic_Ring/2005_Ismail_C6H5_C4H6_highP
+    - First_to_Second_Aromatic_Ring/2012_Matsugi_C3H3_C7H7_highP
+    - First_to_Second_Aromatic_Ring/2016_Mebel_C10H9_highP
+    - First_to_Second_Aromatic_Ring/2016_Mebel_C9H9_highP
+    - First_to_Second_Aromatic_Ring/2016_Mebel_Indene_CH3_highP
+    - First_to_Second_Aromatic_Ring/2017_Buras_C6H5_C3H6_highP
+    - First_to_Second_Aromatic_Ring/2017_Mebel_C6H4C2H_C2H2_highP
+    - First_to_Second_Aromatic_Ring/2017_Mebel_C6H5C2H2_C2H2_highP
+    - First_to_Second_Aromatic_Ring/2017_Mebel_C6H5_C2H2_highP
+    - First_to_Second_Aromatic_Ring/2017_Mebel_C6H5_C4H4_highP
+    - First_to_Second_Aromatic_Ring/phenyl_diacetylene_effective
+    - Aromatics_high_pressure/C10H10_1
+    - Aromatics_high_pressure/C10H10_2
+    - Aromatics_high_pressure/C10H10_H_abstraction
+    - Aromatics_high_pressure/C10H11_1
+    - Aromatics_high_pressure/C10H11_2
+    - Aromatics_high_pressure/C10H11_3
+    - Aromatics_high_pressure/C10H11_4
+    - Aromatics_high_pressure/C10H7
+    - Aromatics_high_pressure/C10H8_H_abstraction_H_recomb
+    - Aromatics_high_pressure/C10H9_1
+    - Aromatics_high_pressure/C10H9_2
+    - Aromatics_high_pressure/C10H9_3
+    - Aromatics_high_pressure/C10H9_4
+    - Aromatics_high_pressure/C12H10_1
+    - Aromatics_high_pressure/C12H10_2
+    - Aromatics_high_pressure/C12H10_H_abstraction
+    - Aromatics_high_pressure/C12H11
+    - Aromatics_high_pressure/C12H8_H_abstraction
+    - Aromatics_high_pressure/C12H9
+    - Aromatics_high_pressure/C14H10_H_abstraction_H_recomb
+    - Aromatics_high_pressure/C14H11_1
+    - Aromatics_high_pressure/C14H11_2
+    - Aromatics_high_pressure/C14H11_3
+    - Aromatics_high_pressure/C14H11_4
+    - Aromatics_high_pressure/C14H9
+    - Aromatics_high_pressure/C16H11
+    - Aromatics_high_pressure/C7H8
+    - Aromatics_high_pressure/C7H8_H_abstraction
+    - Aromatics_high_pressure/C7H9
+    - Aromatics_high_pressure/C8H6_H_abstraction
+    - Aromatics_high_pressure/C8H7
+    - Aromatics_high_pressure/C8H8_H_abstraction
+    - Aromatics_high_pressure/C8H9
+    - Aromatics_high_pressure/C9H10_H_abstraction
+    - Aromatics_high_pressure/C9H11
+    - Aromatics_high_pressure/C9H7
+    - Aromatics_high_pressure/C9H8_1
+    - Aromatics_high_pressure/C9H8_2
+    - Aromatics_high_pressure/C9H8_H_abstraction
+    - Aromatics_high_pressure/C9H9_1
+    - Aromatics_high_pressure/C9H9_2
+

--- a/examples/commented/input.yml
+++ b/examples/commented/input.yml
@@ -72,8 +72,10 @@ rmg:
 
   # database (a required block)
   database:
-    thermo_libraries: ['BurkeH2O2', 'DFT_QCI_thermo', 'primaryThermoLibrary', 'CBS_QB3_1dHR']  # *required*, can be an empty list
-    kinetics_libraries: ['BurkeH2O2inN2', 'NOx2018', 'Klippenstein_Glarborg2016']  # *required*, can be an empty list
+    thermo_libraries: ['BurkeH2O2', 'DFT_QCI_thermo', 'primaryThermoLibrary', 'CBS_QB3_1dHR']  # Can be None for auto-completion
+    kinetics_libraries: ['BurkeH2O2inN2', 'NOx2018', 'Klippenstein_Glarborg2016']  # Can be None for auto-completion
+    chemistry_sets: ['primary', 'nitrogen', 'combustion']  # The chemistry systems for which thermo and kinetics libraries will be loaded. Can be None to avoid auto-completion
+    use_low_credence_libraries: False # Whether to use low credence libraries during auto-completion, default: ``False``
     transport_libraries: ['PrimaryTransportLibrary', 'OneDMinN2', 'NOx2018', 'GRI-Mech']  # optional, default: ['PrimaryTransportLibrary', 'OneDMinN2', 'NOx2018', 'GRI-Mech']
     seed_mechanisms: []  # optional, default: []
     kinetics_depositories: default  # optional, default: 'default'

--- a/t3/common.py
+++ b/t3/common.py
@@ -14,8 +14,8 @@ from arc.species.converter import molecules_from_xyz
 VERSION = '0.1.0'
 
 t3_path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))  # absolute path to the T3 folder
-DATA_BASE_PATH = os.path.join(t3_path, 'tests', 'data')
-SIMULATE_DATA_BASE_PATH = os.path.join(t3_path, 'tests', 'test_simulate_adapters', 'data')
+TEST_DATA_BASE_PATH = os.path.join(t3_path, 'tests', 'data')
+SIMULATE_TEST_DATA_BASE_PATH = os.path.join(t3_path, 'tests', 'test_simulate_adapters', 'data')
 EXAMPLES_BASE_PATH = os.path.join(t3_path, 'examples')
 SCRATCH_BASE_PATH = os.path.join(t3_path, 'tests', 'scratch')
 IPYTHON_SIMULATOR_EXAMPLES_PATH = os.path.join(t3_path, 'ipython', 'simulator_adapter_examples')

--- a/t3/common.py
+++ b/t3/common.py
@@ -14,6 +14,7 @@ from arc.species.converter import molecules_from_xyz
 VERSION = '0.1.0'
 
 t3_path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))  # absolute path to the T3 folder
+DATA_BASE_PATH = os.path.join(t3_path, 'data')
 TEST_DATA_BASE_PATH = os.path.join(t3_path, 'tests', 'data')
 SIMULATE_TEST_DATA_BASE_PATH = os.path.join(t3_path, 'tests', 'test_simulate_adapters', 'data')
 EXAMPLES_BASE_PATH = os.path.join(t3_path, 'examples')

--- a/tests/common.py
+++ b/tests/common.py
@@ -19,7 +19,18 @@ def run_minimal(project: Optional[str] = None,
                 iteration: Optional[int] = None,
                 set_paths: bool = False,
                 ) -> T3:
-    """A helper function for running the minimal example"""
+    """
+    A helper function for running the minimal example.
+
+    Args:
+        project (str, optional): The project name.
+        project_directory (str, optional): The project directory.
+        iteration (int, optional): The iteration number.
+        set_paths (bool, optional): Whether to set the paths.
+
+    Returns:
+        T3: The T3 object.
+    """
     minimal_input = os.path.join(EXAMPLES_BASE_PATH, 'minimal', 'input.yml')
     input_dict = read_yaml_file(path=minimal_input)
     input_dict['verbose'] = 10

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -11,7 +11,7 @@ import pytest
 from rmgpy.species import Species
 
 import t3.common as common
-from t3.common import DATA_BASE_PATH
+from t3.common import TEST_DATA_BASE_PATH
 from t3.schema import RMGSpecies
 from tests.common import run_minimal
 
@@ -33,7 +33,7 @@ label2:
 
 def test_get_species_by_label():
     """Test getting species by label"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'minimal_data'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'minimal_data'),
                      iteration=1,
                      set_paths=True,
                      )
@@ -131,7 +131,7 @@ def test_get_interval():
 
 def test_get_chem_to_rmg_rxn_index_map():
     """Test the get_chem_to_rmg_rxn_index_map() function"""
-    chemkin_path = os.path.join(DATA_BASE_PATH, 'chem_annotated_1.inp')
+    chemkin_path = os.path.join(TEST_DATA_BASE_PATH, 'chem_annotated_1.inp')
     rxn_map = common.get_chem_to_rmg_rxn_index_map(chem_annotated_path=chemkin_path)
     assert rxn_map == {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 5, 7: 6, 8: 7, 9: 8, 10: 9, 11: 9, 12: 10, 13: 11, 14: 12,
                        15: 13, 16: 14, 17: 15, 18: 16, 19: 17, 20: 18, 21: 19, 22: 20, 23: 21, 24: 22, 25: 23, 26: 24,

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -12,7 +12,7 @@ import shutil
 from arc.common import read_yaml_file
 
 from t3 import T3
-from t3.common import DATA_BASE_PATH
+from t3.common import TEST_DATA_BASE_PATH
 from t3.runners.rmg_runner import backup_rmg_files
 from t3.utils.dependencies import check_dependencies
 
@@ -58,7 +58,7 @@ def test_computing_thermo():
     Tests computing thermo for two species and running RMG with the updated data
     Need xtb installed
     """
-    functional_test_directory = os.path.join(DATA_BASE_PATH, 'functional_2_thermo')
+    functional_test_directory = os.path.join(TEST_DATA_BASE_PATH, 'functional_2_thermo')
     #delete_selective_content_from_test_dirs(test_dir=functional_test_directory)
     input_file = os.path.join(functional_test_directory, 'input.yml')
     input_dict = read_yaml_file(path=input_file)
@@ -113,7 +113,7 @@ def test_rmg_files_backup_before_restart():
     3.chem_edge_annotated
     4.RMG log files
     """
-    backup_test_directory = os.path.join(DATA_BASE_PATH, 'backup_rmg_files_before_restart','iteration_1', 'RMG')
+    backup_test_directory = os.path.join(TEST_DATA_BASE_PATH, 'backup_rmg_files_before_restart','iteration_1', 'RMG')
     backup_rmg_files(backup_test_directory)
     # Find the backup directory (there should only be one per restart)
     backup_directories = [d for d in os.listdir(backup_test_directory) if d.startswith('restart_backup')]
@@ -152,11 +152,11 @@ def delete_selective_content_from_test_dirs(test_dir: str):
 
 def teardown_module():
     """teardown any state that was previously setup with a setup_module method."""
-    test_dirs_to_selectively_delete = [os.path.join(DATA_BASE_PATH, 'functional_2_thermo'),
+    test_dirs_to_selectively_delete = [os.path.join(TEST_DATA_BASE_PATH, 'functional_2_thermo'),
                                        ]
     for test_dir in test_dirs_to_selectively_delete:
         delete_selective_content_from_test_dirs(test_dir)
-    test_dirs = [os.path.join(DATA_BASE_PATH, 'T3_functional_test_1'),
+    test_dirs = [os.path.join(TEST_DATA_BASE_PATH, 'T3_functional_test_1'),
                  ]
     for test_dir in test_dirs:
         shutil.rmtree(test_dir, ignore_errors=True)

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -13,14 +13,14 @@ from rmgpy.species import Species
 from rmgpy.thermo import ThermoData
 from rmgpy.statmech import Conformer, IdealGasTranslation, NonlinearRotor, HarmonicOscillator
 
-from t3.common import DATA_BASE_PATH
+from t3.common import TEST_DATA_BASE_PATH
 from tests.common import run_minimal
 from t3.utils.libraries import add_to_rmg_libraries
 
 
 def test_add_to_rmg_library():
     """Test adding thermo calculations to an existing thermo library"""
-    libraries_path = os.path.join(DATA_BASE_PATH, 'libraries')
+    libraries_path = os.path.join(TEST_DATA_BASE_PATH, 'libraries')
     if not os.path.isdir(libraries_path):
         os.makedirs(libraries_path)
 
@@ -153,6 +153,6 @@ def test_add_to_rmg_library():
 
 def teardown_module():
     """teardown any state that was previously set up."""
-    path = os.path.join(DATA_BASE_PATH, 'libraries')
+    path = os.path.join(TEST_DATA_BASE_PATH, 'libraries')
     if os.path.isdir(path):
         shutil.rmtree(path, ignore_errors=True)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -10,11 +10,11 @@ import os
 import shutil
 from typing import Optional
 
-from t3.common import DATA_BASE_PATH
+from t3.common import TEST_DATA_BASE_PATH
 import t3.logger as logger
 
 
-log_project_directory = os.path.join(DATA_BASE_PATH, 'log_file_testing_dir')
+log_project_directory = os.path.join(TEST_DATA_BASE_PATH, 'log_file_testing_dir')
 
 
 def init_logger(project: str = 'project_name',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,7 @@ from rmgpy.thermo import NASA, ThermoData
 from arc.common import read_yaml_file
 from arc.species import ARCSpecies
 
-from t3.common import DATA_BASE_PATH, EXAMPLES_BASE_PATH, PROJECTS_BASE_PATH
+from t3.common import TEST_DATA_BASE_PATH, EXAMPLES_BASE_PATH, PROJECTS_BASE_PATH
 from tests.common import run_minimal
 from t3.main import (T3,
                      legalize_species_label,
@@ -204,8 +204,8 @@ qm_minimal = {'adapter': 'ARC',
               'species': [],
               }
 
-restart_base_path = os.path.join(DATA_BASE_PATH, 'restart')
-dump_species_path = os.path.join(DATA_BASE_PATH, 'test_dump_species')
+restart_base_path = os.path.join(TEST_DATA_BASE_PATH, 'restart')
+dump_species_path = os.path.join(TEST_DATA_BASE_PATH, 'test_dump_species')
 
 
 def setup_module():
@@ -451,7 +451,7 @@ def test_run_arc():
 def test_process_arc_run():
     """Tests processing an ARC run and copying over a thermo library to the RMG-database repository"""
     t3 = run_minimal(project='T3',
-                     project_directory=os.path.join(DATA_BASE_PATH, 'process_arc'),
+                     project_directory=os.path.join(TEST_DATA_BASE_PATH, 'process_arc'),
                      iteration=2,
                      set_paths=True,
                      )
@@ -539,7 +539,7 @@ def test_run_rmg():
 def test_determine_species_to_calculate():
     """Test determining the species to be calculated"""
 
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'determine_species'))
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_species'))
 
     # 1. no calculations required
     t3.iteration = 1
@@ -586,7 +586,7 @@ def test_determine_species_to_calculate():
 
 def test_species_requires_refinement():
     """Test properly identifying the thermo comment of a species to determine whether it requires refinement"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'determine_species'))
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_species'))
     spc_1 = Species(smiles='C')
     spc_1.thermo = NASA()
     spc_1.thermo.comment = 'Thermo group additivity estimation: group(O2s-(Cds-Cd)H) + missing(O2d-CO) + ' \
@@ -646,7 +646,7 @@ def test_species_requires_refinement():
 
 def test_reaction_requires_refinement():
     """Test properly identifying the kinetic comment of a reaction to determine whether it requires refinement"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'determine_reactions'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_reactions'),
                      iteration=1,
                      set_paths=True,
                      )
@@ -660,7 +660,7 @@ family: H_Abstraction"""
 
 def test_determine_species_based_on_sa():
     """Test determining species to calculate based on sensitivity analysis"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'minimal_data'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'minimal_data'),
                      iteration=1,
                      set_paths=True,
                      )
@@ -687,14 +687,14 @@ def test_determine_species_based_on_sa():
     for dir_ in dirs:
         if os.path.isdir(dir_):
             shutil.rmtree(dir_, ignore_errors=True)
-    t3_log = os.path.join(DATA_BASE_PATH, 'minimal_data', 't3.log')
+    t3_log = os.path.join(TEST_DATA_BASE_PATH, 'minimal_data', 't3.log')
     if os.path.isfile(t3_log):
         os.remove(t3_log)
 
 
 def test_determine_species_from_pdep_network():
     """Test determining species from pdep network"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'pdep_network'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'pdep_network'),
                      iteration=1,
                      set_paths=True,
                      )
@@ -716,9 +716,9 @@ def test_determine_species_from_pdep_network():
 def test_determine_species_based_on_collision_violators():
     """Test determining species to calculate based on collision rate violating reactions"""
     t3 = run_minimal()
-    t3.paths['RMG coll vio'] = os.path.join(DATA_BASE_PATH, 'collision_rate_violators', 'collision_rate_violators.log')
-    t3.paths['chem annotated'] = os.path.join(DATA_BASE_PATH, 'collision_rate_violators', 'chem_annotated.inp')
-    t3.paths['species dict'] = os.path.join(DATA_BASE_PATH, 'collision_rate_violators', 'species_dictionary.txt')
+    t3.paths['RMG coll vio'] = os.path.join(TEST_DATA_BASE_PATH, 'collision_rate_violators', 'collision_rate_violators.log')
+    t3.paths['chem annotated'] = os.path.join(TEST_DATA_BASE_PATH, 'collision_rate_violators', 'chem_annotated.inp')
+    t3.paths['species dict'] = os.path.join(TEST_DATA_BASE_PATH, 'collision_rate_violators', 'species_dictionary.txt')
     t3.rmg_species, t3.rmg_reactions = t3.load_species_and_reactions_from_chemkin_file()
     species_to_calc = t3.determine_species_and_reactions_based_on_collision_violators()[0]
     assert len(species_to_calc) == 18
@@ -778,7 +778,7 @@ def test_trsh_rmg_tol():
 
 def test_get_species_key():
     """Test checking whether a species already exists in self.species and getting its key"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'determine_species'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_species'),
                      iteration=2,
                      set_paths=True,
                      )
@@ -799,7 +799,7 @@ def test_get_species_key():
 
 def test_load_species_and_reactions_from_chemkin_file():
     """Test loading RMG species and reactions from a Chemkin file"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'determine_species'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_species'),
                      iteration=2,
                      set_paths=True,
                      )
@@ -814,7 +814,7 @@ def test_load_species_and_reactions_from_chemkin_file():
 
 def test_add_species():
     """Test adding a species to self.species and to self.qm['species']"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'determine_species'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_species'),
                      iteration=2,
                      set_paths=True,
                      )
@@ -867,7 +867,7 @@ H  0.0000000  0.0000000 -0.3736550"""
 
 def test_add_reaction():
     """Test adding a reaction to self.reactions and to self.qm['reactions']"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'determine_reactions'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_reactions'),
                      iteration=1,
                      set_paths=True,
                      )
@@ -978,7 +978,7 @@ def test_load_species():
 
 def test_get_reaction_by_index():
     """Test getting reaction by index"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'minimal_data'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'minimal_data'),
                      iteration=1,
                      set_paths=True,
                      )
@@ -1007,7 +1007,7 @@ def test_legalize_species_label():
 
 def test_get_species_label_by_structure():
     """Test getting the species label from a list by its structure"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'minimal_data'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'minimal_data'),
                      iteration=1,
                      set_paths=True,
                      )
@@ -1041,7 +1041,7 @@ multiplicity 1
 
 def test_check_overtime():
     """Test checking overtime"""
-    t3 = run_minimal(project_directory=os.path.join(DATA_BASE_PATH, 'minimal_data'),
+    t3 = run_minimal(project_directory=os.path.join(TEST_DATA_BASE_PATH, 'minimal_data'),
                      iteration=1,
                      set_paths=True,
                      )
@@ -1070,7 +1070,7 @@ def teardown_module():
     files = [os.path.join(restart_base_path, 'r6', 'iteration_6', 'ARC', 'T3_ARC_restart_test.info'),
              os.path.join(restart_base_path, 'r6', 'iteration_6', 'ARC', 'input.yml'),
              os.path.join(restart_base_path, 'r6', 'species.yml'),
-             os.path.join(DATA_BASE_PATH, 'process_arc', 'species.yml'),
+             os.path.join(TEST_DATA_BASE_PATH, 'process_arc', 'species.yml'),
              ]
     for file in files:
         if os.path.isfile(file):
@@ -1079,10 +1079,10 @@ def teardown_module():
     # delete folders
     for directory in [test_minimal_project_directory,
                       dump_species_path,
-                      os.path.join(DATA_BASE_PATH, 'minimal_data', 'log_archive'),
-                      os.path.join(DATA_BASE_PATH, 'determine_species', 'log_archive'),
-                      os.path.join(DATA_BASE_PATH, 'pdep_network', 'log_archive'),
-                      os.path.join(DATA_BASE_PATH, 'process_arc', 'log_archive'),
+                      os.path.join(TEST_DATA_BASE_PATH, 'minimal_data', 'log_archive'),
+                      os.path.join(TEST_DATA_BASE_PATH, 'determine_species', 'log_archive'),
+                      os.path.join(TEST_DATA_BASE_PATH, 'pdep_network', 'log_archive'),
+                      os.path.join(TEST_DATA_BASE_PATH, 'process_arc', 'log_archive'),
                       os.path.join(restart_base_path, 'r6', 'iteration_6', 'ARC', 'output'),
                       os.path.join(restart_base_path, 'r6', 'iteration_6', 'ARC', 'log_and_restart_archive'),
                       ]:

--- a/tests/test_rmg_runner.py
+++ b/tests/test_rmg_runner.py
@@ -6,7 +6,7 @@ t3 tests test_rmg_runner module
 """
 
 import os
-from t3.common import DATA_BASE_PATH, EXAMPLES_BASE_PATH
+from t3.common import TEST_DATA_BASE_PATH, EXAMPLES_BASE_PATH
 from t3.runners.rmg_runner import rmg_job_converged, write_submit_script
 
 
@@ -138,12 +138,12 @@ touch final_time
 
     def test_rmg_job_converged(self):
         """Test correctly identifying whether an RMG job converged ot not, and if not which error was received."""
-        rmg_folder_1 = os.path.join(DATA_BASE_PATH, 'rmg_convergence', '1_frag_error')
+        rmg_folder_1 = os.path.join(TEST_DATA_BASE_PATH, 'rmg_convergence', '1_frag_error')
         converged, error = rmg_job_converged(project_directory=rmg_folder_1)
         assert not converged
         assert error == "AttributeError: 'Fragment' object has no attribute 'count_internal_rotors'"
 
-        rmg_folder_2 = os.path.join(DATA_BASE_PATH, 'rmg_convergence', '2_converged')
+        rmg_folder_2 = os.path.join(TEST_DATA_BASE_PATH, 'rmg_convergence', '2_converged')
         converged, error = rmg_job_converged(project_directory=rmg_folder_2)
         assert converged
         assert error is None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -250,6 +250,8 @@ def test_rmg_database_schema():
     assert rmg_database.kinetics_depositories == 'default'
     assert rmg_database.kinetics_families == 'default'
     assert rmg_database.kinetics_estimator == 'rate rules'
+    assert rmg_database.chemistry_sets is None
+    assert rmg_database.use_low_credence_libraries is False
 
 
 def test_rmg_species_schema():

--- a/tests/test_simulate_adapters/test_rmg_constantTP.py
+++ b/tests/test_simulate_adapters/test_rmg_constantTP.py
@@ -8,12 +8,12 @@ t3 tests test_rmg_constantTP module
 import os
 import shutil
 
-from t3.common import SIMULATE_DATA_BASE_PATH
+from t3.common import SIMULATE_TEST_DATA_BASE_PATH
 from tests.common import run_minimal
 from t3.simulate.rmg_constantTP import RMGConstantTP
 
 
-TEST_DIR = os.path.join(SIMULATE_DATA_BASE_PATH, 'rmg_simulator_test')
+TEST_DIR = os.path.join(SIMULATE_TEST_DATA_BASE_PATH, 'rmg_simulator_test')
 
 
 def test_set_up_no_sa():

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -9,7 +9,7 @@ import os
 
 from arc.common import read_yaml_file
 
-from t3.common import DATA_BASE_PATH, EXAMPLES_BASE_PATH
+from t3.common import TEST_DATA_BASE_PATH, EXAMPLES_BASE_PATH
 from t3.schema import InputBase, RMG, T3
 from t3.utils.writer import to_camel_case, write_rmg_input_file
 
@@ -31,9 +31,9 @@ def test_write_rmg_input_file():
     """Test writing an RMG input file"""
     minimal_input = os.path.join(EXAMPLES_BASE_PATH, 'minimal', 'input.yml')
     input_dict = read_yaml_file(path=minimal_input)
-    minimal_input_file_path = os.path.join(DATA_BASE_PATH, 'minimal_input.py')
+    minimal_input_file_path = os.path.join(TEST_DATA_BASE_PATH, 'minimal_input.py')
     schema = InputBase(project=input_dict['project'],
-                       project_directory=DATA_BASE_PATH,
+                       project_directory=TEST_DATA_BASE_PATH,
                        t3=input_dict['t3'],
                        rmg=input_dict['rmg'],
                        qm=input_dict['qm'],
@@ -250,7 +250,7 @@ def test_write_rmg_input_file_liquid():
                }
           }
 
-    file_path = os.path.join(DATA_BASE_PATH, 'test_write_rmg_input_file_liquid.py')
+    file_path = os.path.join(TEST_DATA_BASE_PATH, 'test_write_rmg_input_file_liquid.py')
     rmg_schema = RMG(**rmg).dict()  # fill in defaults
     t3_schema = T3(**t3).dict()     # fill in defaults
 
@@ -315,7 +315,7 @@ def test_write_rmg_input_file_seed_all_radicals():
                }
           }
 
-    file_path = os.path.join(DATA_BASE_PATH, 'test_write_rmg_input_file_seed_rads.py')
+    file_path = os.path.join(TEST_DATA_BASE_PATH, 'test_write_rmg_input_file_seed_rads.py')
     rmg_schema = RMG(**rmg).dict()  # fill in defaults
     t3_schema = T3(**t3).dict()     # fill in defaults
 


### PR DESCRIPTION
RMG's libraries are an important asset, yet it takes an expert to know which library to use per application.
This contribution added a feature that allows users to request auto-completion for their libraries by just describing the application of their chemistry set: [`'primary', 'nitrogen', 'sulfur', 'combustion', 'CH_pyrolysis']`
The recommended libraries will be appended in addition to any user-supplied libraries (not adding duplicates)
Tests were added