### PR TITLE
fix(flux): three tooling bugs (bar-chart y-scale, per-observable mkdir, get_width log guard)

### DIFF
--- a/t3/utils/flux.py
+++ b/t3/utils/flux.py
@@ -117,7 +117,7 @@ def generate_flux(model_path: str,
     if generate_separate_diagrams_per_observable:
         for observable in observables:
             folder_path_observable = os.path.join(folder_path, observable)
-            if not os.path.isdir(folder_path):
+            if not os.path.isdir(folder_path_observable):
                 os.makedirs(folder_path_observable)
             generate_flux_diagrams(profiles=profiles,
                                    observables=[observable],
@@ -522,7 +522,13 @@ def generate_top_rop_bar_figs(profiles: dict,
             ax.set_ylabel('ROP, mol/cm^3/s')
             ax.bar(rxn_dict.keys(), rxn_dict.values())
             ax.bar('Total ROP', sum(rxn_dict.values()))
-            ax.barlogy = True
+            # Symmetric-log y-axis: ROPs span many orders of magnitude and can
+            # be negative (net rates), so a plain log scale is invalid. Anchor
+            # the linear-region threshold to the smallest nonzero magnitude so
+            # the log region actually spans the data (the previous ``ax.barlogy``
+            # was not a Matplotlib attribute and silently did nothing).
+            magnitudes = [abs(v) for v in (*rxn_dict.values(), sum(rxn_dict.values())) if v]
+            ax.set_yscale('symlog', linthresh=min(magnitudes) if magnitudes else 1.0)
             plt.xticks(rotation=60)
             plt.tight_layout()
             fig_path = os.path.join(base_path, f'{observable}_{time}_s.png')
@@ -807,6 +813,12 @@ def get_width(x: float,
         if x == x_min == x_max:
             return 1
         return min_width + (x - x_min) * (max_width - min_width) / (x_max - x_min)
+    # Guard the log transform against zero/underflow: a species with exactly
+    # zero mole fraction (or a zero ROP) gives log10(0) = -inf and would
+    # propagate inf/nan into the width. Floor the magnitudes to a tiny positive
+    # value so the smallest inputs map to the minimum width instead.
+    eps = 1e-300
+    x, x_min, x_max = max(x, eps), max(x_min, eps), max(x_max, eps)
     return get_width(x=-np.log10(x_min) - np.log10(x_max) + np.log10(x),
                      x_min=-np.log10(x_max),
                      x_max=-np.log10(x_min),

--- a/tests/test_utils/test_flux.py
+++ b/tests/test_utils/test_flux.py
@@ -286,6 +286,13 @@ def test_get_width():
     assert almost_equal(flux.get_width(x=-1, x_min=2e-18, x_max=1, log_scale=True), 4)
     assert almost_equal(flux.get_width(x=-0.089, x_min=2e-18, x_max=1, log_scale=True), 3.77, places=2)
 
+    # Zero/underflow guard: a zero magnitude (e.g. a species with exactly zero
+    # mole fraction, or a zero ROP) must not yield inf/nan widths — it maps to
+    # the minimum width, and every result stays finite.
+    assert almost_equal(flux.get_width(x=0, x_min=0, x_max=1e-2, log_scale=True), 0.2)
+    assert np.isfinite(flux.get_width(x=1e-6, x_min=0, x_max=1e-2, log_scale=True))
+    assert np.isfinite(flux.get_width(x=0, x_min=0, x_max=0, log_scale=True))
+
 
 def test_get_rxn_in_relevant_direction():
     """Test getting a reaction string in the direction where the species in one of the reactants."""


### PR DESCRIPTION
Three independent, pre-existing bugs in `t3/utils/flux.py`, found while reviewing a downstream vendoring of this module. Each is a small, self-contained fix; a `get_width` regression test is added.

### 1. `generate_top_rop_bar_figs` — dead `ax.barlogy` (bars always linear)
`ax.barlogy = True` is not a Matplotlib API; it silently set an unused attribute, so the ROP bar charts were always linear-scale despite the evident intent. Replaced with a **symmetric-log** y-scale (valid for the negative net ROPs), with `linthresh` anchored to the smallest nonzero magnitude so the log region actually spans the data instead of collapsing into the default `linthresh=1` band.

### 2. `generate_flux` — per-observable dir guard checks the wrong path
The `generate_separate_diagrams_per_observable` branch checked `os.path.isdir(folder_path)` (the parent) while calling `os.makedirs(folder_path_observable)` (the child). The guard now tests the directory actually being created.

### 3. `get_width` — `log10(0)` → `inf`/`nan` widths
`get_width` took `log10` of the magnitudes with no zero/underflow guard. A species with exactly zero mole fraction (common) gives `log10(0) = -inf` and propagates `inf`/`nan` into node/edge widths, which can break diagram generation. Magnitudes are now floored to a tiny positive epsilon so the smallest inputs map to the minimum width. Adds regression cases to `test_get_width`.

### Testing
`test_get_width` (incl. new zero/underflow cases), `test_generate_top_rop_bar_figs_1` (symlog path), and `test_generate_flux` (per-observable path, full JSR sim) pass locally in `t3_env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)