### PR TITLE
Allow auto-library-completion to seed libraries

### DIFF
--- a/data/libraries.yml
+++ b/data/libraries.yml
@@ -9,7 +9,8 @@ primary:
     - DFT_QCI_thermo
     - CBS_QB3_1dHR
   kinetics:
-    - primaryH2O2
+    - name: primaryH2O2
+      seed: true
 
 nitrogen:
   thermo:

--- a/t3/main.py
+++ b/t3/main.py
@@ -1558,6 +1558,7 @@ def auto_complete_rmg_libraries(database: dict) -> dict:
     """
     database['thermo_libraries'] = database['thermo_libraries'] or list()
     database['kinetics_libraries'] = database['kinetics_libraries'] or list()
+    database['seed_mechanisms'] = database['seed_mechanisms'] or list()
     if database['chemistry_sets'] is not None:
         libraries_dict = read_yaml_file(path=os.path.join(DATA_BASE_PATH, 'libraries.yml'))
         low_credence = database['use_low_credence_libraries']
@@ -1571,10 +1572,15 @@ def auto_complete_rmg_libraries(database: dict) -> dict:
                         if isinstance(entry, str) and entry not in libraries:
                             libraries.append(entry)
                         elif isinstance(entry, dict):
-                            if entry['credence'] != 'low' and entry['name'] not in libraries:
+                            if 'credence' in entry and entry['credence'] != 'low' and entry['name'] not in libraries:
                                 libraries.append(entry['name'])
-                            if entry['credence'] == 'low' and low_credence and entry['name'] not in libraries:
+                            if 'credence' in entry and entry['credence'] == 'low' and low_credence and entry['name'] not in libraries:
                                 low_credence_libraries.append(entry['name'])
+                            if 'seed' in entry and entry['seed'] and entry['name'] not in libraries \
+                                    and entry['name'] not in database['seed_mechanisms']:
+                                database['seed_mechanisms'].append(entry['name'])
+                            if 'seed' in entry and not entry['seed'] and entry['name'] not in libraries:
+                                libraries.append(entry['name'])
                 libraries.extend(low_credence_libraries)
     del database['chemistry_sets']
     del database['use_low_credence_libraries']

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1076,7 +1076,8 @@ def test_auto_complete_rmg_libraries():
     assert database_2['thermo_libraries'] == ['primaryThermoLibrary', 'BurkeH2O2', 'Spiekermann_refining_elementary_reactions',
                                               'thermo_DFT_CCSDTF12_BAC', 'DFT_QCI_thermo', 'CBS_QB3_1dHR', 'NH3', 'NitrogenCurran',
                                               'CHON_G4', 'CN', 'NOx2018']
-    assert database_2['kinetics_libraries'] == ['primaryH2O2', 'primaryNitrogenLibrary', 'HydrazinePDep', 'Ethylamine']
+    assert database_2['kinetics_libraries'] == ['primaryNitrogenLibrary', 'HydrazinePDep', 'Ethylamine']
+    assert database_2['seed_mechanisms'] == ['primaryH2O2']
     assert 'chemistry_sets' not in database_2
 
     database_3 = t3.rmg['database'].copy()
@@ -1086,7 +1087,8 @@ def test_auto_complete_rmg_libraries():
     assert database_3['thermo_libraries'] == ['primaryThermoLibrary', 'BurkeH2O2', 'Spiekermann_refining_elementary_reactions',
                                               'thermo_DFT_CCSDTF12_BAC', 'DFT_QCI_thermo', 'CBS_QB3_1dHR', 'NH3', 'NitrogenCurran',
                                               'CHON_G4', 'CN', 'NOx2018', 'primaryNS', 'CHN', 'CHON', 'BurcatNS']
-    assert database_3['kinetics_libraries'] == ['primaryH2O2', 'primaryNitrogenLibrary', 'HydrazinePDep', 'Ethylamine']
+    assert database_3['kinetics_libraries'] == ['primaryNitrogenLibrary', 'HydrazinePDep', 'Ethylamine']
+    assert database_2['seed_mechanisms'] == ['primaryH2O2']
     assert 'chemistry_sets' not in database_3
 
 


### PR DESCRIPTION
The auto-library-completion feature in #160 did not allow to seed libraries.
Now this option was added, and seed libraries can be determined by flagging the `seed` key in the data/libraries.yml file
A test was added