### PR TITLE
fix(docker): align Dockerfile with current ARC base image (mambauser)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,39 @@
-# Using the a base image of rmgpy:latest from DockerHub - Not the official version but a custom version that is smaller in size
+# Base image: ARC (built on mambaorg/micromamba, Ubuntu 24.04).
+# Contract inherited from the base image:
+#   - non-root user `mambauser`, home `/home/mambauser`, code under `/home/mambauser/Code`
+#   - micromamba at MAMBA_ROOT_PREFIX=/opt/conda, MAMBA_DOCKERFILE_ACTIVATE=1
+#   - entrypoint `/usr/local/bin/entrywrapper.sh`, which starts as root and `runuser`s to mambauser
 FROM --platform=linux/amd64 laxzal/arc:latest
 
-USER rmguser
+# Build the T3 layers as the unprivileged base user
+USER mambauser
 
-# Installing ARC
-# Change directory to Code
-WORKDIR /home/rmguser/Code
-
-# Install T3
-
-# Change directory to Code
-WORKDIR /home/rmguser/Code
-
-# Clone main branch T3 repository from GitHub and set as working directory
+# Clone the T3 repository into the base image's Code directory
+WORKDIR /home/mambauser/Code
 RUN git clone -b main https://github.com/ReactionMechanismGenerator/T3.git
-WORKDIR /home/rmguser/Code/T3
+WORKDIR /home/mambauser/Code/T3
 
-# Install T3 Environment
+# Create the T3 environment (python 3.14, see environment.yml) and slim the image.
+# Cleanups are restricted to paths that always exist so a missing path can't break the && chain.
 RUN micromamba create -y -f environment.yml && \
     micromamba clean --all -f -y && \
-    rm -rf /home/rmguser/.cache/yarn \
-    rm -rf /home/rmguser/.cache/pip \
-    && find -name '__pycache__' -type d -exec rm -rf '{}' '+' && \
-    find /opt/conda/envs/t3_env/lib/python3.7/site-packages/scipy -name 'tests' -type d -exec rm -rf '{}' '+' && \
-    find /opt/conda/envs/t3_env/lib/python3.7/site-packages/numpy -name 'tests' -type d -exec rm -rf '{}' '+' && \
-    find /opt/conda/envs/t3_env/lib/python3.7/site-packages/pandas -name 'tests' -type d -exec rm -rf '{}' '+' && \
-    find /opt/conda/envs/t3_env/lib/python3.7/site-packages -name '*.pyx' -delete \
-    && find /opt/conda/ -follow -type f -name '*.a' -delete \
-    && find /opt/conda/ -follow -type f -name '*.pyc' -delete \
-    && find /opt/conda/ -follow -type f -name '*.js.map' -delete
+    rm -rf /home/mambauser/.cache/pip /home/mambauser/.cache/yarn && \
+    find /home/mambauser/Code/T3 -name '__pycache__' -type d -exec rm -rf '{}' '+' && \
+    find /opt/conda/ -follow -type f -name '*.a' -delete && \
+    find /opt/conda/ -follow -type f -name '*.pyc' -delete && \
+    find /opt/conda/ -follow -type f -name '*.js.map' -delete
 
-# Add alias to bashrc - rmge to activate the environment
-# These commands are not necessary for the Docker image to run, but they are useful for the user
-RUN echo "export arc_path='/home/rmguser/Code/ARC/'" >> ~/.bashrc \
-    && echo "export t3_path='/home/rmguser/Code/T3/'" >> ~/.bashrc \
-    && echo "alias t3code='cd \$t3_path'" >> ~/.bashrc \
-    && echo "alias t3e='micromamba activate t3_env'" >> ~/.bashrc \
-    && echo "alias t3='python /home/rmguser/Code/T3/T3.py input.yml'" >> ~/.bashrc
+# Convenience aliases for interactive shells (not required for the image to run)
+RUN echo "export arc_path='/home/mambauser/Code/ARC/'" >> ~/.bashrc && \
+    echo "export t3_path='/home/mambauser/Code/T3/'" >> ~/.bashrc && \
+    echo "alias t3code='cd \$t3_path'" >> ~/.bashrc && \
+    echo "alias t3e='micromamba activate t3_env'" >> ~/.bashrc && \
+    echo "alias t3='python /home/mambauser/Code/T3/T3.py input.yml'" >> ~/.bashrc
 
-# Set the wrapper script as the entrypoint
-ENTRYPOINT ["/home/rmguser/entrywrapper.sh"]
-
-# Activate the T3 environment
-WORKDIR /home/rmguser/
+# Activate the T3 environment for subsequent build steps / interactive use
+WORKDIR /home/mambauser/
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 ENV ENV_NAME=t3_env
+
+# Restore root for the inherited entrypoint (/usr/local/bin/entrywrapper.sh runuser's to mambauser)
+USER root


### PR DESCRIPTION
## Problem

The Docker image build (`docker_build.yml` → `ci-check`) fails at the `git clone` step with:

```
unable to find user rmguser: no matching entries in passwd file
```

**Root cause:** the base image `laxzal/arc:latest` was rebuilt on the modern ARC image (`mambaorg/micromamba`, Ubuntu 24.04), which uses the **`mambauser`** account and `/home/mambauser` home. The old `rmguser` / `/home/rmguser` account this Dockerfile assumed no longer exists, so `USER rmguser` can't resolve. The Dockerfile had also gone stale since 2024 — it referenced Python 3.7 site-packages cleanup paths (T3 is now Python 3.14) and the base image's old entrypoint path.

This is **pre-existing** and independent of the GitHub Actions bumps in #173 — that PR's `ci-check` failure is this same bug (it only surfaced there because `docker_build.yml` runs on changes to workflow/Dockerfile paths).

## Changes

- `USER rmguser` → `mambauser`; `/home/rmguser/*` → `/home/mambauser/*` throughout.
- Inherit the base image's entrypoint (`/usr/local/bin/entrywrapper.sh`, which starts as root and `runuser`s to `mambauser`) instead of hard-coding the removed `/home/rmguser/entrywrapper.sh`; end on `USER root` so the entrypoint can drop privileges itself.
- Replace the hard-coded `python3.7` per-package `find … tests` cleanups with cleanups scoped to paths that always exist, so a missing path can't break the `&&` chain.
- Document the inherited base-image contract at the top of the file.

## Verification

The `docker_build.yml` `ci-check` job (docker build, no push) runs on this PR and is the verification gate. Base-image contract (`mambauser`, `/home/mambauser`, `/usr/local/bin/entrywrapper.sh`) was derived from the current `ReactionMechanismGenerator/ARC` Dockerfile, which `laxzal/arc:latest` tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)