### PR TITLE
PDep explorer: read real RMG network files (inject reactive=False), fail-fast collider config, killable Arkane timeout, pdep-inert schema guard

### DIFF
--- a/examples/pressure_dependence/input.yml
+++ b/examples/pressure_dependence/input.yml
@@ -43,6 +43,8 @@ rmg:
       smiles: N#N
       concentration: 0.75
       balance: true
+      reactive: false   # pdep requires an inert: RMG identifies the bath gas as every
+                        # unreactive core species (rmgpy/rmg/pdep.py:856-858) and asserts one exists
     - label: OH
       smiles: '[OH]'
       SA_observable: true

--- a/t3/main.py
+++ b/t3/main.py
@@ -2399,6 +2399,24 @@ class T3:
                       }
         warnings, selection = list(), None
         try:
+            # Parsed here, before the master-equation SA below is even attempted, and reused by the
+            # selection logic further down rather than re-read: the network file is drawable the
+            # moment it exists on disk, and a real campaign showed a network whose SA later failed
+            # (``sa_all_methods_failed``) getting no diagram at all, because the draw used to hang
+            # off the SA's success. The picture is of the network file, not of the SA's outcome, so
+            # it must not depend on one. ``network_parse_error`` is kept, not just discarded, so the
+            # warning further down (once it is known this candidate got far enough to need it) can
+            # still name what went wrong. Left inside this ``try`` (rather than ahead of it) so an
+            # unexpected failure here is still caught, recorded as ``internal_error`` and re-raised
+            # by the handler below, same as everywhere else in this method.
+            network, network_parse_error = None, None
+            try:
+                network = parse_pdep_network_file(path=network_path)
+            except (OSError, ValueError) as parse_error:
+                network_parse_error = parse_error
+            else:
+                self._draw_pdep_pes_diagram(network=network, network_name=network_name,
+                                            network_path=network_path)
             # Try running this network using user-specified methods by order.
             # Distinct read failures accumulate in configured-method order rather than the last one
             # winning: which method happened to run last is not a diagnosis, and a record naming only
@@ -2578,22 +2596,20 @@ class T3:
             # observable is already known to be sensitive to this reaction (criterion (a)), so ask
             # whether the network's own rate coefficient is in turn sensitive to a transition state
             # whose kinetics is merely an estimate.
-            network, queue_candidate = None, None
-            try:
-                network = parse_pdep_network_file(path=network_path)
-            except (OSError, ValueError) as e:
-                warning = f'Could not parse the PDep network file {network_path}: {e}'
+            # ``network`` was already parsed (and, if it parsed cleanly, already drawn) up top,
+            # before the master-equation SA was attempted, so there is nothing left to do here but
+            # reason about the outcome of that earlier parse.
+            queue_candidate = None
+            if network is None:
+                warning = f'Could not parse the PDep network file {network_path}: {network_parse_error}'
                 self.logger.warning(f'{warning}\nNot assessing network {network_name} for QM refinement.')
                 warnings.append(warning)
-            if network is None:
                 # The well analysis needs the SA output and the label map, not the parsed network, so
                 # it still runs below: refusing it over this failure would drop species this iteration
                 # would otherwise have refined, for a reason that has nothing to do with them.
                 assessment = _pdep_assessment(REASON_NETWORK_PARSE_FAILED, provenance, warnings)
             else:
                 provenance['network_source_hash'] = network.source_hash
-                self._draw_pdep_pes_diagram(network=network, network_name=network_name,
-                                            network_path=network_path)
                 selection, reason_code, secondary_reason_codes = select_from_sa_dict_with_diagnostics(
                     sa_dict=sa_dict,
                     network=network,

--- a/t3/main.py
+++ b/t3/main.py
@@ -80,7 +80,8 @@ from t3.pdep.join import (ARC_TS_LABEL_PREFIX,
                           ts_join_sidecar_path,
                           write_ts_join_sidecar,
                           )
-from t3.pdep.parser import PDepNetwork, parse_pdep_network_file
+from t3.pdep.diagram import T3_PES_DIAGRAM_FILENAME, compute_pes_diagram_data, render_pes_diagram
+from t3.pdep.parser import PDepNetwork, parse_pdep_network_e0_file, parse_pdep_network_file
 from t3.pdep.reason_codes import (REASON_CODE_STATUS,
                                   REASON_INTERNAL_ERROR,
                                   REASON_NETWORK_DISCOVERY_FAILED,
@@ -2314,6 +2315,35 @@ class T3:
                                       assessments=self.pdep_network_assessments,
                                       complete=False)
 
+    def _draw_pdep_pes_diagram(self, network: PDepNetwork, network_name: str, network_path: str) -> None:
+        """
+        Draw T3's own normalized-E0 PES diagram for a successfully-parsed P-dep network.
+
+        Reuses the already-parsed ``network`` (topology) rather than re-reading ``network_path``,
+        and only re-reads the file for its E0 data, which ``network`` does not carry.
+
+        Never raises: a cosmetic artifact must not be able to fail a multi-day campaign. This
+        includes ``compute_pes_diagram_data``'s legitimate ``ValueError`` refusals (a species with
+        no E0, a path reaction whose side matches no configuration) on real RMG networks it
+        genuinely cannot draw honestly -- those degrade to a logged warning here, same as any other
+        failure, rather than being treated as bugs.
+
+        Args:
+            network (PDepNetwork): The network already parsed by the caller.
+            network_name (str): The network file stem, e.g. ``'network4_2'``.
+            network_path (str): The network file this network was parsed from.
+        """
+        try:
+            output_dir = os.path.join(self.paths['PDep SA'], network_name)
+            os.makedirs(output_dir, exist_ok=True)
+            output_path = os.path.join(output_dir, T3_PES_DIAGRAM_FILENAME)
+            data = compute_pes_diagram_data(network=network,
+                                            e0=parse_pdep_network_e0_file(path=network_path))
+            render_pes_diagram(data=data, output_path=output_path)
+        except Exception as e:
+            self.logger.warning(f'Could not draw the PES diagram for PDep network {network_name} '
+                               f'({network_path}): {e}')
+
     def _assess_pdep_network_candidate(self,
                                        reaction: T3Reaction,
                                        reaction_tuple: tuple,
@@ -2562,6 +2592,8 @@ class T3:
                 assessment = _pdep_assessment(REASON_NETWORK_PARSE_FAILED, provenance, warnings)
             else:
                 provenance['network_source_hash'] = network.source_hash
+                self._draw_pdep_pes_diagram(network=network, network_name=network_name,
+                                            network_path=network_path)
                 selection, reason_code, secondary_reason_codes = select_from_sa_dict_with_diagnostics(
                     sa_dict=sa_dict,
                     network=network,

--- a/t3/main.py
+++ b/t3/main.py
@@ -2495,7 +2495,6 @@ class T3:
                                      f'to examine reaction {reaction} (iteration {self.iteration})...')
                     if not run_arkane_job(input_file=arkane_input,
                                           output_directory=arkane_output_dir,
-                                          plot=True,
                                           logger=self.logger,
                                           ):
                         # Recorded, not merely logged: without this the record would say nothing at

--- a/t3/pdep/api.py
+++ b/t3/pdep/api.py
@@ -591,6 +591,7 @@ def explore_pdep_network(network_path: str,
         logger=logger,
         transition_state_seeds=config.transition_state_seeds,
         database_kwargs=deep_thaw(config.database_kwargs),
+        timeout=config.timeout,
         # The check above (selection.network_source_hash vs. parsed_network.source_hash) proves only
         # what the bytes at network_path WERE at the moment this function parsed them. It says
         # nothing about what write_arkane_explorer_input_file() will later read, because that is a

--- a/t3/pdep/diagram.py
+++ b/t3/pdep/diagram.py
@@ -1,0 +1,410 @@
+"""
+t3 pdep diagram module
+
+T3's own potential energy surface (PES) diagram for an explored P-dep network.
+
+Arkane draws a network diagram too (``rmgpy.pdep.draw.NetworkDrawer``, run by
+``arkane/explorer.py``), but T3 cannot call it -- T3 never imports ``rmgpy``/``arkane`` (see
+``t3.pdep.parser``'s module docstring), and that drawer needs cairo, which the target RMG
+environment does not reliably provide. This module renders the same surface from the network
+FILE alone, through the safe never-execute parser, with matplotlib (a dependency T3 already
+carries for ``t3.utils.flux``).
+
+Energies are NORMALIZED: every level is shifted so the lowest-lying ISOMER sits at 0.0 kJ/mol.
+The reference is deliberately the lowest isomer, never "the lowest point on the surface" -- a
+bimolecular asymptote lying deeper than every well legitimately lands at a negative relative
+energy, and silently re-anchoring the zero to it would hide exactly the feature (an exothermic
+exit channel) worth seeing. Only a network with NO isomers falls back to the lowest
+configuration overall, and the diagram data says so via ``reference_kind``.
+"""
+
+from dataclasses import dataclass
+
+import matplotlib.pyplot as plt
+
+from t3.pdep.parser import (PDepNetwork,
+                            PDepNetworkE0,
+                            parse_pdep_network_e0_file,
+                            parse_pdep_network_file)
+
+# The file name the explorer adapter writes the diagram under, inside the exploration run
+# directory (next to Arkane's own input.py/output.py for that run).
+T3_PES_DIAGRAM_FILENAME = 'pes_diagram.png'
+
+REFERENCE_LOWEST_ISOMER = 'lowest_isomer'
+REFERENCE_LOWEST_CONFIGURATION = 'lowest_configuration'
+
+CONFIGURATION_KIND_ISOMER = 'isomer'
+CONFIGURATION_KIND_REACTANT_CHANNEL = 'reactant_channel'
+CONFIGURATION_KIND_PRODUCT_CHANNEL = 'product_channel'
+
+# One categorical hue per configuration role plus one for transition states, assigned in fixed
+# order by the job each color does (identity), all four validated together for colorblind-safe
+# adjacent-pair separation on a white surface (OKLab CVD dE >= 8; the aqua's 2.7:1 surface
+# contrast is relieved by every level carrying a direct text label).
+_COLOR_ISOMER = '#2a78d6'             # blue
+_COLOR_REACTANT_CHANNEL = '#eb6834'   # orange
+_COLOR_PRODUCT_CHANNEL = '#1baf7a'    # aqua
+_COLOR_TRANSITION_STATE = '#4a3aa7'   # violet
+_COLOR_BARRIERLESS = '#7a7a7a'        # neutral gray, dashed: "connected, no barrier datum"
+_COLOR_TEXT_PRIMARY = '#0b0b0b'
+_COLOR_TEXT_SECONDARY = '#52514e'
+
+_KIND_COLORS = {
+    CONFIGURATION_KIND_ISOMER: _COLOR_ISOMER,
+    CONFIGURATION_KIND_REACTANT_CHANNEL: _COLOR_REACTANT_CHANNEL,
+    CONFIGURATION_KIND_PRODUCT_CHANNEL: _COLOR_PRODUCT_CHANNEL,
+}
+
+# Horizontal geometry, in column units (one column per configuration).
+_CONFIG_HALF_WIDTH = 0.27
+_TS_HALF_WIDTH = 0.14
+_TS_SPREAD = 0.18  # extra x offset per additional TS sharing the same midpoint
+
+# Opaque backing patch behind every text annotation: on dense networks the dotted TS connectors
+# and level bars strike through labels that share their z-order space. A white halo under the
+# text (zorder 4) and above the lines (zorder 2-3) guarantees legibility regardless of layout --
+# cheaper and more robust than trying to prove no line ever crosses a label.
+_LABEL_BBOX = dict(boxstyle='round,pad=0.2', facecolor='white', edgecolor='none', alpha=1.0)
+
+
+@dataclass(frozen=True)
+class PESConfiguration:
+    """
+    One stationary configuration of the surface: an isomer (well) or a reactant/product channel
+    (an asymptote; possibly bimolecular, in which case ``e0`` is the sum over its fragments).
+
+    Args:
+        labels (tuple): The species labels, canonically (lexicographically) ordered.
+        kind (str): One of the ``CONFIGURATION_KIND_*`` constants.
+        e0 (float): The configuration E0 (kJ/mol) as declared in the network file.
+        relative_e0 (float): The E0 after the normalization shift (kJ/mol).
+    """
+    labels: tuple
+    kind: str
+    e0: float
+    relative_e0: float
+
+
+@dataclass(frozen=True)
+class PESTransitionState:
+    """
+    One path-reaction connection between two configurations.
+
+    Args:
+        label (Optional[str]): The transition state label, or ``None`` for a reaction declared
+            with no ``transitionState`` keyword.
+        e0 (Optional[float]): The TS E0 (kJ/mol), or ``None`` when the reaction is barrierless /
+            the TS declares no E0 (drawn as a direct dashed connection, never as a fabricated
+            barrier).
+        relative_e0 (Optional[float]): The E0 after the normalization shift, or ``None``.
+        reactants (tuple): The reactant-side configuration key (canonically ordered labels).
+        products (tuple): The product-side configuration key (canonically ordered labels).
+    """
+    label: str | None
+    e0: float | None
+    relative_e0: float | None
+    reactants: tuple
+    products: tuple
+
+
+@dataclass(frozen=True)
+class PESDiagramData:
+    """
+    The computed, normalized energy levels of one explored PES.
+
+    Args:
+        network_id (str): The network identifier (file stem).
+        reference_e0 (float): The absolute E0 (kJ/mol) subtracted from every level.
+        reference_kind (str): ``REFERENCE_LOWEST_ISOMER``, or ``REFERENCE_LOWEST_CONFIGURATION``
+            for the no-isomer fallback (see the module docstring).
+        configurations (tuple): The ``PESConfiguration`` entries.
+        transition_states (tuple): The ``PESTransitionState`` entries, one per path reaction.
+    """
+    network_id: str
+    reference_e0: float
+    reference_kind: str
+    configurations: tuple
+    transition_states: tuple
+
+
+def compute_pes_diagram_data(network: PDepNetwork, e0: PDepNetworkE0) -> PESDiagramData:
+    """
+    Combine a parsed network topology with its declared E0 values into normalized diagram levels.
+
+    Args:
+        network (PDepNetwork): The parsed network topology.
+        e0 (PDepNetworkE0): The declared E0 values (kJ/mol), from the same file.
+
+    Raises:
+        ValueError: If a species participating in any configuration declares no E0 (placing it at
+            zero or dropping it would draw a diagram of a different network); if the network has
+            no configurations at all; or if a path reaction side matches no known configuration.
+
+    Returns:
+        PESDiagramData: The normalized levels.
+    """
+    configurations = []
+    seen_keys = dict()
+    for kind, channels in (
+            (CONFIGURATION_KIND_ISOMER, tuple((isomer,) for isomer in network.isomers)),
+            (CONFIGURATION_KIND_REACTANT_CHANNEL, network.reactant_channels),
+            (CONFIGURATION_KIND_PRODUCT_CHANNEL, network.product_channels)):
+        for channel in channels:
+            key = tuple(sorted(channel))
+            if key in seen_keys:
+                continue
+            missing = sorted(label for label in key if label not in e0.species)
+            if missing:
+                raise ValueError(
+                    f"Cannot place the {kind} configuration {key} of network "
+                    f"'{network.network_id}' on the PES: species {missing} declare(s) no E0 in "
+                    f"the network file. Refusing to draw the configuration at a fabricated "
+                    f"energy or to silently omit it.")
+            configurations.append((key, kind, sum(e0.species[label] for label in key)))
+            seen_keys[key] = kind
+    if not configurations:
+        raise ValueError(f"Network '{network.network_id}' declares no isomers and no channels; "
+                         f"there is no surface to draw.")
+
+    isomer_energies = [energy for _, kind, energy in configurations
+                       if kind == CONFIGURATION_KIND_ISOMER]
+    if isomer_energies:
+        reference_e0 = min(isomer_energies)
+        reference_kind = REFERENCE_LOWEST_ISOMER
+    else:
+        reference_e0 = min(energy for _, _, energy in configurations)
+        reference_kind = REFERENCE_LOWEST_CONFIGURATION
+
+    transition_states = []
+    for path_reaction in network.path_reactions:
+        sides = []
+        for side in (path_reaction.reactants, path_reaction.products):
+            key = tuple(sorted(side))
+            if key not in seen_keys:
+                raise ValueError(
+                    f"The path reaction '{path_reaction.label}' of network "
+                    f"'{network.network_id}' has a side {key} matching no isomer or channel of "
+                    f"the network; refusing to draw a connection to a configuration the network "
+                    f"does not declare.")
+            sides.append(key)
+        ts_label = path_reaction.transition_state
+        ts_e0 = e0.transition_states.get(ts_label) if ts_label is not None else None
+        transition_states.append(PESTransitionState(
+            label=ts_label,
+            e0=ts_e0,
+            relative_e0=ts_e0 - reference_e0 if ts_e0 is not None else None,
+            reactants=sides[0],
+            products=sides[1],
+        ))
+
+    return PESDiagramData(
+        network_id=network.network_id,
+        reference_e0=reference_e0,
+        reference_kind=reference_kind,
+        configurations=tuple(
+            PESConfiguration(labels=key, kind=kind, e0=energy,
+                             relative_e0=energy - reference_e0)
+            for key, kind, energy in configurations),
+        transition_states=tuple(transition_states),
+    )
+
+
+def stagger_label_offsets(points, min_dx: float, min_dy: float) -> tuple:
+    """
+    Resolve label collisions among near-degenerate levels, deterministically.
+
+    Two levels closer than ``min_dx`` horizontally AND ``min_dy`` vertically would overlay their
+    text labels; each such point is bumped to the smallest offset level (0, 1, 2, ...) distinct
+    from every already-placed colliding neighbor, scanning in the caller's order. The caller maps
+    an offset level to a vertical text displacement.
+
+    Args:
+        points: A sequence of ``(x, y)`` positions, in a deterministic order.
+        min_dx (float): The horizontal distance below which two labels can collide.
+        min_dy (float): The vertical distance below which two labels can collide.
+
+    Returns:
+        tuple: One integer offset level per point, in input order.
+    """
+    levels = []
+    placed = []
+    for x, y in points:
+        taken = {level for (px, py, level) in placed
+                 if abs(px - x) < min_dx and abs(py - y) < min_dy}
+        level = 0
+        while level in taken:
+            level += 1
+        levels.append(level)
+        placed.append((x, y, level))
+    return tuple(levels)
+
+
+def _format_channel_label(labels: tuple) -> str:
+    """
+    Format a configuration's species labels for direct labeling (one species per line, joined
+    with '+' -- multi-line so a bimolecular channel's label stays inside its own column).
+
+    Args:
+        labels (tuple): The configuration's species labels.
+
+    Returns:
+        str: The display label.
+    """
+    return ' +\n'.join(labels)
+
+
+def _build_pes_figure(data: PESDiagramData):
+    """
+    Build (but do not save or close) the Matplotlib figure for a PES diagram.
+
+    Split out of ``render_pes_diagram`` so tests can measure the actual rendered geometry
+    (text bounding boxes, line positions) before the figure is closed.
+
+    Layout: one column per configuration -- reactant channels, then isomers, then product
+    channels, left to right -- each drawn as a horizontal level bar with a direct label
+    (species names below, relative E0 above). Each path reaction with a TS energy gets a short
+    TS level at the midpoint between the two configurations it connects, joined to both by thin
+    dotted connectors; a reaction without a TS energy is a dashed straight line (barrierless --
+    no fabricated barrier). Near-degenerate TS levels sharing a midpoint are spread apart, and
+    colliding energy annotations are staggered (see ``stagger_label_offsets``).
+
+    Args:
+        data (PESDiagramData): The computed levels.
+
+    Returns:
+        matplotlib.figure.Figure: The built (unsaved, unclosed) figure.
+    """
+    ordered = sorted(
+        data.configurations,
+        key=lambda c: ({CONFIGURATION_KIND_REACTANT_CHANNEL: 0,
+                        CONFIGURATION_KIND_ISOMER: 1,
+                        CONFIGURATION_KIND_PRODUCT_CHANNEL: 2}[c.kind], c.labels))
+    x_by_key = {config.labels: float(column) for column, config in enumerate(ordered)}
+
+    energies = [c.relative_e0 for c in ordered] \
+        + [ts.relative_e0 for ts in data.transition_states if ts.relative_e0 is not None]
+    span = max(energies) - min(energies) or 1.0
+
+    fig, ax = plt.subplots(figsize=(max(7.0, 1.9 * len(ordered) + 1.5), 6.5))
+
+    # Configuration level bars with direct labels.
+    for config in ordered:
+        x = x_by_key[config.labels]
+        color = _KIND_COLORS[config.kind]
+        ax.hlines(y=config.relative_e0, xmin=x - _CONFIG_HALF_WIDTH, xmax=x + _CONFIG_HALF_WIDTH,
+                  colors=color, linewidth=2.6, zorder=3)
+        ax.annotate(_format_channel_label(config.labels),
+                    xy=(x, config.relative_e0), xytext=(0, -10), textcoords='offset points',
+                    ha='center', va='top', fontsize=7.5, color=_COLOR_TEXT_PRIMARY, zorder=4,
+                    bbox=_LABEL_BBOX)
+        ax.annotate(f'{config.relative_e0:.1f}',
+                    xy=(x, config.relative_e0), xytext=(0, 4), textcoords='offset points',
+                    ha='center', va='bottom', fontsize=7, color=_COLOR_TEXT_SECONDARY, zorder=4,
+                    bbox=_LABEL_BBOX)
+
+    # Transition state levels. Reactions sharing the same midpoint (e.g. two channels into the
+    # same well pair) are spread horizontally, deterministically, before collision staggering.
+    with_energy = [ts for ts in data.transition_states if ts.relative_e0 is not None]
+    with_energy.sort(key=lambda ts: (ts.reactants, ts.products, ts.relative_e0, ts.label or ''))
+    midpoint_counts = dict()
+    ts_positions = []
+    for ts in with_energy:
+        x1, x2 = x_by_key[ts.reactants], x_by_key[ts.products]
+        midpoint = (x1 + x2) / 2.0
+        # A connection spanning non-adjacent columns can put its midpoint exactly on an
+        # INTERMEDIATE column, where the TS level and its annotation land on top of that
+        # column's own bar and labels. Nudge it half a column toward the product side: column
+        # centers are integers, so a half-integer position is never on top of one.
+        if midpoint not in (x1, x2) and midpoint in x_by_key.values():
+            midpoint += 0.5 if x2 > x1 else -0.5
+        occurrence = midpoint_counts.get(midpoint, 0)
+        midpoint_counts[midpoint] = occurrence + 1
+        # 0, +s, -s, +2s, ... around the shared midpoint.
+        shift = ((occurrence + 1) // 2) * _TS_SPREAD * (1 if occurrence % 2 else -1)
+        ts_positions.append((ts, midpoint + (shift if occurrence else 0.0), x1, x2))
+
+    annotation_levels = stagger_label_offsets(
+        points=tuple((x, ts.relative_e0) for ts, x, _, _ in ts_positions),
+        min_dx=2.0 * _TS_SPREAD + 0.01, min_dy=0.05 * span)
+    for (ts, x, x1, x2), annotation_level in zip(ts_positions, annotation_levels):
+        ax.hlines(y=ts.relative_e0, xmin=x - _TS_HALF_WIDTH, xmax=x + _TS_HALF_WIDTH,
+                  colors=_COLOR_TRANSITION_STATE, linewidth=2.2, zorder=3)
+        for x_config, key in ((x1, ts.reactants), (x2, ts.products)):
+            config_e0 = next(c.relative_e0 for c in ordered if c.labels == key)
+            direction = 1 if x_config < x else -1
+            ax.plot([x_config + direction * _CONFIG_HALF_WIDTH, x - direction * _TS_HALF_WIDTH],
+                    [config_e0, ts.relative_e0],
+                    color=_COLOR_TRANSITION_STATE, linewidth=0.9, linestyle=':', zorder=2)
+        annotation = f'{ts.label} ({ts.relative_e0:.1f})' if ts.label else f'{ts.relative_e0:.1f}'
+        ax.annotate(annotation,
+                    xy=(x, ts.relative_e0), xytext=(0, 4 + 11 * annotation_level),
+                    textcoords='offset points', ha='center', va='bottom', fontsize=7,
+                    color=_COLOR_TEXT_SECONDARY, zorder=4, bbox=_LABEL_BBOX)
+
+    # Barrierless connections: a direct dashed line, never a fabricated barrier.
+    for ts in data.transition_states:
+        if ts.relative_e0 is not None:
+            continue
+        x1, x2 = x_by_key[ts.reactants], x_by_key[ts.products]
+        e1 = next(c.relative_e0 for c in ordered if c.labels == ts.reactants)
+        e2 = next(c.relative_e0 for c in ordered if c.labels == ts.products)
+        direction = 1 if x1 < x2 else -1
+        ax.plot([x1 + direction * _CONFIG_HALF_WIDTH, x2 - direction * _CONFIG_HALF_WIDTH],
+                [e1, e2], color=_COLOR_BARRIERLESS, linewidth=1.1, linestyle='--', zorder=2)
+        if ts.label:
+            ax.annotate(ts.label, xy=((x1 + x2) / 2.0, (e1 + e2) / 2.0),
+                        xytext=(0, 4), textcoords='offset points', ha='center', va='bottom',
+                        fontsize=7, color=_COLOR_TEXT_SECONDARY, zorder=4, bbox=_LABEL_BBOX)
+
+    ax.axhline(y=0.0, color=_COLOR_TEXT_SECONDARY, linewidth=0.6, linestyle=(0, (6, 6)),
+               alpha=0.45, zorder=1)
+    reference_note = 'E0 relative to the lowest isomer' \
+        if data.reference_kind == REFERENCE_LOWEST_ISOMER \
+        else 'E0 relative to the lowest configuration (network declares no isomers)'
+    ax.set_title(f'PES of {data.network_id} — {reference_note}',
+                 fontsize=10, color=_COLOR_TEXT_PRIMARY)
+    ax.set_ylabel('E0 (kJ/mol)', fontsize=9, color=_COLOR_TEXT_PRIMARY)
+    ax.set_xticks([])
+    ax.margins(x=0.06, y=0.18)
+    for spine in ('top', 'right', 'bottom'):
+        ax.spines[spine].set_visible(False)
+    ax.yaxis.grid(True, linewidth=0.4, alpha=0.25)
+    ax.set_axisbelow(True)
+    fig.tight_layout()
+    return fig
+
+
+def render_pes_diagram(data: PESDiagramData, output_path: str) -> None:
+    """
+    Render computed PES levels to an image file (format follows the extension).
+
+    Args:
+        data (PESDiagramData): The computed levels.
+        output_path (str): The image file path to write (e.g. ``.../pes_diagram.png``).
+    """
+    fig = _build_pes_figure(data)
+    fig.savefig(output_path, dpi=300, facecolor='w', edgecolor='w')
+    plt.close(fig)
+
+
+def draw_pes_diagram(network_path: str, output_path: str) -> PESDiagramData:
+    """
+    Parse a pdep network file and render its normalized PES diagram.
+
+    Args:
+        network_path (str): The path to the network file (typically the exploration's resolved
+            final network artifact, ``pdep/final/network<i>_(full|reduced).py``).
+        output_path (str): The image file path to write (format follows the extension).
+
+    Raises:
+        ValueError: As ``parse_pdep_network_file``/``parse_pdep_network_e0_file``/
+            ``compute_pes_diagram_data``.
+
+    Returns:
+        PESDiagramData: The computed levels the rendered diagram shows.
+    """
+    data = compute_pes_diagram_data(network=parse_pdep_network_file(path=network_path),
+                                    e0=parse_pdep_network_e0_file(path=network_path))
+    render_pes_diagram(data=data, output_path=output_path)
+    return data

--- a/t3/pdep/explorer/arkane.py
+++ b/t3/pdep/explorer/arkane.py
@@ -97,6 +97,7 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
                  transition_state_seeds: tuple = None,
                  database_kwargs: dict = None,
                  expected_source_hash: str = None,
+                 timeout: float = None,
                  ):
         """
         Args:
@@ -132,6 +133,12 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
                                                   function's docstring for why this must be the
                                                   hash checked against the same read that consumes
                                                   the bytes, not an earlier, separate one.
+            timeout (float, optional): The wall-clock deadline, in seconds, for the Arkane process,
+                                       forwarded verbatim to ``run_arkane_job`` (which validates
+                                       and enforces it -- see its docstring for the process-group
+                                       kill mechanics). ``None`` (the default) means no deadline.
+                                       An overrun is recorded as a failed exploration with a
+                                       distinguishable reason, never raised.
         """
         super().__init__(seed_species=seed_species, transition_state_seeds=transition_state_seeds)
         self.output_directory = output_directory
@@ -145,6 +152,7 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
         self.logger = logger
         self.database_kwargs = database_kwargs
         self.expected_source_hash = expected_source_hash
+        self.timeout = timeout
 
         # Set True only by ``_claim_run_directory()`` on its success path (rule 0). ``set_up()``
         # refuses to run while this is False, so it cannot be used to bypass the claim.
@@ -382,30 +390,35 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
         # stdout.log/stderr.log/arkane.log cannot exist. A deletion here would be dead code that
         # reads as a defense, and would quietly mask any future weakening of rule 0.
 
-        # Called synchronously, exactly as ``ArkaneMESolverAdapter.solve()`` calls it. There is
-        # deliberately NO timeout here, because T3 cannot honour one and a timeout that cannot be
-        # honoured is worse than none. The earlier attempt wrapped this call in a
-        # ThreadPoolExecutor and gave up on the future, which failed twice over:
-        #   1. It did not even return early -- `finally: executor.shutdown(wait=True)` ran before
-        #      the `return False` propagated and blocked until Arkane finished anyway, so the
-        #      "timeout" bought nothing but a relabelled outcome.
-        #   2. It could not have worked at any wait= setting, because nothing cancellable escapes:
-        #      run_arkane_job (t3/runners/rmg_runner.py:543) calls ARC's run_arkane in-process,
-        #      which reaches subprocess.run at ARC/arc/job/local.py:59-61 with no timeout= and no
-        #      Popen/PID exposed to any caller. Python threads cannot be killed either.
-        # Abandoning the future without killing the process is not a lesser version of a timeout,
-        # it is a corruption hazard: Arkane would keep writing into a run directory T3 had already
-        # declared failed, and rule 0 would then refuse that directory forever after. A real
-        # timeout has to be built where the process is spawned -- either a `timeout=` on ARC's
-        # execute_command, or a runner that spawns Arkane in its own process group and kills the
-        # group -- and belongs in the runner layer, not smuggled in here.
-        job_ran = run_arkane_job(input_file=input_file_path,
-                                 output_directory=self.output_directory,
-                                 logger=self.logger,
-                                 required_artifact='output.py')
+        # Called synchronously, exactly as ``ArkaneMESolverAdapter.solve()`` calls it. The
+        # ``timeout`` is NOT enforced here but in the runner, because that is the only layer that
+        # can honour one: an earlier in-adapter attempt wrapped this call in a ThreadPoolExecutor
+        # and gave up on the future, which could never work -- run_arkane_job used to call ARC's
+        # run_arkane in-process, which reaches subprocess.run at ARC/arc/job/local.py:59-61 with no
+        # timeout= and no Popen/PID exposed to any caller, and Python threads cannot be killed.
+        # Abandoning a future without killing the process is a corruption hazard, not a lesser
+        # timeout: Arkane would keep writing into a run directory T3 had already declared failed,
+        # and rule 0 would then refuse that directory forever after. run_arkane_job therefore
+        # spawns Arkane in its own process SESSION when a timeout is given and kills the whole
+        # process group on overrun (see its docstring); this adapter only forwards the deadline
+        # and records the distinguishable verdict.
+        job_result = run_arkane_job(input_file=input_file_path,
+                                    output_directory=self.output_directory,
+                                    logger=self.logger,
+                                    required_artifact='output.py',
+                                    timeout=self.timeout)
 
-        # Failure signal 1 of 4: nonzero exit (surfaced here as run_arkane_job's own bool).
-        if not job_ran:
+        # Failure signal 1 of 4: the runner's own verdict. A deadline overrun gets its OWN
+        # diagnosis rather than the generic job-failure one -- "Arkane failed" invites reading the
+        # logs, "Arkane was killed at the deadline" invites raising the budget, and a caller must
+        # be able to tell them apart from the recorded reasons alone. ``getattr`` (not attribute
+        # access) keeps this signal readable from any truthy/falsy stand-in a test may substitute
+        # for the real ArkaneJobResult.
+        if getattr(job_result, 'timed_out', False):
+            reasons.append(f'The Arkane exploration timed out (deadline: {self.timeout} s) and its '
+                           f'process group was killed: '
+                           f'{getattr(job_result, "reason", None) or "no further detail recorded."}')
+        elif not job_result:
             reasons.append('Arkane reported job failure (a non-zero exit status, or the required '
                            "'output.py' artifact was never created).")
 

--- a/t3/pdep/explorer/arkane.py
+++ b/t3/pdep/explorer/arkane.py
@@ -21,6 +21,7 @@ from collections import Counter
 from typing import TYPE_CHECKING
 
 from t3.pdep.cache import hash_file
+from t3.pdep.diagram import T3_PES_DIAGRAM_FILENAME, draw_pes_diagram
 from t3.pdep.explorer.adapter import PESExplorerAdapter
 from t3.pdep.explorer.factory import register_explorer_adapter
 from t3.pdep.explorer.input_file import write_arkane_explorer_input_file
@@ -492,10 +493,40 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
             self.final_network_paths = final_network_paths
             self.output_paths = output_paths
             self._me_success_results = tuple(me_success_results)
+            # T3's own normalized PES diagram of the explored surface, drawn BEFORE the manifest
+            # so that, when it lands, it is hashed like every other artifact of this run.
+            self._draw_pes_diagram(final_network_path=final_network_paths[0])
             # Rule 6: record a run manifest. Explorer output is a function of RMG database
             # contents, so a run recorded with no provenance at all is not replayable.
             self.manifest = self._build_manifest(input_file_path=input_file_path,
                                                  arkane_log_path=arkane_log_path)
+
+    def _draw_pes_diagram(self, final_network_path: str) -> str | None:
+        """
+        Draw T3's normalized PES diagram for a successful exploration -- strictly best-effort.
+
+        Drawn from the FINAL network artifact, not from ``self.network_path``: the final network
+        carries every species the exploration discovered, while the source network is the surface
+        as it looked before the run. Any failure is logged and swallowed, never re-raised: the
+        diagram describes the result, it is not part of it, and no drawing problem (a matplotlib
+        quirk, a species without an E0) may flip an exploration that genuinely succeeded into a
+        recorded failure.
+
+        Args:
+            final_network_path (str): The resolved final network artifact to draw from.
+
+        Returns:
+            Optional[str]: The diagram path, or ``None`` if drawing failed.
+        """
+        diagram_path = os.path.join(self.output_directory, T3_PES_DIAGRAM_FILENAME)
+        try:
+            draw_pes_diagram(network_path=final_network_path, output_path=diagram_path)
+        except Exception as e:
+            if self.logger is not None:
+                self.logger.warning(f'Could not draw the T3 PES diagram for '
+                                    f'{final_network_path} ({type(e).__name__}): {e}')
+            return None
+        return diagram_path
 
 
     def _check_final_network_payload(self, final_network_path: str, me_success_results: tuple) -> tuple:
@@ -754,6 +785,11 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
             os.path.join(self.output_directory, name)
             for name in os.listdir(self.output_directory)
             if _ARKANE_NETWORK_PDF_RE.match(name)))
+        # T3's own PES diagram (see _draw_pes_diagram). Present-when-drawn, like the PDF above:
+        # its drawing is best-effort, so its absence must not fail the manifest.
+        pes_diagram_path = os.path.join(self.output_directory, T3_PES_DIAGRAM_FILENAME)
+        if os.path.isfile(pes_diagram_path):
+            artifact_paths.append(pes_diagram_path)
         artifacts = [
             {'path': path, 'size': os.path.getsize(path), 'sha256': hash_file(path)}
             for path in artifact_paths

--- a/t3/pdep/explorer/arkane.py
+++ b/t3/pdep/explorer/arkane.py
@@ -46,6 +46,15 @@ _OUTPUT_FILENAME_RE = re.compile(r'^output(\d*)\.py$')
 # is the FULL (always written) or REDUCED (only written when a reduction filter ran) variant.
 _FINAL_NETWORK_FILENAME_RE = re.compile(r'^network(\d+)_(full|reduced)\.py$')
 
+# Matches Arkane's own PES drawing in the run directory, under BOTH spellings it can end up with.
+# ``PressureDependenceJob.draw`` (arkane/pdep.py:625-652) writes 'network.pdf' into the run
+# directory whenever cairo is importable, and ``ExplorerJob.execute`` (arkane/explorer.py:358-359)
+# then renames it to 'network<p>.pdf' -- but via a bare RELATIVE 'network.pdf', i.e. in whatever
+# CWD the Arkane process happens to run in, so the rename only lands when that CWD is the run
+# directory. Digits-only for the index, exactly as Arkane writes it: this is a provenance record,
+# and a stray look-alike PDF this run never produced must not be recorded as if it had.
+_ARKANE_NETWORK_PDF_RE = re.compile(r'^network(\d*)\.pdf$')
+
 
 def _get_rmgpy_revision() -> str | None:
     """
@@ -737,6 +746,14 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
         artifact_paths = [input_file_path, *self.output_paths, *self.final_network_paths]
         if os.path.isfile(arkane_log_path):
             artifact_paths.append(arkane_log_path)
+        # Arkane's own PES drawing, when its drawer actually ran (it silently skips without cairo).
+        # Never required -- its absence is normal -- but when present it is an artifact of this run
+        # like any other and gets the same path/size/sha256 record. See _ARKANE_NETWORK_PDF_RE for
+        # why both 'network.pdf' and 'network<p>.pdf' are Arkane's spellings of the same drawing.
+        artifact_paths.extend(sorted(
+            os.path.join(self.output_directory, name)
+            for name in os.listdir(self.output_directory)
+            if _ARKANE_NETWORK_PDF_RE.match(name)))
         artifacts = [
             {'path': path, 'size': os.path.getsize(path), 'sha256': hash_file(path)}
             for path in artifact_paths

--- a/t3/pdep/explorer/config.py
+++ b/t3/pdep/explorer/config.py
@@ -10,6 +10,7 @@ it is split that way rather than centralized here.
 """
 
 import copy
+import math
 import os
 import types
 from collections.abc import Mapping
@@ -198,14 +199,25 @@ class PDepExplorerConfig:
         database_kwargs (Mapping, optional): Keyword arguments describing the RMG database settings
                                              to use for the exploration. Stored deeply frozen (list
                                              values become tuples); see the class docstring.
+        timeout (float, optional): The wall-clock deadline, in seconds, for the explorer's
+                                   underlying Arkane process. ``None`` (the default) means no
+                                   deadline. Enforced at the runner layer
+                                   (``t3.runners.rmg_runner.run_arkane_job`` spawns Arkane in its
+                                   own process session and kills the whole group on overrun); a
+                                   timed-out run surfaces as a 'failed' exploration result with a
+                                   distinguishable reason, never as an exception. Validated here
+                                   with the same rule the runner itself enforces (a positive,
+                                   finite number), so an unenforceable deadline is refused at
+                                   construction rather than after a run directory was claimed.
 
     Raises:
         ValueError: If ``explorer`` or ``method`` is not a non-empty str, or ``method`` is not one of
                    ``t3.utils.writer.METHOD_MAP``; if ``trusted_output_root`` or ``output_directory``
                    is not a non-empty, absolute str path, or ``output_directory`` does not resolve
                    strictly inside ``trusted_output_root``; if ``bath_gas`` is ``None``, empty, or
-                   not a ``Mapping``; if ``database_kwargs`` is given and is not a ``Mapping``; or
-                   if any numeric field fails its contract in
+                   not a ``Mapping``; if ``database_kwargs`` is given and is not a ``Mapping``; if
+                   ``timeout`` is given and is not a positive finite number of seconds; or if any
+                   numeric field fails its contract in
                    ``t3.pdep.explorer.input_file._EXPLORER_NUMBER_CONTRACTS``.
     """
     explorer: str
@@ -220,6 +232,7 @@ class PDepExplorerConfig:
     maximum_radical_electrons: int | None = None
     transition_state_seeds: tuple = field(default_factory=tuple)
     database_kwargs: Mapping | None = None
+    timeout: float | None = None
 
     def __post_init__(self):
         """
@@ -286,6 +299,17 @@ class PDepExplorerConfig:
             value = getattr(self, field_name)
             refuse_bare_string_seed(field_name=field_name, value=value)
             object.__setattr__(self, field_name, tuple(value or tuple()))
+
+        # The SAME rule t3.runners.rmg_runner.run_arkane_job enforces (bool excluded explicitly
+        # because it is an int subclass: timeout=True would otherwise mean a 1-second deadline
+        # nobody asked for). Checked here as well so an unenforceable deadline is refused before a
+        # run directory is ever claimed for it, not by the runner mid-run -- the same layering
+        # argument as bath_gas below.
+        if self.timeout is not None:
+            if isinstance(self.timeout, bool) or not isinstance(self.timeout, (int, float)) \
+                    or not math.isfinite(self.timeout) or self.timeout <= 0:
+                raise ValueError(f"'timeout' must be a positive finite number of seconds, or None for no "
+                                 f"deadline, got {self.timeout!r} of type {type(self.timeout).__name__}.")
 
         # Refused HERE, not left to write time. bath_gas=None (or an empty Mapping) used to pass
         # construction and only raise inside write_arkane_explorer_input_file's empty-bath-gas

--- a/t3/pdep/explorer/config.py
+++ b/t3/pdep/explorer/config.py
@@ -95,7 +95,10 @@ class PDepExplorerConfig:
 
     - Construction time (HERE, ``__post_init__``): types; that ``trusted_output_root`` and
       ``output_directory`` are absolute and that ``output_directory`` is strictly contained in
-      ``trusted_output_root``; the numeric ``explorer(...)`` field contracts (via
+      ``trusted_output_root``; that ``bath_gas`` is a non-empty Mapping (a config without one is a
+      GUARANTEED write-time failure, and the old None-passes-construction behavior only surfaced it
+      after the adapter's rule-0 claim had already burned a run directory -- issue #183); the
+      numeric ``explorer(...)`` field contracts (via
       ``t3.pdep.explorer.input_file.validate_explorer_field_values``). None of this can go stale
       between construction and use, and none of it needs anything this object does not already carry.
     - Factory/adapter time (``t3.pdep.explorer.factory.explorer_factory`` /
@@ -112,9 +115,12 @@ class PDepExplorerConfig:
       validating a fact that can already be stale by the time it matters (TOCTOU): nothing stops the
       filesystem changing between this object's construction and its actual use.
     - Write time (``t3.pdep.explorer.input_file.write_arkane_explorer_input_file``): bath-gas species
-      existence against the network file, reactive=False marking, renderability of every value as an
-      Arkane-loadable literal. None of that is knowable from a config in isolation -- it depends on
-      the actual network source file being explored, which this config also does not carry.
+      existence against the network file, the reactive-keyword rules (injection of
+      ``reactive = False`` for a declared bath-gas species that carries none, refusal of an explicit
+      ``reactive=True`` contradiction), renderability of every value as an Arkane-loadable literal.
+      None of that is knowable from a config in isolation -- it depends on the actual network source
+      file being explored, which this config also does not carry. (That the bath gas is non-empty at
+      all IS knowable here, and is checked here; see the construction-time bullet.)
 
     'explorer' is checked only for being a non-empty str, NOT against the explorer registry
     (``t3.pdep.explorer.factory._registered_explorer_adapters``): the registry is the single source
@@ -174,8 +180,10 @@ class PDepExplorerConfig:
                               Not otherwise validated here; see the class docstring.
         method (str): The master-equation method, one of ``t3.utils.writer.METHOD_MAP``
                      (e.g. 'CSE', 'MSC', 'RS').
-        bath_gas (Mapping, optional): The bath gas composition, mapping species labels to mole
-                                      fractions. Stored deeply frozen; see the class docstring.
+        bath_gas (Mapping): The bath gas composition, mapping species labels to mole fractions.
+                            REQUIRED and non-empty (the ``None`` default exists only so the refusal
+                            can explain itself rather than surface as a bare TypeError); see the
+                            class docstring's construction-time bullet. Stored deeply frozen.
         explore_tol (float, optional): The energy tolerance for exploring new isomers/reactions.
         energy_tol (float, optional): The energy tolerance for including a well/transition state in
                                       the output network.
@@ -195,8 +203,9 @@ class PDepExplorerConfig:
         ValueError: If ``explorer`` or ``method`` is not a non-empty str, or ``method`` is not one of
                    ``t3.utils.writer.METHOD_MAP``; if ``trusted_output_root`` or ``output_directory``
                    is not a non-empty, absolute str path, or ``output_directory`` does not resolve
-                   strictly inside ``trusted_output_root``; if ``bath_gas`` or ``database_kwargs`` is
-                   given and is not a ``Mapping``; or if any numeric field fails its contract in
+                   strictly inside ``trusted_output_root``; if ``bath_gas`` is ``None``, empty, or
+                   not a ``Mapping``; if ``database_kwargs`` is given and is not a ``Mapping``; or
+                   if any numeric field fails its contract in
                    ``t3.pdep.explorer.input_file._EXPLORER_NUMBER_CONTRACTS``.
     """
     explorer: str
@@ -277,6 +286,23 @@ class PDepExplorerConfig:
             value = getattr(self, field_name)
             refuse_bare_string_seed(field_name=field_name, value=value)
             object.__setattr__(self, field_name, tuple(value or tuple()))
+
+        # Refused HERE, not left to write time. bath_gas=None (or an empty Mapping) used to pass
+        # construction and only raise inside write_arkane_explorer_input_file's empty-bath-gas
+        # guard -- which runs AFTER the adapter's rule-0 claim has already created the run
+        # directory, so a config that could never be written also burned a directory name the
+        # adapter then refuses forever (rule 0 has no stale-claim recovery, by design). That the
+        # bath gas must be non-empty is knowable from this object's own arguments -- the writer's
+        # OTHER bath-gas rules (label membership, reactive-keyword handling) genuinely need the
+        # source file and stay at write time, per the class docstring's split.
+        if self.bath_gas is None or (isinstance(self.bath_gas, Mapping) and not self.bath_gas):
+            raise ValueError(
+                f"'bath_gas' is required and must be a non-empty Mapping of species labels to mole "
+                f"fractions (e.g. {{'N2': 1.0}}), got {self.bath_gas!r}. An Arkane explorer input "
+                f"cannot be written without one (the writer removes the source's network(...) "
+                f"block, Arkane's only other source of a bath gas), so a config without one is a "
+                f"guaranteed write-time failure -- refused here, before a run directory is ever "
+                f"claimed for it.")
 
         for field_name in ('bath_gas', 'database_kwargs'):
             value = getattr(self, field_name)

--- a/t3/pdep/explorer/factory.py
+++ b/t3/pdep/explorer/factory.py
@@ -48,6 +48,7 @@ def explorer_factory(explorer: str,
                      transition_state_seeds: tuple = None,
                      database_kwargs: dict = None,
                      expected_source_hash: str = None,
+                     timeout: float = None,
                      ) -> PESExplorerAdapter:
     """
     A factory generating the explorer adapter corresponding to ``explorer``.
@@ -93,6 +94,11 @@ def explorer_factory(explorer: str,
                                               ``network_path``'s bytes must match when the adapter's
                                               ``set_up()`` reads them, forwarded verbatim to the
                                               adapter's constructor.
+        timeout (float, optional): The wall-clock deadline, in seconds, for the explorer's
+                                   underlying process, forwarded verbatim to the adapter's
+                                   constructor (``None`` means no deadline; validated and enforced
+                                   at the runner layer, see
+                                   ``t3.runners.rmg_runner.run_arkane_job``).
 
     Raises:
         ValueError: If the provided explorer is not in the keys for the
@@ -151,6 +157,7 @@ def explorer_factory(explorer: str,
                              transition_state_seeds=expected_ts_seeds,
                              database_kwargs=database_kwargs,
                              expected_source_hash=expected_source_hash,
+                             timeout=timeout,
                              )
 
     # The quiet half of the same defect: re-running the rules above only catches a forgetful adapter

--- a/t3/pdep/explorer/input_file.py
+++ b/t3/pdep/explorer/input_file.py
@@ -68,6 +68,15 @@ _EXPLORER_KWARG_NAMES = {
 # is read verbatim out of the source network file, so it is untrusted input either way.
 _KINETICS_LABEL_INJECTION_CHARS = ('\n', '\r', "'", '"', '\\')
 
+# Sentinel distinguishing "the species() block carries no 'reactive' keyword at all" from every
+# value the keyword could literally hold (True/False, or None for a non-literal expression, which
+# ``_literal_or_none`` cannot tell apart from a literal ``None``). The distinction is load-bearing
+# for the bath-gas rule: an ABSENT keyword on a declared bath-gas species is the shape every
+# RMG-written network file has (``arkane/pdep.py:654`` ``save_input_file`` never emits ``reactive``
+# for any species) and gets ``reactive = False`` injected into the generated file, while an
+# explicit ``reactive=True`` is a contradiction that is refused (see ``_validate_bath_gas``).
+_REACTIVE_ABSENT = object()
+
 # The subset of Arkane's own input-file namespace (``local_context`` at RMG-Py
 # ``arkane/input.py:607``; T3 must not import arkane, hence a transcription rather than a reference)
 # that this module will splice verbatim out of an untrusted source and into a NEW file Arkane will
@@ -148,6 +157,12 @@ class ExplorerInputSummary:
         kinetics_labels_emitted (tuple): The reaction labels a ``kinetics('<label>')`` job
                                         directive was emitted for (reactions that had no explicit
                                         ``kinetics=`` keyword of their own).
+        reactive_false_injected (tuple): The bath-gas species labels whose ``species()`` blocks had
+                                        no ``reactive`` keyword in the source and had
+                                        ``reactive = False`` injected into the generated file
+                                        (issue #183: an RMG-written source never carries the
+                                        keyword, so this records exactly what the writer added on
+                                        the source's behalf).
         warnings (tuple): Human-readable warnings (e.g. that a multi-species bath gas's fractions
                           are recorded here but will not be honored by Arkane; see P16).
     """
@@ -155,6 +170,7 @@ class ExplorerInputSummary:
     seed_species: tuple
     bath_gas: dict
     kinetics_labels_emitted: tuple = field(default_factory=tuple)
+    reactive_false_injected: tuple = field(default_factory=tuple)
     warnings: tuple = field(default_factory=tuple)
 
 
@@ -187,9 +203,15 @@ def write_arkane_explorer_input_file(source_path: str,
         method (str): 'CSE', 'MSC' or 'RS' (see ``t3.utils.writer.METHOD_MAP``), used to rewrite
                      the kept ``pressureDependence(...)`` block's ``method = ...`` line.
         bath_gas (dict): The bath gas composition, mapping species labels to mole fractions. Every
-                        label must be a ``species()`` block in the source carrying a literal
-                        ``reactive=False`` keyword (P16: Arkane/RMG identify the bath gas as every
-                        unreactive core species, not by name).
+                        label must be a ``species()`` block in the source. P16: Arkane/RMG identify
+                        the bath gas as every unreactive core species, not by name, so the
+                        generated file must carry ``reactive=False`` on each of these blocks --
+                        and since no RMG-written source ever carries the keyword
+                        (``arkane/pdep.py:654`` never emits it; issue #183), this writer INJECTS
+                        ``reactive = False`` into a declared bath-gas species block that has no
+                        ``reactive`` keyword, and refuses one carrying an explicit literal
+                        ``reactive=True`` (a contradiction) or a non-literal value (unverifiable).
+                        See ``_validate_bath_gas``.
         explore_tol (float, optional): The energy tolerance for exploring new isomers/reactions.
         energy_tol (float, optional): The energy tolerance for including a well/transition state in
                                       the output network.
@@ -218,8 +240,10 @@ def write_arkane_explorer_input_file(source_path: str,
                    or 2 labels; if a seed label is not a ``species()`` block in the source (e.g. it
                    is a ``transitionState()`` label, or does not exist at all, or is defined as
                    BOTH a ``species()`` and a ``transitionState()``); if a ``bath_gas`` label is
-                   not a ``species()`` block, or is a ``species()`` block that does not carry a
-                   literal ``reactive=False`` keyword; if the source does not contain exactly one
+                   not a ``species()`` block, or is a ``species()`` block carrying an explicit
+                   literal ``reactive=True`` or a non-literal ``reactive`` value (an absent
+                   keyword is NOT refused -- ``reactive = False`` is injected into the generated
+                   file instead); if the source does not contain exactly one
                    ``pressureDependence(...)`` block; if a ``reaction()`` block has neither an
                    explicit ``kinetics=`` keyword nor a literal ``label`` to target a
                    ``kinetics('<label>')`` job directive at; or if ``expected_source_hash`` is
@@ -296,7 +320,8 @@ def write_arkane_explorer_input_file(source_path: str,
             if label is not None:
                 species_nodes[label] = node
                 reactive_node = kwargs.get('reactive')
-                species_reactive[label] = True if reactive_node is None else _literal_or_none(reactive_node)
+                species_reactive[label] = _REACTIVE_ABSENT if reactive_node is None \
+                    else _literal_or_none(reactive_node)
 
         elif call_name == 'transitionState':
             label = _literal_or_none(kwargs.get('label'))
@@ -347,8 +372,22 @@ def write_arkane_explorer_input_file(source_path: str,
         raise ValueError(f"The master-equation 'method' must be one of {sorted(METHOD_MAP)}, got "
                          f"{method!r}. Arkane's own name for it is written into the kept "
                          f"pressureDependence(...) block, so an unrecognized method cannot be rendered.")
-    warnings_list = _validate_bath_gas(bath_gas=bath_gas, species_nodes=species_nodes,
-                                       species_reactive=species_reactive, source_path=source_path)
+    warnings_list, reactive_injection_labels = _validate_bath_gas(
+        bath_gas=bath_gas, species_nodes=species_nodes,
+        species_reactive=species_reactive, source_path=source_path)
+
+    # Inject 'reactive = False,' into each declared bath-gas species() block that carries no
+    # 'reactive' keyword in the source -- see _validate_bath_gas's docstring for why this is a
+    # faithful translation of the caller's declaration rather than a rewrite of user input, and why
+    # no RMG-written source ever carries the keyword itself (issue #183). The insertion lands at
+    # the first keyword's own position (a keyword argument's placement inside the call is
+    # semantically free), so the edit is computed structurally from the AST like every other edit
+    # here, never by text-scanning for a species block.
+    for label in reactive_injection_labels:
+        species_call = species_nodes[label].value
+        first_kw = species_call.keywords[0]
+        insert_pos = _pos(text, line_starts, first_kw.lineno, first_kw.col_offset)
+        edits.append((insert_pos, insert_pos, f"reactive = False,\n{' ' * first_kw.col_offset}"))
 
     # Remove every network(...) block: Arkane's explorer input parser does not recognize it, and
     # keeping it would (at best) be dead text and (at worst) confuse a human re-reading the file.
@@ -459,6 +498,7 @@ def write_arkane_explorer_input_file(source_path: str,
         seed_species=seed_species,
         bath_gas=dict(bath_gas),
         kinetics_labels_emitted=tuple(kinetics_labels_emitted),
+        reactive_false_injected=tuple(reactive_injection_labels),
         warnings=tuple(warnings_list),
     )
 
@@ -690,24 +730,47 @@ def validate_explorer_field_values(explore_tol, energy_tol, flux_tol, maximum_ra
 
 
 def _validate_bath_gas(bath_gas: dict, species_nodes: dict, species_reactive: dict,
-                       source_path: str) -> list:
+                       source_path: str) -> tuple:
     """
-    Validate the bath gas composition against Arkane/RMG's bath-gas identification rule (P16).
+    Validate the bath gas composition against Arkane/RMG's bath-gas identification rule (P16), and
+    decide which species blocks need ``reactive = False`` injected into the generated file.
+
+    Arkane/RMG identify the bath gas as every UNREACTIVE core species, never by name
+    (``rmgpy/rmg/pdep.py:856-863``), and the literal keyword in the ``species()`` block is the only
+    channel that survives: the explorer's own ``make_new_species(spec, reactive=False)``
+    (``arkane/explorer.py:141``) is overridden when the species enters the core, because
+    ``rmgpy/rmg/model.py:475`` re-reads ``reactive = object.reactive`` from the loaded species
+    object. Yet no RMG-written network file ever carries the keyword -- ``arkane/pdep.py:654``
+    (``save_input_file``) emits species blocks with no ``reactive`` at all (issue #183). So an
+    ABSENT keyword on a declared bath-gas species is not a refusal case but the normal case, and
+    since this module GENERATES the destination file, it emits the fact the caller declared
+    (``bath_gas`` names this species as the collider) as ``reactive = False`` in the generated
+    blocks: a translation between two encodings of one fact, not a rewrite of user input. Only a
+    species that EXPLICITLY contradicts the declaration (a literal ``reactive=True``), or whose
+    ``reactive`` value cannot be literally evaluated at all, is refused.
 
     Args:
         bath_gas (dict): Bath gas species label -> mole fraction.
         species_nodes (dict): species() label -> AST node, as collected from the source.
-        species_reactive (dict): species() label -> whether it carries a literal 'reactive=False'
-                                 keyword (True by default, matching Arkane/RMG's own default).
+        species_reactive (dict): species() label -> the literal value of its 'reactive' keyword,
+                                 or ``_REACTIVE_ABSENT`` when the block carries no such keyword
+                                 (``None`` means the keyword exists but its value is not a
+                                 literal).
         source_path (str): The source network path, used in error messages.
 
     Raises:
-        ValueError: If a bath gas label is not a species() block in the source, or is a species()
-                   block that does not carry a literal 'reactive=False' keyword.
+        ValueError: If the bath gas is empty; if a fraction violates its contract or the
+                   composition's sum/equality contracts; if a bath gas label is not a species()
+                   block in the source; if a bath gas species carries an explicit literal
+                   ``reactive=True`` (a contradiction this writer refuses to resolve either way);
+                   or if its ``reactive`` value is not a literal ``True``/``False``.
 
     Returns:
-        list: Warnings, e.g. that a multi-species bath gas's requested fractions are recorded here
-             but will not be honored by Arkane/RMG (P16).
+        tuple: A 2-tuple of
+              - list: Warnings, e.g. that a multi-species bath gas's requested fractions are
+                recorded but will not be honored by Arkane/RMG (P16).
+              - tuple: The bath-gas labels whose species() blocks need ``reactive = False``
+                injected (those carrying no ``reactive`` keyword in the source).
     """
     # An EMPTY bath gas is refused here rather than passed through. Every check below is a loop
     # over ``bath_gas``, so an empty dict satisfies all of them vacuously -- the guard would report
@@ -744,11 +807,35 @@ def _validate_bath_gas(bath_gas: dict, species_nodes: dict, species_reactive: di
         if label not in species_nodes:
             raise ValueError(f"Bath gas label '{label}' is not defined as a species() block anywhere in the "
                              f"source. Known species labels are {sorted(species_nodes)}.")
-        if species_reactive.get(label, True) is not False:
-            raise ValueError(f"Bath gas label '{label}' is a species() block that does not carry a literal "
-                             f"'reactive=False' keyword. Per P16 (rmgpy/rmg/pdep.py:856-863), Arkane/RMG identify "
-                             f"the bath gas as every unreactive core species, not by name; a bath gas species that "
-                             f"is not explicitly marked reactive=False would never be recognized as bath gas.")
+
+    # Decided per label AFTER the membership loop above so a mixed error (one unknown label, one
+    # conflicted one) always reports the missing block first -- the more fundamental problem.
+    inject_labels = list()
+    for label in bath_gas:
+        reactive_value = species_reactive[label]
+        if reactive_value is _REACTIVE_ABSENT:
+            # The RMG-written shape (arkane/pdep.py:654 emits no 'reactive' for any species):
+            # marked for injection into the generated file, see this function's docstring.
+            inject_labels.append(label)
+        elif reactive_value is True:
+            raise ValueError(f"Bath gas label '{label}' is a species() block carrying an explicit literal "
+                             f"'reactive=True', which contradicts its declaration as bath gas. Per P16 "
+                             f"(rmgpy/rmg/pdep.py:856-863), Arkane/RMG identify the bath gas as every "
+                             f"unreactive core species, and the species block's own keyword is the only "
+                             f"channel that survives into the core (rmgpy/rmg/model.py:475 re-reads "
+                             f"'reactive' from the loaded species, overriding arkane/explorer.py:141's "
+                             f"make_new_species(..., reactive=False)). Honouring the bath-gas declaration "
+                             f"would silently rewrite the source's own explicit claim, and honouring the "
+                             f"claim would have Arkane generate statmech for the collider -- so this "
+                             f"contradiction is refused rather than resolved either way. Fix the source, "
+                             f"or drop '{label}' from bath_gas.")
+        elif reactive_value is not False:
+            raise ValueError(f"Bath gas label '{label}' is a species() block whose 'reactive' keyword is not "
+                             f"a literal True or False, so it cannot be verified either way: injecting "
+                             f"'reactive = False' beside it could contradict whatever the expression "
+                             f"evaluates to when Arkane loads the file, and leaving it is a bath gas "
+                             f"Arkane may never recognize as one (P16, rmgpy/rmg/pdep.py:856-863). Make it "
+                             f"a literal, or remove it so this writer can inject the declared fact itself.")
 
     # Checked once over the whole composition rather than per species, because it is the only property
     # here that no individual fraction can violate on its own. ``math.isclose`` with an absolute
@@ -804,7 +891,7 @@ def _validate_bath_gas(bath_gas: dict, species_nodes: dict, species_reactive: di
                              f"CORE species. The fractions therefore match what will run, but the species SET "
                              f"may not -- if the core carries other unreactive species, they are included and "
                              f"the per-species weight changes accordingly.")
-    return warnings_list
+    return warnings_list, tuple(inject_labels)
 
 
 def _rewrite_method_line(text: str, method: str, source_path: str) -> str:

--- a/t3/pdep/mesolver/arkane.py
+++ b/t3/pdep/mesolver/arkane.py
@@ -149,7 +149,8 @@ class ArkaneMESolverAdapter(MESolverAdapter):
             with open(stderr_path, 'r') as f:
                 stderr_text = f.read()
 
-        # ``run_arkane_job`` reports a bool rather than a raw exit status, so it is folded in as a
+        # ``run_arkane_job`` reports a truthy/falsy ArkaneJobResult rather than a raw exit status,
+        # so it is folded in as a
         # 0/1 exit code. It is weaker evidence than the payload check below (Arkane exits 0 on the
         # silent-CSE failure), but it is not redundant either: it catches an ARC-level failure that
         # still happens to leave a plausible-looking output.py behind.

--- a/t3/pdep/parser.py
+++ b/t3/pdep/parser.py
@@ -42,6 +42,7 @@ __all__ = [
     'NetworkTextUnparseable',
     'PDepArkaneReaction',
     'PDepNetwork',
+    'PDepNetworkE0',
     'PDepPathReaction',
     'TGridClampRecord',
     'canonical_channel_pair',
@@ -49,12 +50,35 @@ __all__ = [
     'network_thermo_t_max',
     'parse_arkane_pdep_output_file',
     'parse_arkane_pdep_output_text',
+    'parse_pdep_network_e0_file',
+    'parse_pdep_network_e0_text',
     'parse_pdep_network_file',
     'parse_pdep_network_text',
     'to_json_safe',
 ]
 
 RECOGNIZED_TOP_LEVEL_CALLS = {'species', 'transitionState', 'reaction', 'network', 'pressureDependence'}
+
+# kJ/mol per one of each energy unit RMG itself accepts for an E0 quantity: the five named
+# ``rmgpy.quantity.Energy`` units plus its two extra-dimensionality conversions ('K' via R and
+# 'cm^-1' via h*c*100*Na -- see rmgpy/quantity.py:747-756). Factors are computed from CODATA 2018
+# exact constants rather than typed in rounded, so they match rmgpy's own conversions to full
+# precision. A unit outside this table is refused, never guessed: a wrong energy scale would
+# produce a diagram that looks plausible and is quantitatively wrong everywhere.
+_AVOGADRO = 6.02214076e23           # mol^-1
+_PLANCK = 6.62607015e-34            # J*s
+_SPEED_OF_LIGHT = 299792458.0       # m/s
+_ELEMENTARY_CHARGE = 1.602176634e-19  # C
+_GAS_CONSTANT = 8.31446261815324    # J/(mol*K)
+E0_UNIT_TO_KJ_PER_MOL = {
+    'J/mol': 1e-3,
+    'kJ/mol': 1.0,
+    'cal/mol': 4.184e-3,
+    'kcal/mol': 4.184,
+    'eV/molecule': _ELEMENTARY_CHARGE * _AVOGADRO * 1e-3,
+    'cm^-1': _PLANCK * _SPEED_OF_LIGHT * 100.0 * _AVOGADRO * 1e-3,
+    'K': _GAS_CONSTANT * 1e-3,
+}
 
 # ``pdepreaction(...)`` is deliberately NOT part of ``RECOGNIZED_TOP_LEVEL_CALLS`` above: it is
 # not part of the Arkane *input* DSL that RMG pdep network files use. It is a write-only call
@@ -825,6 +849,144 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
         product_channels_declared=product_channels_declared,
         source_hash=source_hash,
     )
+
+
+@dataclass(frozen=True)
+class PDepNetworkE0:
+    """
+    The E0 values a pdep network file declares, converted to kJ/mol.
+
+    A mapping deliberately SEPARATE from ``PDepNetwork``: the network dataclass is a frozen,
+    hashable-by-field topology record that several persistence paths serialize, while these are
+    plain dicts (unhashable) that only the PES-diagram path needs. Species without an ``E0``
+    keyword are ABSENT from the mapping, never recorded as 0.0 -- a consumer that needs a missing
+    species' energy must fail closed itself rather than silently place the species at the origin.
+
+    Args:
+        species (dict): Species label -> E0 (kJ/mol).
+        transition_states (dict): Transition state label -> E0 (kJ/mol).
+    """
+    species: dict
+    transition_states: dict
+
+
+def _e0_kj_per_mol(node, *, path: str, call_name: str, label: str) -> float | None:
+    """
+    Evaluate a ``species(...)``/``transitionState(...)`` ``E0=`` keyword node to kJ/mol.
+
+    Args:
+        node: The keyword's (still-AST) value node, or ``None`` if the keyword is absent.
+        path (str): The file path being parsed (for error messages only).
+        call_name (str): ``'species'`` or ``'transitionState'`` (for error messages only).
+        label (str): The declaring call's label (for error messages only).
+
+    Raises:
+        ValueError: If ``E0`` is present but is not a literal ``(number, unit_string)`` pair, or
+            its unit is not one RMG's own Energy quantity accepts (see ``E0_UNIT_TO_KJ_PER_MOL``).
+
+    Returns:
+        Optional[float]: The E0 in kJ/mol, or ``None`` if the keyword is genuinely absent.
+    """
+    if node is None:
+        return None
+    value = _literal_or_none(node)
+    # A written-but-unevaluable E0 (a call such as Quantity(...), a bare name) must raise rather
+    # than read as absent: a consumer would then report "no E0 declared" about a species whose
+    # file plainly gives one -- the same fail-open shape _literal_or_raise exists to refuse.
+    if value is None \
+            or not (isinstance(value, tuple) and len(value) == 2
+                    and isinstance(value[0], (int, float)) and not isinstance(value[0], bool)
+                    and isinstance(value[1], str)):
+        raise ValueError(f"The pdep network file at '{path}' declares an 'E0' keyword on "
+                         f"{call_name}(label={label!r}) that is not a literal (number, "
+                         f"unit-string) pair; refusing to read it as absent in its place.")
+    magnitude, unit = value
+    if unit not in E0_UNIT_TO_KJ_PER_MOL:
+        raise ValueError(f"The pdep network file at '{path}' declares E0={value!r} on "
+                         f"{call_name}(label={label!r}) with the unrecognized energy unit "
+                         f"{unit!r}; the recognized units are "
+                         f"{sorted(E0_UNIT_TO_KJ_PER_MOL)}. Refusing to guess an energy scale.")
+    return magnitude * E0_UNIT_TO_KJ_PER_MOL[unit]
+
+
+def parse_pdep_network_e0_file(path: str) -> PDepNetworkE0:
+    """
+    Read the E0 values (kJ/mol) a pdep network file on disk declares.
+
+    Args:
+        path (str): The path to the RMG pdep network file.
+
+    Raises:
+        ValueError: As ``parse_pdep_network_e0_text``.
+
+    Returns:
+        PDepNetworkE0: The declared species/transition-state E0 values, in kJ/mol.
+    """
+    with open(path, 'rb') as f:
+        data = f.read()
+    # Decoded via the PEP 263 cookie for the same reason parse_pdep_network_file is: these files
+    # are Python source, and a hard-coded 'utf-8' or the locale encoding mis-reads legal ones.
+    encoding, _ = tokenize.detect_encoding(io.BytesIO(data).readline)
+    return parse_pdep_network_e0_text(text=data.decode(encoding), path=path)
+
+
+def parse_pdep_network_e0_text(text: str, path: str = '') -> PDepNetworkE0:
+    """
+    Read the E0 values (kJ/mol) pdep network file text declares.
+
+    This is the energy companion to ``parse_pdep_network_text``: the same never-execute ast walk,
+    reading only the ``E0 = (value, unit)`` keyword of every ``species(...)`` and
+    ``transitionState(...)`` call. It deliberately does NOT require any ``reaction(...)`` entries:
+    it answers "what energies does this file declare", not "is this a well-formed network" -- the
+    topology parser owns the latter.
+
+    Args:
+        text (str): The RMG pdep network file content.
+        path (str, optional): The path the text was read from, if any (error messages only).
+
+    Raises:
+        ValueError: If the text cannot be parsed as Python; if any ``E0`` is present but not a
+            literal ``(number, unit_string)`` pair, or carries an unrecognized unit; or if the
+            same label is declared twice with CONFLICTING E0 values (last-wins would silently pick
+            one of two contradictory statements about one stationary point; an identical duplicate
+            carries no ambiguity and is tolerated).
+
+    Returns:
+        PDepNetworkE0: The declared species/transition-state E0 values, in kJ/mol. Labels whose
+            declaration carries no ``E0`` keyword are absent from the mappings.
+    """
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', SyntaxWarning)
+            tree = ast.parse(text)
+    except SyntaxError as e:
+        raise ValueError(f"Could not parse the pdep network file at '{path}' as Python: {e}")
+
+    e0_by_call_name = {'species': dict(), 'transitionState': dict()}
+    for node in tree.body:
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        call_name = _get_call_name(call)
+        if call_name not in e0_by_call_name:
+            continue
+        kwargs = _call_keywords(call, path=path, call_name=call_name)
+        label = _literal_or_raise(kwargs.get('label'), path=path, keyword='label',
+                                  action="omit it from the E0 mapping")
+        if label is None:
+            continue
+        e0 = _e0_kj_per_mol(kwargs.get('E0'), path=path, call_name=call_name, label=label)
+        if e0 is None:
+            continue
+        recorded = e0_by_call_name[call_name]
+        if label in recorded and recorded[label] != e0:
+            raise ValueError(f"The pdep network file at '{path}' declares "
+                             f"{call_name}(label={label!r}) twice with conflicting E0 values "
+                             f"({recorded[label]} vs. {e0} kJ/mol); refusing to pick one of two "
+                             f"contradictory statements about the same stationary point.")
+        recorded[label] = e0
+    return PDepNetworkE0(species=e0_by_call_name['species'],
+                         transition_states=e0_by_call_name['transitionState'])
 
 
 def _parse_reaction(kwargs: dict, path: str = '') -> PDepPathReaction:

--- a/t3/pdep/parser.py
+++ b/t3/pdep/parser.py
@@ -870,9 +870,100 @@ class PDepNetworkE0:
     transition_states: dict
 
 
+class _NotAConstantNumber(Exception):
+    """
+    Internal signal that an AST node is not a constant arithmetic numeric expression.
+
+    Carries a human-readable description of the offending construct (e.g. ``"a name ('x')"``) so
+    the catching call site can build an error message that names what it refused, without every
+    call site re-deriving that description itself.
+    """
+
+    def __init__(self, description: str):
+        self.description = description
+        super().__init__(description)
+
+
+def _describe_non_numeric_node(node) -> str:
+    """
+    Describe an AST node that ``_fold_constant_number`` refused, for use in an error message.
+
+    Args:
+        node: The offending AST node.
+
+    Returns:
+        str: A short, human-readable description of the node (e.g. ``"a name ('x')"``).
+    """
+    if isinstance(node, ast.Name):
+        return f"a name ({node.id!r})"
+    if isinstance(node, ast.Call):
+        return f"a call ({_get_call_name(node) or '<unnamed>'}(...))"
+    if isinstance(node, ast.Attribute):
+        return f"an attribute access ('.{node.attr}')"
+    if isinstance(node, ast.Subscript):
+        return "a subscript"
+    if isinstance(node, ast.Compare):
+        return "a comparison"
+    if isinstance(node, ast.BinOp):
+        return f"a {type(node.op).__name__} operator"
+    return f"a {type(node).__name__} node"
+
+
+def _fold_constant_number(node) -> float:
+    """
+    Fold an AST expression node to a float, IF AND ONLY IF it is built entirely from numeric
+    literals combined with unary +/- and binary +, -, *, / (parenthesised nesting included).
+
+    This exists because RMG writes a TS's ``E0`` as an arithmetic expression rather than a plain
+    literal whenever an energy correction was applied (e.g. ``E0 = (264.497 - 411.735,
+    "kJ/mol")``), and ``ast.literal_eval`` -- correctly -- refuses any ``BinOp``. The expression is
+    still fully constant, so it can be evaluated safely by hand: this function walks the tree
+    itself and combines only numbers with +, -, *, /, so nothing beyond that arithmetic can ever
+    run. It NEVER calls ``eval``/``exec``, and a ``Name`` is refused outright rather than looked up
+    in any namespace -- there is no namespace here, so there is nothing a name could safely mean.
+
+    Args:
+        node: An AST expression node.
+
+    Raises:
+        _NotAConstantNumber: If ``node`` (or any subnode) is not built solely from numeric
+            literals and +, -, *, / arithmetic -- e.g. a name, a call, an attribute access, a
+            subscript, a comparison, or a non-arithmetic operator such as ``**``.
+        ZeroDivisionError: If the expression divides by a folded zero.
+
+    Returns:
+        float: The folded numeric value.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) \
+            and not isinstance(node.value, bool):
+        return float(node.value)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        operand = _fold_constant_number(node.operand)
+        return -operand if isinstance(node.op, ast.USub) else operand
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub, ast.Mult, ast.Div)):
+        left = _fold_constant_number(node.left)
+        right = _fold_constant_number(node.right)
+        if isinstance(node.op, ast.Add):
+            return left + right
+        if isinstance(node.op, ast.Sub):
+            return left - right
+        if isinstance(node.op, ast.Mult):
+            return left * right
+        if right == 0:
+            raise ZeroDivisionError('division by zero in a constant numeric expression')
+        return left / right
+    raise _NotAConstantNumber(_describe_non_numeric_node(node))
+
+
 def _e0_kj_per_mol(node, *, path: str, call_name: str, label: str) -> float | None:
     """
     Evaluate a ``species(...)``/``transitionState(...)`` ``E0=`` keyword node to kJ/mol.
+
+    The numeric half of the pair is folded via ``_fold_constant_number`` rather than
+    ``ast.literal_eval``, so a constant arithmetic expression such as
+    ``E0 = (264.497 - 411.735, "kJ/mol")`` -- what RMG writes whenever an energy correction was
+    applied to a transition state -- is read exactly rather than refused. The unit half keeps the
+    plain-literal reading it always had: it is a bare string, never an expression.
 
     Args:
         node: The keyword's (still-AST) value node, or ``None`` if the keyword is absent.
@@ -881,28 +972,44 @@ def _e0_kj_per_mol(node, *, path: str, call_name: str, label: str) -> float | No
         label (str): The declaring call's label (for error messages only).
 
     Raises:
-        ValueError: If ``E0`` is present but is not a literal ``(number, unit_string)`` pair, or
-            its unit is not one RMG's own Energy quantity accepts (see ``E0_UNIT_TO_KJ_PER_MOL``).
+        ValueError: If ``E0`` is present but is not a 2-element tuple, its numeric half is not a
+            constant numeric literal/expression (e.g. a name, a call, an attribute access), its
+            numeric half divides by zero, or its unit is not one RMG's own Energy quantity accepts
+            (see ``E0_UNIT_TO_KJ_PER_MOL``).
 
     Returns:
         Optional[float]: The E0 in kJ/mol, or ``None`` if the keyword is genuinely absent.
     """
     if node is None:
         return None
-    value = _literal_or_none(node)
-    # A written-but-unevaluable E0 (a call such as Quantity(...), a bare name) must raise rather
-    # than read as absent: a consumer would then report "no E0 declared" about a species whose
-    # file plainly gives one -- the same fail-open shape _literal_or_raise exists to refuse.
-    if value is None \
-            or not (isinstance(value, tuple) and len(value) == 2
-                    and isinstance(value[0], (int, float)) and not isinstance(value[0], bool)
-                    and isinstance(value[1], str)):
+    # The unit half must be a bare string constant; there is no arithmetic to fold there. The
+    # numeric half is folded separately below so a BinOp there (unreadable by ast.literal_eval
+    # alone) does not doom the whole pair.
+    if not (isinstance(node, ast.Tuple) and len(node.elts) == 2
+            and isinstance(node.elts[1], ast.Constant) and isinstance(node.elts[1].value, str)):
         raise ValueError(f"The pdep network file at '{path}' declares an 'E0' keyword on "
                          f"{call_name}(label={label!r}) that is not a literal (number, "
                          f"unit-string) pair; refusing to read it as absent in its place.")
-    magnitude, unit = value
+    magnitude_node, unit_node = node.elts
+    try:
+        magnitude = _fold_constant_number(magnitude_node)
+    except _NotAConstantNumber as e:
+        # A written-but-unfoldable E0 (a call such as Quantity(...), a bare name) must raise
+        # rather than read as absent: a consumer would then report "no E0 declared" about a
+        # species whose file plainly gives one -- the same fail-open shape _literal_or_raise
+        # exists to refuse.
+        raise ValueError(f"The pdep network file at '{path}' declares an 'E0' keyword on "
+                         f"{call_name}(label={label!r}) whose numeric half is {e.description}, "
+                         f"not a constant number or arithmetic expression; refusing to read it "
+                         f"as absent in its place.") from e
+    except ZeroDivisionError as e:
+        raise ValueError(f"The pdep network file at '{path}' declares an 'E0' keyword on "
+                         f"{call_name}(label={label!r}) whose numeric half divides by zero; "
+                         f"refusing to read it as absent in its place.") from e
+    unit = unit_node.value
     if unit not in E0_UNIT_TO_KJ_PER_MOL:
-        raise ValueError(f"The pdep network file at '{path}' declares E0={value!r} on "
+        raise ValueError(f"The pdep network file at '{path}' declares E0=({magnitude!r}, "
+                         f"{unit!r}) on "
                          f"{call_name}(label={label!r}) with the unrecognized energy unit "
                          f"{unit!r}; the recognized units are "
                          f"{sorted(E0_UNIT_TO_KJ_PER_MOL)}. Refusing to guess an energy scale.")

--- a/t3/runners/rmg_runner.py
+++ b/t3/runners/rmg_runner.py
@@ -5,11 +5,15 @@ Should be executed locally on the head node using the t3 environment.
 
 import datetime
 import logging
+import math
 import os
 import shlex
 import shutil
+import signal
 import subprocess
+import sys
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from arc.job.local import (_determine_job_id,
@@ -472,14 +476,133 @@ def fix_cantera_model_files(rmg_path: str) -> None:
     fix_cantera(model_path=os.path.join(rmg_path, 'cantera_from_ck', 'chem.yaml'))
 
 
+@dataclass(frozen=True)
+class ArkaneJobResult:
+    """
+    The outcome of ``run_arkane_job``.
+
+    Truth-y exactly when the job succeeded (``__bool__`` below), so every caller that treated the
+    old plain-``bool`` return as a truth value keeps working unchanged; what the object adds is the
+    DIAGNOSIS a bool could not carry -- most importantly whether a failure was a deadline overrun
+    (``timed_out``), which a caller must be able to distinguish from "Arkane ran and failed"
+    without parsing a reason string.
+
+    Args:
+        succeeded (bool): Whether the job succeeded (produced its required artifact, with no
+                          run/timeout failure).
+        timed_out (bool): Whether the job overran its ``timeout`` deadline and was killed.
+        reason (str, optional): A human-readable diagnosis when ``succeeded`` is False.
+    """
+    succeeded: bool
+    timed_out: bool = False
+    reason: str | None = None
+
+    def __bool__(self) -> bool:
+        """
+        Returns:
+            bool: Whether the job succeeded.
+        """
+        return self.succeeded
+
+
+# The interpreter script the ``timeout`` path of ``run_arkane_job`` runs in its own process:
+# exactly the same ARC entry point (``arc.statmech.arkane.run_arkane``) the in-process path calls,
+# so the two paths cannot drift on HOW Arkane is invoked -- only on WHERE (a killable session vs.
+# this process).
+_ARKANE_SUBPROCESS_SCRIPT = (
+    'import sys\n'
+    'from arc.statmech.arkane import run_arkane\n'
+    'run_arkane(statmech_dir=sys.argv[1])\n'
+)
+
+# How long a timed-out Arkane process group is given to exit on SIGTERM before it is SIGKILLed.
+_ARKANE_KILL_GRACE_SECONDS = 10
+
+
+def _spawn_arkane_subprocess(output_directory: str) -> subprocess.Popen:
+    """
+    Spawn ``arc.statmech.arkane.run_arkane`` in its own interpreter and its own process SESSION.
+
+    ``start_new_session=True`` is the load-bearing part: ARC's ``run_arkane`` shells out through
+    ``bash -lc`` and ``conda run`` (arc/statmech/arkane.py), so the actual Arkane interpreter is a
+    grandchild -- killing only the direct child would orphan it, still writing into the run
+    directory. A fresh session makes the child a process-group leader whose pgid covers every
+    descendant, so ``_kill_process_group`` can take the whole tree down at once.
+
+    Kept as a module-level helper (rather than inlined) so tests can substitute a controllable
+    process without re-implementing the wait/kill/reap logic under test.
+
+    Args:
+        output_directory (str): The directory containing ``input.py``, passed to ``run_arkane``.
+
+    Returns:
+        subprocess.Popen: The spawned process (its pid == its pgid, per the new session).
+    """
+    return subprocess.Popen(
+        [sys.executable, '-c', _ARKANE_SUBPROCESS_SCRIPT, output_directory],
+        start_new_session=True,
+    )
+
+
+def _kill_process_group(process: subprocess.Popen) -> None:
+    """
+    Terminate a spawned process's entire process group and reap the direct child.
+
+    SIGTERM first (Arkane/Python get a chance to flush logs), SIGKILL after
+    ``_ARKANE_KILL_GRACE_SECONDS``. Every ``ProcessLookupError`` window (the group exiting between
+    our decision and our signal) is tolerated: the goal state "nothing from this run is still
+    running" is then already true. The final ``wait()`` reaps the zombie so the caller can observe
+    ``process.poll() is not None``.
+
+    Args:
+        process (subprocess.Popen): The process to kill (spawned with ``start_new_session=True``).
+    """
+    try:
+        pgid = os.getpgid(process.pid)
+    except ProcessLookupError:
+        process.wait()
+        return
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        process.wait()
+        return
+    try:
+        process.wait(timeout=_ARKANE_KILL_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            # The group exited on its own between the SIGTERM grace wait above and this SIGKILL --
+            # the goal state ("nothing from this run is still running") is already true, so there is
+            # nothing to signal and nothing to handle.
+            pass
+        process.wait()
+
+
 def run_arkane_job(input_file: str,
                    output_directory: str,
                    plot: bool = False,
                    logger: Logger | None = None,
                    required_artifact: str = os.path.join('sensitivity', 'sa_coefficients.yml'),
-                   ) -> bool:
+                   timeout: float | None = None,
+                   ) -> ArkaneJobResult:
     """
     Run an Arkane job.
+
+    With ``timeout=None`` (the default), ARC's ``run_arkane`` is called in-process, exactly as
+    before. With a ``timeout``, the SAME ARC entry point runs in its own interpreter in its own
+    process session instead, because an in-process call cannot be killed at all: ARC reaches
+    ``subprocess.run`` (arc/job/local.py) with no ``timeout=`` and no Popen/PID exposed to any
+    caller, and a Python thread cannot be killed either -- an earlier in-adapter attempt to wrap
+    the call in a ThreadPoolExecutor could only relabel the outcome while Arkane kept running and
+    kept writing into a run directory already declared failed. Spawning the process ourselves is
+    what makes a deadline enforceable: on overrun the whole process group (the ``conda run`` bash
+    wrapper AND the Arkane interpreter under it) is SIGTERMed, then SIGKILLed, then reaped.
+
+    A deadline overrun is reported as a falsy result with ``timed_out=True`` -- never raised --
+    so a caller assembling a run record gets a recordable failure, not an exception that destroys
+    the record.
 
     Args:
         input_file (str): The path to the Arkane input file.
@@ -492,17 +615,34 @@ def run_arkane_job(input_file: str,
                                            present) and required to exist afterward. Defaults to
                                            the SA job's ``sensitivity/sa_coefficients.yml``, so
                                            this is a no-op for all existing callers.
+        timeout (float, optional): The wall-clock deadline, in seconds, for the Arkane process.
+                                   ``None`` (the default) preserves the historical in-process,
+                                   unbounded call.
 
     Raises:
         ValueError: If ``required_artifact`` is an absolute path, or resolves (after ``..`` and
                     symlink resolution) to a location outside ``output_directory``. The joined
                     path is deleted before the run, so an unconfined value would delete an
-                    arbitrary file elsewhere on the filesystem.
+                    arbitrary file elsewhere on the filesystem. Also if ``timeout`` is given and
+                    is not a positive finite number of seconds -- an unenforceable deadline
+                    (zero, negative, inf, nan, or a non-number) silently meaning "no deadline"
+                    would be worse than refusing it.
 
     Returns:
-        bool: Whether the job was successful.
+        ArkaneJobResult: The outcome; truthy exactly when the job succeeded, so callers treating
+                        it as the historical plain bool keep working.
     """
     from arc.statmech.arkane import run_arkane
+
+    # Checked before ANY side effect (the artifact deletion below), like the required_artifact
+    # confinement checks: an invalid deadline is an argument error about this call, not a run
+    # outcome. bool is excluded explicitly because it is an int subclass, so timeout=True would
+    # otherwise be accepted as a 1-second deadline nobody asked for.
+    if timeout is not None:
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) \
+                or not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError(f"The 'timeout' argument must be a positive finite number of seconds, or None "
+                             f"for no deadline, got {timeout!r} of type {type(timeout).__name__}.")
 
     # Confine the artifact path to output_directory BEFORE any side effect: the joined path is
     # deleted below, so a traversal value ('../important.yml') or an absolute value (which makes
@@ -539,18 +679,41 @@ def run_arkane_job(input_file: str,
     if os.path.isfile(artifact_path):
         os.remove(artifact_path)
 
-    try:
-        run_arkane(statmech_dir=output_directory)
-    except Exception as e:
-        if logger:
-            logger.error(f'Arkane run failed with error: {e}')
-        return False
+    if timeout is None:
+        try:
+            run_arkane(statmech_dir=output_directory)
+        except Exception as e:
+            reason = f'Arkane run failed with error: {e}'
+            if logger:
+                logger.error(reason)
+            return ArkaneJobResult(succeeded=False, reason=reason)
+    else:
+        process = _spawn_arkane_subprocess(output_directory=output_directory)
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _kill_process_group(process=process)
+            reason = (f'Arkane run in {output_directory} timed out after {timeout} s; its process '
+                      f'group was killed (SIGTERM, then SIGKILL after {_ARKANE_KILL_GRACE_SECONDS} s) '
+                      f'so nothing keeps writing into the run directory after this verdict.')
+            if logger:
+                logger.error(reason)
+            return ArkaneJobResult(succeeded=False, timed_out=True, reason=reason)
+        if process.returncode != 0:
+            # Mirrors the in-process path's except-clause: a run that died is a failure regardless
+            # of what artifacts it may have left behind. NOT labelled a timeout -- the deadline was
+            # met, the process failed on its own.
+            reason = f'Arkane run failed (exit status {process.returncode}).'
+            if logger:
+                logger.error(reason)
+            return ArkaneJobResult(succeeded=False, reason=reason)
 
     if not os.path.isfile(artifact_path):
+        reason = f'The Arkane job in {output_directory} did not produce {artifact_path}.'
         if logger:
-            logger.error(f'The Arkane job in {output_directory} did not produce {artifact_path}.')
-        return False
-    return True
+            logger.error(reason)
+        return ArkaneJobResult(succeeded=False, reason=reason)
+    return ArkaneJobResult(succeeded=True)
 
 
 def run_rmg_sa_incore(rmg_input_file_path: str,

--- a/t3/runners/rmg_runner.py
+++ b/t3/runners/rmg_runner.py
@@ -582,7 +582,6 @@ def _kill_process_group(process: subprocess.Popen) -> None:
 
 def run_arkane_job(input_file: str,
                    output_directory: str,
-                   plot: bool = False,
                    logger: Logger | None = None,
                    required_artifact: str = os.path.join('sensitivity', 'sa_coefficients.yml'),
                    timeout: float | None = None,
@@ -607,7 +606,6 @@ def run_arkane_job(input_file: str,
     Args:
         input_file (str): The path to the Arkane input file.
         output_directory (str): The path to the output directory.
-        plot (bool, optional): Whether to plot the results.
         logger (Logger, optional): The logger object.
         required_artifact (str, optional): A path, relative to ``output_directory``, naming the
                                            artifact that Arkane must (re)write for the job to be

--- a/t3/schema.py
+++ b/t3/schema.py
@@ -794,6 +794,29 @@ class RMG(BaseModel):
         return value
 
     @model_validator(mode='after')
+    def check_pdep_has_an_unreactive_species(self) -> RMG:
+        """
+        A pdep run requires at least one unreactive (inert) species to serve as the bath gas.
+
+        RMG identifies the bath gas as every unreactive core species -- ``rmgpy/rmg/pdep.py:856-858``
+        builds ``[spec for spec in core.species if not spec.reactive]`` and then asserts
+        ``len(bath_gas) > 0`` ('No unreactive species to identify as bath gas') inside every
+        pressure-dependent network update. An input with a pdep block and no ``reactive: false``
+        species therefore cannot fail at input parsing: it dies deep inside network generation,
+        potentially hours into the run, with an AssertionError that names nothing the user typed.
+        Refusing it here converts that into an immediate, actionable input error.
+        (Originally proposed in PR #60.)
+        """
+        if self.pdep is not None and self.species and not any(not spec.reactive for spec in self.species):
+            raise ValueError(
+                "A pdep section requires at least one unreactive species to serve as the bath gas: "
+                "RMG identifies the bath gas as every core species declared with 'reactive: false' "
+                "(rmgpy/rmg/pdep.py:856-858, which asserts that at least one exists inside every "
+                "network update -- deep into the run, long after the input was accepted). Mark an "
+                "inert species (e.g. N2, Ar, He) with 'reactive: false', or remove the pdep section.")
+        return self
+
+    @model_validator(mode='after')
     def check_species_and_reactors(self) -> RMG:
         if self.reactors and self.species:
             reactor_types = {reactor.type for reactor in self.reactors}

--- a/tests/test_pdep/test_api.py
+++ b/tests/test_pdep/test_api.py
@@ -832,6 +832,7 @@ def _make_config(trusted_output_root, output_directory, method='CSE'):
         output_directory=output_directory,
         seed_species=('H',),
         method=method,
+        bath_gas={'He': 1.0},
     )
 
 

--- a/tests/test_pdep/test_diagram.py
+++ b/tests/test_pdep/test_diagram.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+t3 tests test_pdep test_diagram module
+
+Tests T3's own PES energy diagram (``t3.pdep.diagram``): the pure energy-level computation
+(normalization to the lowest-lying isomer) and the matplotlib rendering. The rendering tests
+assert artifact existence and format only -- layout aesthetics are eyeballed, not pinned.
+"""
+
+import os
+
+import matplotlib
+matplotlib.use('Agg')  # headless rendering; must precede any pyplot-touching import below
+import matplotlib.pyplot as plt
+
+import pytest
+
+from t3.common import TEST_DATA_BASE_PATH
+from t3.pdep.diagram import (
+    REFERENCE_LOWEST_CONFIGURATION,
+    REFERENCE_LOWEST_ISOMER,
+    T3_PES_DIAGRAM_FILENAME,
+    _build_pes_figure,
+    compute_pes_diagram_data,
+    draw_pes_diagram,
+    stagger_label_offsets,
+)
+from t3.pdep.parser import parse_pdep_network_e0_file, parse_pdep_network_e0_text, \
+    parse_pdep_network_file, parse_pdep_network_text
+
+PDEP_NETWORK_DIR = os.path.join(TEST_DATA_BASE_PATH, 'pdep_network', 'iteration_1', 'RMG', 'pdep')
+REAL_NETWORKS_DIR = os.path.join(TEST_DATA_BASE_PATH, 'pdep_real_networks')
+
+NETWORK_799_PATH = os.path.join(REAL_NETWORKS_DIR, 'network799_1', 'network799_1.py')
+NETWORK_21_PATH = os.path.join(REAL_NETWORKS_DIR, 'network21_1', 'network21_1.py')
+NETWORK_4_1_PATH = os.path.join(PDEP_NETWORK_DIR, 'network4_1.py')
+NETWORK_4_2_PATH = os.path.join(PDEP_NETWORK_DIR, 'network4_2.py')
+NETWORK_1_1_PATH = os.path.join(PDEP_NETWORK_DIR, 'network1_1.py')
+
+ALL_FIXTURE_NETWORK_PATHS = [NETWORK_799_PATH, NETWORK_21_PATH, NETWORK_4_1_PATH,
+                             NETWORK_4_2_PATH, NETWORK_1_1_PATH]
+
+
+def _read(path):
+    with open(path) as f:
+        return f.read()
+
+
+def _compute_from_text(text):
+    network = parse_pdep_network_text(text=text, network_id='synthetic')
+    e0 = parse_pdep_network_e0_text(text=text)
+    return compute_pes_diagram_data(network=network, e0=e0)
+
+
+def _config_by_labels(data, labels):
+    return next(c for c in data.configurations if set(c.labels) == set(labels))
+
+
+class TestNormalization:
+
+    def test_the_lowest_isomer_sits_exactly_at_zero(self):
+        network = parse_pdep_network_text(text=_read(NETWORK_799_PATH), network_id='network799_1')
+        e0 = parse_pdep_network_e0_text(text=_read(NETWORK_799_PATH))
+        data = compute_pes_diagram_data(network=network, e0=e0)
+        assert data.reference_kind == REFERENCE_LOWEST_ISOMER
+        assert data.reference_e0 == pytest.approx(-170.357)
+        isomer = _config_by_labels(data, {'O=C1OO1(21648)'})
+        assert isomer.kind == 'isomer'
+        assert isomer.relative_e0 == 0.0
+
+    def test_relative_spacings_are_preserved_under_the_shift(self):
+        text = _read(NETWORK_799_PATH)
+        data = _compute_from_text(text)
+        # Raw E0 sums: isomer -170.357; O(S)+CO2 = 432.331 - 402.51 = 29.821;
+        # CO3t = -60.3782; [O]O[C]=O = 106.943. All shifted by +170.357:
+        assert _config_by_labels(data, {'O-2(13598)', 'CO2(11)'}).relative_e0 == pytest.approx(200.178)
+        assert _config_by_labels(data, {'[O]C([O])=O(8160)'}).relative_e0 == pytest.approx(109.9788)
+        assert _config_by_labels(data, {'[O]O[C]=O(8100)'}).relative_e0 == pytest.approx(277.300)
+        # And the shift is uniform: pairwise differences equal the raw pairwise differences.
+        for config in data.configurations:
+            assert config.relative_e0 == pytest.approx(config.e0 - data.reference_e0)
+        for ts in data.transition_states:
+            assert ts.relative_e0 == pytest.approx(ts.e0 - data.reference_e0)
+
+    def test_the_lowest_of_several_isomers_is_the_reference(self):
+        text = _read(NETWORK_4_2_PATH)
+        data = _compute_from_text(text)
+        assert data.reference_kind == REFERENCE_LOWEST_ISOMER
+        # Isomers: C4rad(5) at 63.0573, butyl_2(67) at 52.4618 kJ/mol -- the LOWER one is zero.
+        assert data.reference_e0 == pytest.approx(52.4618)
+        assert _config_by_labels(data, {'butyl_2(67)'}).relative_e0 == 0.0
+        assert _config_by_labels(data, {'C4rad(5)'}).relative_e0 == pytest.approx(10.5955)
+
+    def test_a_bimolecular_asymptote_below_the_lowest_isomer_stays_below_zero(self):
+        """The spec's edge case, decided deliberately: the reference is the lowest ISOMER, never
+        silently redefined to the lowest point overall -- so an exit channel lying deeper than
+        every well legitimately lands at a negative relative energy."""
+        text = """species(label='I', E0=(0.0, 'kJ/mol'))
+species(label='A', E0=(-10.0, 'kJ/mol'))
+species(label='B', E0=(-20.0, 'kJ/mol'))
+transitionState(label='TS1', E0=(15.0, 'kJ/mol'))
+reaction(label='r1', reactants=['I'], products=['A', 'B'], transitionState='TS1')
+network(label='N', isomers=['I'], reactants=[])
+"""
+        data = _compute_from_text(text)
+        assert data.reference_kind == REFERENCE_LOWEST_ISOMER
+        assert data.reference_e0 == pytest.approx(0.0)
+        assert _config_by_labels(data, {'I'}).relative_e0 == 0.0
+        assert _config_by_labels(data, {'A', 'B'}).relative_e0 == pytest.approx(-30.0)
+
+    def test_a_network_with_no_isomers_falls_back_to_the_lowest_configuration(self):
+        """With no isomer the spec's reference is undefined; the deliberate fallback is the lowest
+        configuration overall, and the data says so out loud via reference_kind."""
+        text = """species(label='A', E0=(10.0, 'kJ/mol'))
+species(label='B', E0=(20.0, 'kJ/mol'))
+species(label='C', E0=(5.0, 'kJ/mol'))
+transitionState(label='TS1', E0=(50.0, 'kJ/mol'))
+reaction(label='r1', reactants=['A', 'B'], products=['C'], transitionState='TS1')
+network(label='N', isomers=[], reactants=[('A', 'B')])
+"""
+        data = _compute_from_text(text)
+        assert data.reference_kind == REFERENCE_LOWEST_CONFIGURATION
+        assert data.reference_e0 == pytest.approx(5.0)
+        assert _config_by_labels(data, {'C'}).relative_e0 == 0.0
+        assert _config_by_labels(data, {'A', 'B'}).relative_e0 == pytest.approx(25.0)
+
+
+class TestConfigurationsAndTransitionStates:
+
+    def test_bath_gas_species_participate_in_no_configuration(self):
+        """network799_1 declares Ar and Ne (bath gas) as species with E0 values; they are part of
+        no isomer or channel and must not appear as diagram configurations."""
+        data = _compute_from_text(_read(NETWORK_799_PATH))
+        all_labels = {label for config in data.configurations for label in config.labels}
+        assert 'Ar' not in all_labels
+        assert 'Ne' not in all_labels
+        assert len(data.configurations) == 4  # 1 isomer + 3 derived product channels
+
+    def test_configuration_kinds(self):
+        data = _compute_from_text(_read(NETWORK_4_2_PATH))
+        kinds = {tuple(sorted(c.labels)): c.kind for c in data.configurations}
+        assert kinds[('C4rad(5)',)] == 'isomer'
+        assert kinds[('butyl_2(67)',)] == 'isomer'
+        assert kinds[('C4ene(26)', 'H(34)')] == 'reactant_channel'
+
+    def test_each_transition_state_connects_two_known_configurations(self):
+        data = _compute_from_text(_read(NETWORK_799_PATH))
+        config_keys = {tuple(sorted(c.labels)) for c in data.configurations}
+        assert len(data.transition_states) == 3
+        for ts in data.transition_states:
+            assert ts.reactants in config_keys
+            assert ts.products in config_keys
+        ts1 = next(ts for ts in data.transition_states if ts.label == 'TS1')
+        assert ts1.e0 == pytest.approx(31.8584)
+        assert ts1.relative_e0 == pytest.approx(202.2154)
+
+    def test_a_reaction_without_a_transition_state_is_barrierless(self):
+        text = """species(label='I', E0=(0.0, 'kJ/mol'))
+species(label='P', E0=(-5.0, 'kJ/mol'))
+reaction(label='r1', reactants=['I'], products=['P'])
+network(label='N', isomers=['I'], reactants=[])
+"""
+        data = _compute_from_text(text)
+        (ts,) = data.transition_states
+        assert ts.label is None
+        assert ts.e0 is None
+        assert ts.relative_e0 is None
+
+    def test_a_labeled_transition_state_without_an_e0_keeps_its_label_and_no_energy(self):
+        text = """species(label='I', E0=(0.0, 'kJ/mol'))
+species(label='P', E0=(-5.0, 'kJ/mol'))
+transitionState(label='TS1')
+reaction(label='r1', reactants=['I'], products=['P'], transitionState='TS1')
+network(label='N', isomers=['I'], reactants=[])
+"""
+        data = _compute_from_text(text)
+        (ts,) = data.transition_states
+        assert ts.label == 'TS1'
+        assert ts.e0 is None
+        assert ts.relative_e0 is None
+
+    def test_a_participating_species_with_no_e0_is_refused_by_name(self):
+        """A configuration whose species has no declared E0 cannot be placed on the surface;
+        silently dropping it (or placing it at zero) would draw a diagram of a different network."""
+        text = """species(label='I', E0=(0.0, 'kJ/mol'))
+species(label='P')
+reaction(label='r1', reactants=['I'], products=['P'])
+network(label='N', isomers=['I'], reactants=[])
+"""
+        network = parse_pdep_network_text(text=text, network_id='synthetic')
+        e0 = parse_pdep_network_e0_text(text=text)
+        with pytest.raises(ValueError, match="'P'"):
+            compute_pes_diagram_data(network=network, e0=e0)
+
+
+class TestStaggerLabelOffsets:
+
+    def test_two_near_degenerate_points_get_distinct_levels(self):
+        levels = stagger_label_offsets(points=((0.0, 100.0), (0.5, 101.0)), min_dx=0.7, min_dy=5.0)
+        assert levels[0] != levels[1]
+
+    def test_well_separated_points_all_sit_at_level_zero(self):
+        levels = stagger_label_offsets(points=((0.0, 0.0), (2.0, 0.0), (0.1, 300.0)),
+                                       min_dx=0.7, min_dy=5.0)
+        assert levels == (0, 0, 0)
+
+    def test_a_cluster_of_three_gets_three_distinct_levels(self):
+        levels = stagger_label_offsets(points=((0.0, 10.0), (0.2, 11.0), (0.4, 12.0)),
+                                       min_dx=0.7, min_dy=5.0)
+        assert len(set(levels)) == 3
+
+    def test_the_result_is_deterministic(self):
+        points = ((0.3, 5.0), (0.0, 5.5), (0.6, 4.5))
+        assert stagger_label_offsets(points=points, min_dx=0.7, min_dy=5.0) \
+            == stagger_label_offsets(points=points, min_dx=0.7, min_dy=5.0)
+
+
+class TestDrawPESDiagram:
+
+    @pytest.mark.parametrize('network_path', [NETWORK_799_PATH, NETWORK_21_PATH, NETWORK_4_2_PATH])
+    def test_a_diagram_is_produced_for_a_representative_network(self, tmp_path, network_path):
+        output_path = os.path.join(str(tmp_path), T3_PES_DIAGRAM_FILENAME)
+        data = draw_pes_diagram(network_path=network_path, output_path=output_path)
+        assert os.path.isfile(output_path)
+        assert os.path.getsize(output_path) > 0
+        # PNG magic bytes: the format follows the file extension.
+        with open(output_path, 'rb') as f:
+            assert f.read(8) == b'\x89PNG\r\n\x1a\n'
+        assert data.configurations
+
+    def test_the_format_follows_the_extension(self, tmp_path):
+        output_path = os.path.join(str(tmp_path), 'pes_diagram.svg')
+        draw_pes_diagram(network_path=NETWORK_799_PATH, output_path=output_path)
+        with open(output_path, 'rb') as f:
+            head = f.read(200)
+        assert b'<svg' in head or b'<?xml' in head
+
+    def test_drawing_a_no_isomer_network_annotates_the_fallback_reference(self, tmp_path):
+        text = """species(label='A', E0=(10.0, 'kJ/mol'))
+species(label='B', E0=(20.0, 'kJ/mol'))
+species(label='C', E0=(5.0, 'kJ/mol'))
+transitionState(label='TS1', E0=(50.0, 'kJ/mol'))
+reaction(label='r1', reactants=['A', 'B'], products=['C'], transitionState='TS1')
+network(label='N', isomers=[], reactants=[('A', 'B')])
+"""
+        network_path = os.path.join(str(tmp_path), 'network_no_isomer.py')
+        with open(network_path, 'w') as f:
+            f.write(text)
+        output_path = os.path.join(str(tmp_path), T3_PES_DIAGRAM_FILENAME)
+        data = draw_pes_diagram(network_path=network_path, output_path=output_path)
+        assert data.reference_kind == REFERENCE_LOWEST_CONFIGURATION
+        assert os.path.getsize(output_path) > 0
+
+
+def _bbox_overlap_area(a, b):
+    """Return the overlap area (px^2) of two Matplotlib Bbox objects, 0.0 if disjoint."""
+    dx = min(a.x1, b.x1) - max(a.x0, b.x0)
+    dy = min(a.y1, b.y1) - max(a.y0, b.y0)
+    return dx * dy if dx > 0 and dy > 0 else 0.0
+
+
+def _segment_crosses_box(p0, p1, box):
+    """Return True if the segment p0->p1 (display coords) enters the interior of `box`.
+
+    Liang-Barsky clipping: solve for the parametric range [t0, t1] along the segment that
+    survives clipping against each of the box's four half-planes: a nonempty, non-degenerate
+    range means the segment actually enters the box's interior.
+    """
+    x0, y0 = float(p0[0]), float(p0[1])
+    dx, dy = float(p1[0]) - x0, float(p1[1]) - y0
+    t0, t1 = 0.0, 1.0
+    for p, q in ((-dx, x0 - box.x0), (dx, box.x1 - x0),
+                 (-dy, y0 - box.y0), (dy, box.y1 - y0)):
+        if p == 0.0:
+            if q < 0.0:
+                return False
+            continue
+        r = q / p
+        if p < 0.0:
+            t0 = max(t0, r)
+        else:
+            t1 = min(t1, r)
+        if t0 > t1:
+            return False
+    return True
+
+
+def _measure_rendered_geometry(data):
+    """Render `data` via ``_build_pes_figure`` and return (texts, boxes, segments).
+
+    ``texts``/``boxes`` are parallel lists of non-blank text artists and their display-space
+    bounding boxes (``get_window_extent``); ``segments`` are all drawn line segments (level
+    bars from ``ax.hlines`` land as ``LineCollection``s in ``ax.collections``; TS connectors
+    and barrierless dashes are plain ``ax.lines``), also in display space.
+    """
+    fig = _build_pes_figure(data=data)
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+        texts = [t for ax in fig.axes for t in ax.texts if t.get_text().strip()]
+        boxes = [t.get_window_extent(renderer=renderer) for t in texts]
+        segments = []
+        for ax in fig.axes:
+            for line in ax.lines:
+                pts = ax.transData.transform(line.get_xydata())
+                segments.extend(zip(pts[:-1], pts[1:]))
+            for coll in ax.collections:  # ax.hlines(...) -> LineCollection
+                for seg in coll.get_segments():
+                    pts = ax.transData.transform(seg)
+                    segments.extend(zip(pts[:-1], pts[1:]))
+        return texts, boxes, segments
+    finally:
+        plt.close(fig)
+
+
+def _has_opaque_backing(text):
+    """Return True if `text` carries an opaque (alpha >= 0.8) backing patch."""
+    patch = text.get_bbox_patch()
+    return patch is not None and (patch.get_alpha() or 1.0) >= 0.8
+
+
+class TestRenderedLabelLegibility:
+    """
+    Verifies the ACTUAL rendered geometry, not just the data model: dense networks used to have
+    text annotations struck through by the dotted TS connectors and level bars they overlap in
+    z-order. Every annotation now carries an opaque backing patch (see ``_LABEL_BBOX`` in
+    ``t3.pdep.diagram``), so a line crossing a label's box is only a defect when that label has
+    no such patch. Separately, ``stagger_label_offsets`` is responsible for zero text-vs-text
+    overlaps; both properties are checked here on every fixture network.
+    """
+
+    @pytest.mark.parametrize('network_path', ALL_FIXTURE_NETWORK_PATHS)
+    def test_no_two_labels_overlap(self, network_path):
+        data = compute_pes_diagram_data(network=parse_pdep_network_file(path=network_path),
+                                        e0=parse_pdep_network_e0_file(path=network_path))
+        texts, boxes, _ = _measure_rendered_geometry(data=data)
+        overlapping = [(texts[i].get_text(), texts[j].get_text())
+                       for i in range(len(boxes)) for j in range(i + 1, len(boxes))
+                       if _bbox_overlap_area(boxes[i], boxes[j]) > 0.0]
+        assert overlapping == []
+
+    @pytest.mark.parametrize('network_path', ALL_FIXTURE_NETWORK_PATHS)
+    def test_no_label_is_struck_through_by_a_line(self, network_path):
+        data = compute_pes_diagram_data(network=parse_pdep_network_file(path=network_path),
+                                        e0=parse_pdep_network_e0_file(path=network_path))
+        texts, boxes, segments = _measure_rendered_geometry(data=data)
+        struck = []
+        for text, box in zip(texts, boxes):
+            if _has_opaque_backing(text):
+                continue  # an opaque backing patch makes any crossing line harmless
+            if any(_segment_crosses_box(p0, p1, box) for p0, p1 in segments):
+                struck.append(text.get_text())
+        assert struck == []

--- a/tests/test_pdep/test_explorer_arkane.py
+++ b/tests/test_pdep/test_explorer_arkane.py
@@ -1482,6 +1482,72 @@ class TestArkaneExplorerAdapterManifest:
             assert artifact['sha256'].startswith('sha256:')
             assert artifact['size'] > 0
 
+    def test_an_arkane_network_pdf_is_collected_into_the_manifest(self, tmp_path, monkeypatch):
+        """
+        Arkane's explorer draws its own PES diagram ('network<p>.pdf', arkane/explorer.py:357-359)
+        into the run directory, and T3 used to throw it away: the manifest hashed only
+        input.py/output*.py/network<i>_(full|reduced).py/arkane.log. When the PDF exists it is an
+        artifact of this run like any other, so it must be recorded.
+        """
+        adapter = _build_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(
+                success=True,
+                output_files={'output.py': VALID_OUTPUT_PY,
+                              'network0.pdf': '%PDF-1.4 fake arkane network drawing'},
+                final_files={'network0_full.py': VALID_NETWORK_PY},
+            ))
+        assert adapter.explore() is True
+        paths_recorded = {a['path'] for a in adapter.manifest['artifacts']}
+        assert os.path.join(adapter.output_directory, 'network0.pdf') in paths_recorded
+        pdf_artifact = next(a for a in adapter.manifest['artifacts']
+                            if a['path'].endswith('network0.pdf'))
+        assert pdf_artifact['sha256'].startswith('sha256:')
+        assert pdf_artifact['size'] > 0
+
+    def test_an_unrenamed_network_pdf_is_also_collected(self, tmp_path, monkeypatch):
+        """
+        Arkane's rename of 'network.pdf' to 'network<p>.pdf' happens in whatever CWD the Arkane
+        process ran in (a bare relative 'network.pdf', arkane/explorer.py:358-359), while the PDF
+        itself is drawn into the run directory (PressureDependenceJob.draw). When the CWD is not
+        the run directory the rename misses, and the artifact stays 'network.pdf' -- both
+        spellings are the same drawing and both must be collected.
+        """
+        adapter = _build_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(
+                success=True,
+                output_files={'output.py': VALID_OUTPUT_PY,
+                              'network.pdf': '%PDF-1.4 fake arkane network drawing'},
+                final_files={'network0_full.py': VALID_NETWORK_PY},
+            ))
+        assert adapter.explore() is True
+        paths_recorded = {a['path'] for a in adapter.manifest['artifacts']}
+        assert os.path.join(adapter.output_directory, 'network.pdf') in paths_recorded
+
+    def test_a_file_merely_resembling_the_arkane_pdf_is_not_collected(self, tmp_path, monkeypatch):
+        """
+        Only Arkane's own naming ('network.pdf' / 'network<p>.pdf', digits only) is collected:
+        the manifest asserts provenance, and recording an arbitrary stray PDF as a run artifact
+        would fabricate provenance for a file this run never produced.
+        """
+        adapter = _build_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(
+                success=True,
+                output_files={'output.py': VALID_OUTPUT_PY,
+                              'mynetwork0.pdf': 'not arkane naming',
+                              'networkX.pdf': 'not arkane naming either'},
+                final_files={'network0_full.py': VALID_NETWORK_PY},
+            ))
+        assert adapter.explore() is True
+        paths_recorded = {a['path'] for a in adapter.manifest['artifacts']}
+        assert not any(p.endswith('mynetwork0.pdf') for p in paths_recorded)
+        assert not any(p.endswith('networkX.pdf') for p in paths_recorded)
+
 
 class TestTheClaimStageCannotEscapeTheStateContract:
     """

--- a/tests/test_pdep/test_explorer_arkane.py
+++ b/tests/test_pdep/test_explorer_arkane.py
@@ -349,7 +349,8 @@ def _make_fake_run_arkane_job(*, success=True, output_files=None, final_files=No
     output_files = output_files or {}
     final_files = final_files or {}
 
-    def _fake(input_file, output_directory, plot=False, logger=None, required_artifact='output.py'):
+    def _fake(input_file, output_directory, plot=False, logger=None, required_artifact='output.py',
+              timeout=None):
         for name, content in output_files.items():
             _write(os.path.join(output_directory, name), content)
         for name, content in final_files.items():
@@ -391,6 +392,61 @@ class TestArkaneExplorerAdapterRegistration:
     def test_registered_under_arkane(self):
         from t3.pdep.explorer.arkane import ArkaneExplorerAdapter
         assert _registered_explorer_adapters.get('Arkane') is ArkaneExplorerAdapter
+
+
+class TestArkaneExplorerAdapterTimeout:
+    """
+    The adapter's ``timeout`` is a passthrough to ``run_arkane_job``, and a deadline overrun is a
+    RECORDED, distinguishable failure (issue #183: a hung Arkane used to hang the whole campaign,
+    with no kill path anywhere between the adapter and ARC's un-timeboxed subprocess call).
+    """
+
+    def test_timeout_is_forwarded_to_run_arkane_job(self, tmp_path, monkeypatch):
+        """The configured deadline must reach the runner that enforces it, verbatim."""
+        captured = {}
+        inner = _make_fake_run_arkane_job(success=True)
+
+        def _fake(**kwargs):
+            captured.update(kwargs)
+            return inner(**{key: value for key, value in kwargs.items() if key != 'timeout'})
+
+        monkeypatch.setattr('t3.pdep.explorer.arkane.run_arkane_job', _fake)
+        adapter = _build_adapter(tmp_path, monkeypatch, timeout=42.5)
+        adapter.explore()
+        assert captured['timeout'] == 42.5
+
+    def test_timeout_defaults_to_none(self, tmp_path, monkeypatch):
+        """With no timeout configured, the runner must receive None (the historical, unbounded
+        in-process call), not some invented default deadline."""
+        captured = {}
+        inner = _make_fake_run_arkane_job(success=True)
+
+        def _fake(**kwargs):
+            captured.update(kwargs)
+            return inner(**{key: value for key, value in kwargs.items() if key != 'timeout'})
+
+        monkeypatch.setattr('t3.pdep.explorer.arkane.run_arkane_job', _fake)
+        adapter = _build_adapter(tmp_path, monkeypatch)
+        adapter.explore()
+        assert captured['timeout'] is None
+
+    def test_timed_out_run_is_a_recorded_distinguishable_failure(self, tmp_path, monkeypatch):
+        """A deadline overrun surfaces as succeeded=False with a reason naming the timeout --
+        never as an exception (which would destroy the run record), and never folded into the
+        generic 'Arkane reported job failure' diagnosis."""
+        from t3.runners.rmg_runner import ArkaneJobResult
+
+        timeout_reason = 'Arkane run in /x timed out after 7 s; its process group was killed.'
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            lambda **kwargs: ArkaneJobResult(succeeded=False, timed_out=True, reason=timeout_reason))
+        adapter = _build_adapter(tmp_path, monkeypatch, timeout=7)
+
+        assert adapter.explore() is False
+        assert adapter.succeeded is False
+        assert any('timed out' in reason for reason in adapter.reasons), adapter.reasons
+        assert not any('Arkane reported job failure' in reason for reason in adapter.reasons), \
+            'A timeout must be its own diagnosis, not the generic job-failure one.'
 
 
 class TestArkaneExplorerAdapterExclusivity:

--- a/tests/test_pdep/test_explorer_arkane.py
+++ b/tests/test_pdep/test_explorer_arkane.py
@@ -1549,6 +1549,107 @@ class TestArkaneExplorerAdapterManifest:
         assert not any(p.endswith('networkX.pdf') for p in paths_recorded)
 
 
+class TestArkaneExplorerAdapterPESDiagram:
+    """
+    Every successful exploration leaves T3's own normalized PES diagram
+    (``t3.pdep.diagram``) in the run directory, recorded in the manifest -- and the drawing is
+    strictly best-effort: no drawing failure may ever flip a successful exploration to failed,
+    because the diagram describes the result, it is not part of it.
+    """
+
+    def test_a_successful_explore_leaves_a_pes_diagram_and_records_it(self, tmp_path, monkeypatch):
+        adapter = _build_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(
+                success=True,
+                output_files={'output.py': VALID_OUTPUT_PY},
+                final_files={'network0_full.py': VALID_NETWORK_PY},
+            ))
+        assert adapter.explore() is True
+        diagram_path = os.path.join(adapter.output_directory, 'pes_diagram.png')
+        assert os.path.isfile(diagram_path)
+        assert os.path.getsize(diagram_path) > 0
+        paths_recorded = {a['path'] for a in adapter.manifest['artifacts']}
+        assert diagram_path in paths_recorded
+
+    def test_a_diagram_failure_never_flips_a_successful_exploration(self, tmp_path, monkeypatch):
+        class _RecordingLogger:
+            def __init__(self):
+                self.warnings = []
+
+            def warning(self, message):
+                self.warnings.append(message)
+
+        logger = _RecordingLogger()
+        adapter = _build_adapter(tmp_path, monkeypatch, logger=logger)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(
+                success=True,
+                output_files={'output.py': VALID_OUTPUT_PY},
+                final_files={'network0_full.py': VALID_NETWORK_PY},
+            ))
+
+        def _refusing_draw(**kwargs):
+            raise ValueError('deliberately broken drawer')
+
+        monkeypatch.setattr('t3.pdep.explorer.arkane.draw_pes_diagram', _refusing_draw)
+        assert adapter.explore() is True
+        assert adapter.succeeded is True
+        assert adapter.reasons == tuple()
+        diagram_path = os.path.join(adapter.output_directory, 'pes_diagram.png')
+        assert not os.path.isfile(diagram_path)
+        paths_recorded = {a['path'] for a in adapter.manifest['artifacts']}
+        assert diagram_path not in paths_recorded
+        assert any('deliberately broken drawer' in message for message in logger.warnings)
+
+    def test_a_diagram_failure_with_no_logger_is_still_silent_success(self, tmp_path, monkeypatch):
+        adapter = _build_adapter(tmp_path, monkeypatch, logger=None)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(
+                success=True,
+                output_files={'output.py': VALID_OUTPUT_PY},
+                final_files={'network0_full.py': VALID_NETWORK_PY},
+            ))
+        monkeypatch.setattr('t3.pdep.explorer.arkane.draw_pes_diagram',
+                            lambda **kwargs: (_ for _ in ()).throw(RuntimeError('boom')))
+        assert adapter.explore() is True
+
+    def test_a_failed_exploration_draws_no_diagram(self, tmp_path, monkeypatch):
+        adapter = _build_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(success=False))
+        assert adapter.explore() is False
+        assert not os.path.isfile(os.path.join(adapter.output_directory, 'pes_diagram.png'))
+
+    def test_the_diagram_is_drawn_from_the_final_network_artifact(self, tmp_path, monkeypatch):
+        """The final network file is the EXPLORED surface (it carries every species the
+        exploration discovered); the seed network the run started from is not. Drawing from the
+        source network would render the surface as it looked before the exploration ran."""
+        adapter = _build_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(
+                success=True,
+                output_files={'output.py': VALID_OUTPUT_PY},
+                final_files={'network0_full.py': VALID_NETWORK_PY},
+            ))
+        drawn_from = {}
+
+        def _recording_draw(network_path, output_path):
+            drawn_from['network_path'] = network_path
+            with open(output_path, 'wb') as f:
+                f.write(b'fake png')
+
+        monkeypatch.setattr('t3.pdep.explorer.arkane.draw_pes_diagram', _recording_draw)
+        assert adapter.explore() is True
+        assert drawn_from['network_path'] == os.path.join(
+            adapter.output_directory, 'pdep', 'final', 'network0_full.py')
+
+
 class TestTheClaimStageCannotEscapeTheStateContract:
     """
     The claim runs BEFORE both guards, so a crash there was still the "never ran" lie.

--- a/tests/test_pdep/test_explorer_config.py
+++ b/tests/test_pdep/test_explorer_config.py
@@ -32,6 +32,7 @@ def _valid_kwargs(**overrides) -> dict:
         output_directory='/tmp/root/sub',
         seed_species=['methoxy'],
         method='CSE',
+        bath_gas={'He': 1.0},
     )
     kwargs.update(overrides)
     return kwargs
@@ -113,6 +114,24 @@ def test_refuses_non_mapping_bath_gas():
     """A non-Mapping bath_gas (e.g. a list of pairs) would fail later with a confusing AttributeError."""
     with pytest.raises(ValueError, match="'bath_gas' must be a Mapping"):
         PDepExplorerConfig(**_valid_kwargs(bath_gas=[('He', 1.0)]))
+
+
+def test_refuses_omitted_bath_gas_at_construction_time():
+    """
+    The layering trap from issue #183: bath_gas=None used to pass construction-time validation and
+    only raise inside write_arkane_explorer_input_file -- AFTER the adapter had already claimed the
+    run directory (rule 0 creates it), so the guaranteed failure also burned a directory name. A
+    config that can never be written is refused where it is built.
+    """
+    with pytest.raises(ValueError, match="'bath_gas' is required"):
+        PDepExplorerConfig(**_valid_kwargs(bath_gas=None))
+
+
+def test_refuses_empty_bath_gas_at_construction_time():
+    """An empty bath-gas Mapping is the same guaranteed write-time failure as None (the writer
+    refuses bathGas={}), and is equally knowable from the config's own arguments."""
+    with pytest.raises(ValueError, match="'bath_gas' is required"):
+        PDepExplorerConfig(**_valid_kwargs(bath_gas={}))
 
 
 def test_refuses_non_mapping_database_kwargs():

--- a/tests/test_pdep/test_explorer_config.py
+++ b/tests/test_pdep/test_explorer_config.py
@@ -134,6 +134,22 @@ def test_refuses_empty_bath_gas_at_construction_time():
         PDepExplorerConfig(**_valid_kwargs(bath_gas={}))
 
 
+@pytest.mark.parametrize('bad_timeout', [0, -5, float('inf'), float('nan'), True, '60'])
+def test_refuses_a_timeout_that_is_not_a_positive_finite_number(bad_timeout):
+    """An unenforceable deadline (zero, negative, non-finite, bool, or a string) silently meaning
+    'no deadline' would be worse than refusing it; the same rule run_arkane_job enforces, applied
+    at construction time so it never burns a claimed run directory."""
+    with pytest.raises(ValueError, match="'timeout'"):
+        PDepExplorerConfig(**_valid_kwargs(timeout=bad_timeout))
+
+
+def test_accepts_a_positive_timeout_and_defaults_to_none():
+    """A positive number of seconds is stored verbatim; omitting it means no deadline (None)."""
+    assert PDepExplorerConfig(**_valid_kwargs(timeout=3600)).timeout == 3600
+    assert PDepExplorerConfig(**_valid_kwargs(timeout=0.5)).timeout == 0.5
+    assert PDepExplorerConfig(**_valid_kwargs()).timeout is None
+
+
 def test_refuses_non_mapping_database_kwargs():
     """A non-Mapping database_kwargs (e.g. a list) would fail later with a confusing AttributeError."""
     with pytest.raises(ValueError, match="'database_kwargs' must be a Mapping"):

--- a/tests/test_pdep/test_explorer_factory.py
+++ b/tests/test_pdep/test_explorer_factory.py
@@ -48,6 +48,7 @@ class _DummyPESExplorerAdapter(PESExplorerAdapter):
                  transition_state_seeds: tuple = None,
                  database_kwargs: dict = None,
                  expected_source_hash: str = None,
+                 timeout: float = None,
                  ):
         super().__init__(seed_species=seed_species, transition_state_seeds=transition_state_seeds)
         self.output_directory = output_directory
@@ -64,6 +65,7 @@ class _DummyPESExplorerAdapter(PESExplorerAdapter):
         # dummy holding a list where the real adapter holds a tuple -- i.e. quietly not well-behaved.
         self.database_kwargs = database_kwargs
         self.expected_source_hash = expected_source_hash
+        self.timeout = timeout
         self.explored = False
 
     def set_up(self):
@@ -277,6 +279,17 @@ class TestExplorerFactory(object):
                                    transition_state_seeds=('TS1',),
                                    )
         assert isinstance(adapter, _DummyTSSeedCompatibleAdapter)
+
+    def test_timeout_is_forwarded_to_the_adapter(self):
+        """The factory forwards ``timeout`` verbatim (and defaults it to None): the deadline is
+        configured on PDepExplorerConfig but enforced layers below, so a dropped passthrough here
+        would silently disable every configured timeout."""
+        adapter = explorer_factory(explorer='DummyExplorer', network_path='network.py', method='CSE',
+                                   seed_species=['OH'], output_directory='out', timeout=12.5)
+        assert adapter.timeout == 12.5
+        adapter = explorer_factory(explorer='DummyExplorer', network_path='network.py', method='CSE',
+                                   seed_species=['OH'], output_directory='out')
+        assert adapter.timeout is None
 
     def test_get_networks_before_explore_raises_runtime_error(self):
         """get_networks() before a successful explore() raises RuntimeError, never returns empty results silently."""

--- a/tests/test_pdep/test_explorer_input_file.py
+++ b/tests/test_pdep/test_explorer_input_file.py
@@ -8,10 +8,12 @@ Tests for ``t3.pdep.explorer.input_file.write_arkane_explorer_input_file``: tran
 P-dep network file (or a T3 hybrid network input, both plain Arkane DSL) into a valid Arkane
 PES-explorer input file.
 
-Fixtures are hand-built strings, not the real ``tests/data/pdep_network/...`` fixture, because that
-fixture's bath-gas species lack ``reactive=False`` and its ``reaction()`` blocks all carry explicit
-``kinetics=``, so it cannot exercise the bath-gas-refusal or kinetics-emission paths this module
-must cover. All test outputs are written to pytest's ``tmp_path``, never into ``tests/data/``.
+Most fixtures are hand-built strings so individual paths (kinetics emission, each refusal) can be
+exercised in isolation. The real RMG-written fixture at ``tests/data/pdep_network/.../network4_2.py``
+is exercised end-to-end as well (``test_real_rmg_network_file_writes_end_to_end``): its bath-gas
+species carry no ``reactive`` keyword at all -- the exact shape ``arkane/pdep.py:654``
+(``save_input_file``) emits for every species, and the shape issue #183 showed this writer refused
+wholesale. All test outputs are written to pytest's ``tmp_path``, never into ``tests/data/``.
 """
 
 import ast
@@ -32,6 +34,7 @@ from t3.pdep.explorer.input_file import (
     ExplorerInputSummary,
     write_arkane_explorer_input_file,
 )
+from t3.common import TEST_DATA_BASE_PATH
 from t3.pdep.hashing import hash_file
 
 # A minimal but structurally realistic RMG pdep network source: two species (one of them a bath
@@ -100,11 +103,27 @@ SOURCE_WITH_KINETICS = SOURCE_NO_KINETICS.replace(
     "    kinetics=Arrhenius(A=(1e13, 's^-1'), n=0, Ea=(50, 'kJ/mol')),\n)",
 )
 
-# A variant with two bath gas species, neither marked reactive=False, to exercise the bath-gas
-# validation refusal path.
-SOURCE_BATH_GAS_NOT_UNREACTIVE = SOURCE_NO_KINETICS.replace(
+# A variant whose bath gas species carries no 'reactive' keyword at all -- the shape every
+# RMG-written network file has (arkane/pdep.py:654 save_input_file never emits 'reactive' for any
+# species; issue #183) -- to exercise the reactive=False injection path.
+SOURCE_BATH_GAS_NO_REACTIVE_KEYWORD = SOURCE_NO_KINETICS.replace(
     "    reactive=False,\n)",
     ")",
+)
+
+# A variant whose bath gas species carries an EXPLICIT reactive=True: a self-contradictory
+# declaration (named as bath gas while asserted reactive) that must be refused, never silently
+# rewritten.
+SOURCE_BATH_GAS_EXPLICITLY_REACTIVE = SOURCE_NO_KINETICS.replace(
+    "    reactive=False,\n",
+    "    reactive=True,\n",
+)
+
+# A variant whose bath gas species carries a NON-LITERAL reactive value, which cannot be verified
+# either way and must be refused.
+SOURCE_BATH_GAS_NON_LITERAL_REACTIVE = SOURCE_NO_KINETICS.replace(
+    "    reactive=False,\n",
+    "    reactive=SMILES('[He]'),\n",
 )
 
 # A variant where the reaction() block has no 'label' keyword at all, so a kinetics(...) directive
@@ -141,6 +160,32 @@ def _write_source(tmp_path, text, name='network.py'):
     with open(source_path, 'w') as f:
         f.write(text)
     return source_path
+
+
+def _species_reactive_map(path: str) -> dict:
+    """
+    Parse a generated input file and map every species() label to its literal ``reactive`` keyword
+    value, or ``None`` where the block carries no ``reactive`` keyword at all.
+
+    Args:
+        path (str): The generated input file path.
+
+    Returns:
+        dict: label -> literal reactive value (or None when absent).
+    """
+    with open(path) as f:
+        tree = ast.parse(f.read())
+    reactive_map = dict()
+    for node in tree.body:
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call) \
+                or not isinstance(node.value.func, ast.Name) or node.value.func.id != 'species':
+            continue
+        kwargs = {kw.arg: kw.value for kw in node.value.keywords if kw.arg is not None}
+        label = ast.literal_eval(kwargs['label'])
+        assert [kw.arg for kw in node.value.keywords].count('reactive') <= 1, \
+            f'species {label!r} carries a duplicated reactive keyword'
+        reactive_map[label] = ast.literal_eval(kwargs['reactive']) if 'reactive' in kwargs else None
+    return reactive_map
 
 
 def test_writes_valid_python_with_all_required_blocks(tmp_path):
@@ -483,15 +528,95 @@ def test_refuses_bath_gas_label_not_a_species_block(tmp_path):
     assert not os.path.isfile(dest_path)
 
 
-def test_refuses_bath_gas_species_not_marked_unreactive(tmp_path):
-    """P16: PDepNetwork.update identifies bath gas as every unreactive core species; a bath-gas
-    species() block that is not reactive=False would never be recognized as bath gas by Arkane."""
-    source_path = _write_source(tmp_path, SOURCE_BATH_GAS_NOT_UNREACTIVE)
+def test_injects_reactive_false_for_bath_gas_species_without_reactive_keyword(tmp_path):
+    """
+    Issue #183, the core defect: RMG's ``save_input_file`` (arkane/pdep.py:654) never writes a
+    ``reactive`` keyword for ANY species, so requiring a literal ``reactive=False`` in the SOURCE
+    refused every real RMG-written network file. The fact "this species is the bath gas" is
+    declared by the caller (``bath_gas``), and this writer GENERATES the destination file -- so it
+    emits ``reactive = False`` on the declared bath-gas species itself: a faithful translation
+    between two encodings of one fact, not a rewrite of user input.
+    """
+    source_path = _write_source(tmp_path, SOURCE_BATH_GAS_NO_REACTIVE_KEYWORD)
     dest_path = str(tmp_path / 'input.py')
 
-    with pytest.raises(ValueError):
+    result = write_arkane_explorer_input_file(source_path=source_path, dest_path=dest_path, **DEFAULT_KWARGS)
+
+    assert result.reactive_false_injected == ('He',)
+    assert _species_reactive_map(dest_path) == {'methoxy': None, 'CH2O': None, 'H': None, 'He': False}
+
+
+def test_does_not_reinject_reactive_false_when_source_already_carries_it(tmp_path):
+    """A source bath-gas species already marked reactive=False is left verbatim: no duplicate
+    keyword (which would be a SyntaxError Arkane could never load), and no injection recorded."""
+    source_path = _write_source(tmp_path, SOURCE_NO_KINETICS)
+    dest_path = str(tmp_path / 'input.py')
+
+    result = write_arkane_explorer_input_file(source_path=source_path, dest_path=dest_path, **DEFAULT_KWARGS)
+
+    assert result.reactive_false_injected == tuple()
+    assert _species_reactive_map(dest_path)['He'] is False
+
+
+def test_refuses_bath_gas_species_explicitly_marked_reactive(tmp_path):
+    """A species named as bath gas while carrying an explicit reactive=True is a contradiction:
+    honouring the name would rewrite the source's own claim, honouring the claim would run Arkane
+    statmech on the collider. Refuse loudly rather than pick a side."""
+    source_path = _write_source(tmp_path, SOURCE_BATH_GAS_EXPLICITLY_REACTIVE)
+    dest_path = str(tmp_path / 'input.py')
+
+    with pytest.raises(ValueError, match='explicit.*reactive=True|reactive=True.*explicit'):
         write_arkane_explorer_input_file(source_path=source_path, dest_path=dest_path, **DEFAULT_KWARGS)
     assert not os.path.isfile(dest_path)
+
+
+def test_refuses_bath_gas_species_with_non_literal_reactive_value(tmp_path):
+    """A bath-gas species whose reactive value cannot be literally evaluated can be verified
+    neither as a conflict nor as already-unreactive; injecting next to it could contradict what the
+    expression evaluates to at Arkane load time."""
+    source_path = _write_source(tmp_path, SOURCE_BATH_GAS_NON_LITERAL_REACTIVE)
+    dest_path = str(tmp_path / 'input.py')
+
+    with pytest.raises(ValueError, match='literal'):
+        write_arkane_explorer_input_file(source_path=source_path, dest_path=dest_path, **DEFAULT_KWARGS)
+    assert not os.path.isfile(dest_path)
+
+
+def test_real_rmg_network_file_writes_end_to_end(tmp_path):
+    """
+    THE issue #183 regression test: a real, RMG-written network file (species blocks carrying no
+    ``reactive`` keyword anywhere, bath gas declared only in the ``network(...)`` block RMG writes)
+    must be writable into a loadable explorer input. Before the injection fix, this writer refused
+    every such file, i.e. the entire feature path was unusable on real RMG output.
+    """
+    source_path = os.path.join(TEST_DATA_BASE_PATH, 'pdep_network', 'iteration_1', 'RMG', 'pdep',
+                               'network4_2.py')
+    with open(source_path) as f:
+        assert 'reactive' not in f.read(), \
+            'fixture precondition: a real RMG-written network file carries no reactive keyword'
+    dest_path = str(tmp_path / 'input.py')
+
+    result = write_arkane_explorer_input_file(
+        source_path=source_path, dest_path=dest_path,
+        seed_species=('C4rad(5)',), method='MSC',
+        bath_gas={'He': 0.5, 'Ne': 0.5},
+    )
+
+    assert sorted(result.reactive_false_injected) == ['He', 'Ne']
+    reactive_map = _species_reactive_map(dest_path)
+    assert reactive_map['He'] is False
+    assert reactive_map['Ne'] is False
+    assert all(value is None for label, value in reactive_map.items() if label not in ('He', 'Ne'))
+    # The generated text must still be a loadable input: valid Python with exactly one
+    # pressureDependence block, no network block, and the explorer block appended last.
+    with open(dest_path) as f:
+        tree = ast.parse(f.read())
+    top_level_calls = [node.value.func.id for node in tree.body
+                       if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
+                       and isinstance(node.value.func, ast.Name)]
+    assert 'network' not in top_level_calls
+    assert top_level_calls.count('pressureDependence') == 1
+    assert top_level_calls[-1] == 'explorer'
 
 
 def test_multiple_bath_gases_warns_and_records_fractions_without_honoring_them(tmp_path):

--- a/tests/test_pdep/test_main_funnel.py
+++ b/tests/test_pdep/test_main_funnel.py
@@ -46,6 +46,7 @@ from t3.pdep.reason_codes import (REASON_INTERNAL_ERROR,
                                   STATUS_NOT_EVALUATED,
                                   STATUS_QUALIFIED,
                                   )
+from t3.pdep.diagram import T3_PES_DIAGRAM_FILENAME
 from t3.pdep.selector import CACHE_STATUS_GENERATED
 
 from tests.test_pdep._wiring_helpers import (NETWORK_NAME,
@@ -624,3 +625,54 @@ class TestTheRecordOnDisk(object):
             'the stale finished record must not have survived into this pass'
         records = load_pdep_network_assessments(_record_path(t3), allow_incomplete=True)
         assert [record.reason_code for record in records] == [REASON_INTERNAL_ERROR]
+
+
+class TestPESDiagram(object):
+    """The normalized-E0 PES diagram is drawn for every successfully-parsed network, but a
+    failure to draw it must never take the assessment down with it (see t3.main.py's
+    ``_draw_pdep_pes_diagram``).
+    """
+
+    def _diagram_path(self, t3):
+        return os.path.join(t3.paths['PDep SA'], NETWORK_NAME, T3_PES_DIAGRAM_FILENAME)
+
+    def test_a_successful_assessment_draws_the_pes_diagram(self, tmp_path, monkeypatch):
+        t3 = _build_t3(tmp_path)
+        pdep_rxns_to_explore = _build_pdep_rxns_to_explore(t3)
+        run_arkane_job, _ = _arkane_writing(t3, {'CSE': _build_sa_dict(t3)})
+        monkeypatch.setattr(t3_main, 'run_arkane_job', run_arkane_job)
+
+        t3.determine_species_from_pdep_network(pdep_rxns_to_explore=pdep_rxns_to_explore)
+
+        diagram_path = self._diagram_path(t3)
+        assert os.path.isfile(diagram_path)
+        assert os.path.getsize(diagram_path) > 0
+        with open(diagram_path, 'rb') as f:
+            assert f.read(8) == b'\x89PNG\r\n\x1a\n'
+        # Drawing the diagram is not allowed to have changed the assessment itself.
+        record = _sole_record(t3)
+        assert record.status == STATUS_QUALIFIED
+
+    def test_a_diagram_failure_is_a_logged_warning_not_a_crash(self, tmp_path, monkeypatch):
+        t3 = _build_t3(tmp_path)
+        pdep_rxns_to_explore = _build_pdep_rxns_to_explore(t3)
+        run_arkane_job, _ = _arkane_writing(t3, {'CSE': _build_sa_dict(t3)})
+        monkeypatch.setattr(t3_main, 'run_arkane_job', run_arkane_job)
+
+        logged_warnings = []
+        monkeypatch.setattr(t3.logger, 'warning', lambda message: logged_warnings.append(message))
+
+        def _raise(*args, **kwargs):
+            raise ValueError('a species with no E0, e.g.')
+
+        monkeypatch.setattr(t3_main, 'compute_pes_diagram_data', _raise)
+
+        t3.determine_species_from_pdep_network(pdep_rxns_to_explore=pdep_rxns_to_explore)
+
+        assert not os.path.isfile(self._diagram_path(t3))
+        assert any('PES diagram' in message and NETWORK_NAME in message for message in logged_warnings), \
+            'the diagram failure should have been logged as a warning naming the network'
+        # The assessment outcome itself must be unaffected by the diagram failure.
+        record = _sole_record(t3)
+        assert record.status == STATUS_QUALIFIED
+        assert record.reason_code == REASON_QUALIFIED_UNCERTAIN_TS

--- a/tests/test_pdep/test_main_funnel.py
+++ b/tests/test_pdep/test_main_funnel.py
@@ -676,3 +676,50 @@ class TestPESDiagram(object):
         record = _sole_record(t3)
         assert record.status == STATUS_QUALIFIED
         assert record.reason_code == REASON_QUALIFIED_UNCERTAIN_TS
+
+    def test_a_network_whose_sa_fails_still_gets_a_diagram(self, tmp_path, monkeypatch):
+        # The regression from a real campaign: network1_1's master-equation SA failed for every
+        # configured method (REASON_SA_ALL_METHODS_FAILED), and the assessment returned before ever
+        # reaching the success branch the diagram draw used to hang off. The network file itself was
+        # present and perfectly drawable throughout -- the diagram must not depend on the SA outcome.
+        t3 = _build_t3(tmp_path)
+        pdep_rxns_to_explore = _build_pdep_rxns_to_explore(t3)
+        run_arkane_job, calls = _arkane_writing(t3, {})  # every method reports failure
+        monkeypatch.setattr(t3_main, 'run_arkane_job', run_arkane_job)
+
+        t3.determine_species_from_pdep_network(pdep_rxns_to_explore=pdep_rxns_to_explore)
+
+        assert calls == list(t3.t3['sensitivity']['ME_methods']), 'every configured method should get a turn'
+        record = _sole_record(t3)
+        assert record.status == STATUS_NOT_EVALUATED
+        assert record.reason_code == REASON_SA_ALL_METHODS_FAILED
+        diagram_path = self._diagram_path(t3)
+        assert os.path.isfile(diagram_path), \
+            'the network file was resolvable and drawable regardless of what happened to the SA'
+        assert os.path.getsize(diagram_path) > 0
+        with open(diagram_path, 'rb') as f:
+            assert f.read(8) == b'\x89PNG\r\n\x1a\n'
+
+    def test_a_successful_assessment_draws_the_pes_diagram_exactly_once(self, tmp_path, monkeypatch):
+        # The diagram is now drawn ahead of the master-equation SA rather than after it. A network
+        # whose SA subsequently succeeds must still get exactly one diagram, not a second draw once
+        # the success branch is reached.
+        t3 = _build_t3(tmp_path)
+        pdep_rxns_to_explore = _build_pdep_rxns_to_explore(t3)
+        run_arkane_job, _ = _arkane_writing(t3, {'CSE': _build_sa_dict(t3)})
+        monkeypatch.setattr(t3_main, 'run_arkane_job', run_arkane_job)
+
+        draw_calls = []
+        original_render = t3_main.render_pes_diagram
+
+        def _counting_render(*args, **kwargs):
+            draw_calls.append(1)
+            return original_render(*args, **kwargs)
+
+        monkeypatch.setattr(t3_main, 'render_pes_diagram', _counting_render)
+
+        t3.determine_species_from_pdep_network(pdep_rxns_to_explore=pdep_rxns_to_explore)
+
+        assert len(draw_calls) == 1
+        record = _sole_record(t3)
+        assert record.status == STATUS_QUALIFIED

--- a/tests/test_pdep/test_main_funnel.py
+++ b/tests/test_pdep/test_main_funnel.py
@@ -78,7 +78,7 @@ def _arkane_writing(t3, payloads):
     """
     calls = list()
 
-    def _fake_run_arkane_job(input_file, output_directory, plot, logger):
+    def _fake_run_arkane_job(input_file, output_directory, logger):
         method = os.path.basename(output_directory)
         calls.append(method)
         if method not in payloads:

--- a/tests/test_pdep/test_parser.py
+++ b/tests/test_pdep/test_parser.py
@@ -12,6 +12,7 @@ import os
 import pytest
 
 from t3.common import TEST_DATA_BASE_PATH
+from t3.pdep.diagram import compute_pes_diagram_data
 from t3.pdep.hashing import hash_bytes, hash_file
 from t3.pdep.parser import (
     _call_keywords,
@@ -1233,3 +1234,72 @@ species(label='g', E0=(1000.0, 'K'))
                  "transitionState(label='TS1', E0=(2.0, 'kJ/mol'))")
         assert set(e0.species) == {'a'}
         assert set(e0.transition_states) == {'TS1'}
+
+
+class TestConstantExpressionE0:
+    """
+    RMG writes a transition state's ``E0`` as a constant arithmetic expression -- not a plain
+    literal -- whenever an energy correction was applied, e.g.
+    ``E0 = (264.497 - 411.735, "kJ/mol"), # removing the applied energy_correction``
+    (a real line from ``iteration_1/RMG/pdep/network1_1.py`` of a live campaign run). This class
+    covers the AST-folding that reads such expressions without ever executing the file.
+    """
+
+    def test_a_subtraction_expression_folds_to_the_expected_value(self):
+        e0 = parse_pdep_network_e0_text(
+            text="transitionState(label='TS1', E0=(264.497 - 411.735, \"kJ/mol\"))")
+        assert e0.transition_states['TS1'] == pytest.approx(264.497 - 411.735)
+
+    def test_plain_literals_still_parse_unchanged(self):
+        e0 = parse_pdep_network_e0_text(
+            text="species(label='a', E0=(1.5, 'kJ/mol'))\n"
+                 "species(label='b', E0=(-2.5, 'kJ/mol'))")
+        assert e0.species['a'] == pytest.approx(1.5)
+        assert e0.species['b'] == pytest.approx(-2.5)
+
+    def test_nested_and_mixed_operator_expressions_fold_correctly(self):
+        e0 = parse_pdep_network_e0_text(
+            text="species(label='a', E0=((1.0 + 2.0) * -(3.0 - 1.0) / 2.0, 'kJ/mol'))")
+        assert e0.species['a'] == pytest.approx((1.0 + 2.0) * -(3.0 - 1.0) / 2.0)
+
+    def test_a_name_in_the_numeric_half_is_refused(self):
+        with pytest.raises(ValueError, match='name'):
+            parse_pdep_network_e0_text(text="species(label='a', E0=(x - 1, 'kJ/mol'))")
+
+    def test_a_call_in_the_numeric_half_is_refused(self):
+        with pytest.raises(ValueError, match='call'):
+            parse_pdep_network_e0_text(text="species(label='a', E0=(f(1.0), 'kJ/mol'))")
+
+    def test_an_attribute_access_in_the_numeric_half_is_refused(self):
+        with pytest.raises(ValueError, match='attribute'):
+            parse_pdep_network_e0_text(text="species(label='a', E0=(obj.value, 'kJ/mol'))")
+
+    def test_division_by_a_folded_zero_is_refused(self):
+        with pytest.raises(ValueError, match='zero'):
+            parse_pdep_network_e0_text(text="species(label='a', E0=(1.0 / (2.0 - 2.0), 'kJ/mol'))")
+
+    def test_end_to_end_a_real_energy_corrected_ts_yields_a_relative_e0(self):
+        """The exact bug this fix closes: an energy-corrected TS from a real campaign network,
+        which used to leave every transition state's ``relative_e0`` as ``None`` (no E0 could
+        ever be read), now yields a real number all the way through
+        ``compute_pes_diagram_data``."""
+        # Shape lifted from the real 'network1_1.py' produced by a live T3 campaign run
+        # (iteration_1/RMG/pdep/network1_1.py); the comment RMG itself appends is kept verbatim.
+        text = """species(label='I', E0=(0.0, 'kJ/mol'))
+species(label='P', E0=(-5.0, 'kJ/mol'))
+transitionState(
+    label = 'TS1',
+    E0 = (264.497 - 411.735, "kJ/mol"), # removing the applied energy_correction
+    spinMultiplicity = 1,
+    opticalIsomers = 1,
+)
+reaction(label='r1', reactants=['I'], products=['P'], transitionState='TS1')
+network(label='N', isomers=['I'], reactants=[])
+"""
+        network = parse_pdep_network_text(text=text, network_id='synthetic')
+        e0 = parse_pdep_network_e0_text(text=text)
+        data = compute_pes_diagram_data(network=network, e0=e0)
+        (ts,) = data.transition_states
+        assert ts.label == 'TS1'
+        assert ts.relative_e0 is not None
+        assert ts.relative_e0 == pytest.approx((264.497 - 411.735) - 0.0)

--- a/tests/test_pdep/test_parser.py
+++ b/tests/test_pdep/test_parser.py
@@ -18,6 +18,8 @@ from t3.pdep.parser import (
     PDepArkaneReaction,
     parse_arkane_pdep_output_file,
     parse_arkane_pdep_output_text,
+    parse_pdep_network_e0_file,
+    parse_pdep_network_e0_text,
     parse_pdep_network_file,
     parse_pdep_network_text,
     to_json_safe,
@@ -1139,3 +1141,95 @@ def test_parse_pdep_network_file_strips_a_utf8_bom(tmp_path):
     network = parse_pdep_network_file(path=str(path))
     assert network.path_reactions
     assert network.source_hash == hash_file(path=str(path))
+
+
+class TestParsePDepNetworkE0:
+    """
+    The E0 reader that feeds T3's own PES diagram (``t3.pdep.diagram``): species and
+    transitionState ``E0 = (value, unit)`` keywords, converted to kJ/mol, read with the same
+    never-execute ast machinery as the rest of this module.
+    """
+
+    def test_real_fixture_values_network4_2(self):
+        e0 = parse_pdep_network_e0_file(path=os.path.join(PDEP_NETWORK_DIR, 'network4_2.py'))
+        assert len(e0.species) == 16
+        assert len(e0.transition_states) == 10
+        assert e0.species['butyl_2(67)'] == pytest.approx(52.4618)
+        assert e0.species['H(34)'] == pytest.approx(211.8)
+        assert e0.transition_states['TS1'] == pytest.approx(505.143)
+
+    def test_real_fixture_values_network799_1(self):
+        e0 = parse_pdep_network_e0_file(path=os.path.join(
+            TEST_DATA_BASE_PATH, 'pdep_real_networks', 'network799_1', 'network799_1.py'))
+        assert e0.species['O=C1OO1(21648)'] == pytest.approx(-170.357)
+        assert e0.transition_states['TS2'] == pytest.approx(-58.4241)
+
+    def test_every_rmg_energy_unit_is_converted_to_kj_per_mol(self):
+        text = """species(label='a', E0=(1000.0, 'J/mol'))
+species(label='b', E0=(2.5, 'kJ/mol'))
+species(label='c', E0=(1.0, 'kcal/mol'))
+species(label='d', E0=(1000.0, 'cal/mol'))
+species(label='e', E0=(1.0, 'eV/molecule'))
+species(label='f', E0=(100.0, 'cm^-1'))
+species(label='g', E0=(1000.0, 'K'))
+"""
+        e0 = parse_pdep_network_e0_text(text=text)
+        assert e0.species['a'] == pytest.approx(1.0)
+        assert e0.species['b'] == pytest.approx(2.5)
+        assert e0.species['c'] == pytest.approx(4.184)
+        assert e0.species['d'] == pytest.approx(4.184)
+        assert e0.species['e'] == pytest.approx(96.485332, abs=1e-4)
+        # h * c * 100 * Na = 11.9627 J/mol per cm^-1 (rmgpy.quantity's own conversion)
+        assert e0.species['f'] == pytest.approx(1.19627, abs=1e-4)
+        # R = 8.31446 J/(mol*K)
+        assert e0.species['g'] == pytest.approx(8.31446, abs=1e-4)
+
+    def test_an_unknown_unit_is_refused_not_guessed(self):
+        with pytest.raises(ValueError, match='furlong'):
+            parse_pdep_network_e0_text(text="species(label='a', E0=(1.0, 'furlong'))")
+
+    def test_a_non_literal_e0_is_refused_not_read_as_absent(self):
+        """An E0 that is a call (or any non-literal) must raise: silently treating it as absent
+        would later report 'this species has no E0' about a species whose file plainly gives one."""
+        with pytest.raises(ValueError, match='E0'):
+            parse_pdep_network_e0_text(text="species(label='a', E0=Quantity(1.0, 'kJ/mol'))")
+
+    def test_a_malformed_e0_shape_is_refused(self):
+        for bad in ("species(label='a', E0=5.0)",
+                    "species(label='a', E0=(1.0, 2.0))",
+                    "species(label='a', E0=(1.0, 'kJ/mol', 'extra'))"):
+            with pytest.raises(ValueError, match='E0'):
+                parse_pdep_network_e0_text(text=bad)
+
+    def test_a_missing_e0_is_absent_not_zero(self):
+        e0 = parse_pdep_network_e0_text(
+            text="species(label='a')\nspecies(label='b', E0=(1.0, 'kJ/mol'))")
+        assert 'a' not in e0.species
+        assert e0.species['b'] == pytest.approx(1.0)
+
+    def test_conflicting_duplicate_labels_are_refused(self):
+        """The same label declared twice with different E0 values is ambiguity, not data:
+        last-wins would silently pick one of two contradictory statements about one species."""
+        with pytest.raises(ValueError, match="'a'"):
+            parse_pdep_network_e0_text(
+                text="species(label='a', E0=(1.0, 'kJ/mol'))\n"
+                     "species(label='a', E0=(2.0, 'kJ/mol'))")
+        with pytest.raises(ValueError, match='TS1'):
+            parse_pdep_network_e0_text(
+                text="transitionState(label='TS1', E0=(1.0, 'kJ/mol'))\n"
+                     "transitionState(label='TS1', E0=(2.0, 'kJ/mol'))")
+
+    def test_an_identical_duplicate_is_tolerated(self):
+        """Two identical declarations carry no ambiguity; refusing them would refuse a file whose
+        meaning is perfectly clear."""
+        e0 = parse_pdep_network_e0_text(
+            text="species(label='a', E0=(1.0, 'kJ/mol'))\n"
+                 "species(label='a', E0=(1.0, 'kJ/mol'))")
+        assert e0.species['a'] == pytest.approx(1.0)
+
+    def test_transition_states_and_species_are_kept_apart(self):
+        e0 = parse_pdep_network_e0_text(
+            text="species(label='a', E0=(1.0, 'kJ/mol'))\n"
+                 "transitionState(label='TS1', E0=(2.0, 'kJ/mol'))")
+        assert set(e0.species) == {'a'}
+        assert set(e0.transition_states) == {'TS1'}

--- a/tests/test_runners/test_rmg_runner.py
+++ b/tests/test_runners/test_rmg_runner.py
@@ -6,6 +6,7 @@ t3 tests test_rmg_runner module
 """
 
 import os
+import subprocess
 import time
 
 import pytest
@@ -179,7 +180,9 @@ class TestRunArkaneJob(object):
                 f.write('some: data\n')
 
         monkeypatch.setattr('arc.statmech.arkane.run_arkane', fake_run_arkane)
-        assert run_arkane_job(input_file=input_file, output_directory=output_directory) is True
+        result = run_arkane_job(input_file=input_file, output_directory=output_directory)
+        assert bool(result) is True
+        assert result.timed_out is False
 
     def test_no_sa_coefficients_file_returns_false(self, tmp_path, monkeypatch):
         """Arkane runs without error but never writes sa_coefficients.yml -> False."""
@@ -190,7 +193,10 @@ class TestRunArkaneJob(object):
             pass  # writes nothing
 
         monkeypatch.setattr('arc.statmech.arkane.run_arkane', fake_run_arkane)
-        assert run_arkane_job(input_file=input_file, output_directory=output_directory) is False
+        result = run_arkane_job(input_file=input_file, output_directory=output_directory)
+        assert bool(result) is False
+        assert result.timed_out is False
+        assert 'did not produce' in result.reason
 
     def test_stale_pre_existing_sa_coefficients_file_returns_false(self, tmp_path, monkeypatch):
         """A pre-existing sa_coefficients.yml from a previous run, not rewritten -> deleted, False.
@@ -213,7 +219,7 @@ class TestRunArkaneJob(object):
             pass  # does not rewrite sa_coefficients.yml
 
         monkeypatch.setattr('arc.statmech.arkane.run_arkane', fake_run_arkane)
-        assert run_arkane_job(input_file=input_file, output_directory=output_directory) is False
+        assert bool(run_arkane_job(input_file=input_file, output_directory=output_directory)) is False
         assert not os.path.isfile(stale_path), \
             'The stale sa_coefficients.yml should have been deleted before Arkane was invoked.'
 
@@ -285,9 +291,9 @@ class TestRunArkaneJob(object):
                 f.write('# fresh artifact\n')
 
         monkeypatch.setattr('arc.statmech.arkane.run_arkane', fake_run_arkane_rewriting)
-        assert run_arkane_job(input_file=input_file,
-                              output_directory=output_directory,
-                              required_artifact='output.py') is True
+        assert bool(run_arkane_job(input_file=input_file,
+                                   output_directory=output_directory,
+                                   required_artifact='output.py')) is True
 
         with open(artifact_path, 'w') as f:
             f.write('# stale artifact from a previous run\n')
@@ -296,9 +302,9 @@ class TestRunArkaneJob(object):
             pass
 
         monkeypatch.setattr('arc.statmech.arkane.run_arkane', fake_run_arkane_writing_nothing)
-        assert run_arkane_job(input_file=input_file,
-                              output_directory=output_directory,
-                              required_artifact='output.py') is False
+        assert bool(run_arkane_job(input_file=input_file,
+                                   output_directory=output_directory,
+                                   required_artifact='output.py')) is False
         assert not os.path.isfile(artifact_path), \
             'The stale artifact should have been deleted before Arkane was invoked.'
 
@@ -314,7 +320,89 @@ class TestRunArkaneJob(object):
                 f.write('some: other data\n')
 
         monkeypatch.setattr('arc.statmech.arkane.run_arkane', fake_run_arkane)
-        assert run_arkane_job(input_file=input_file, output_directory=output_directory) is False
+        assert bool(run_arkane_job(input_file=input_file, output_directory=output_directory)) is False
+
+
+class TestRunArkaneJobTimeout(object):
+    """
+    Test run_arkane_job()'s ``timeout`` path: with a deadline, Arkane runs in a separate process
+    session that can actually be KILLED (in-process ARC calls cannot be; the subprocess ARC spawns
+    exposes no timeout and no PID -- see the design note in run_arkane_job's docstring), and a
+    deadline overrun surfaces as a falsy, ``timed_out`` result with a reason -- never as an
+    exception, which would destroy the run record the caller is building.
+    """
+
+    @staticmethod
+    def _write_input_file(tmp_path):
+        input_file = tmp_path / 'input.py'
+        input_file.write_text("# minimal Arkane input\n")
+        return str(input_file)
+
+    def test_overrunning_the_deadline_reports_timed_out_and_kills_the_process(self, tmp_path, monkeypatch):
+        """A run overrunning ``timeout`` is killed (whole process group), reaped, and reported as a
+        falsy result with ``timed_out`` set and the deadline named in the reason."""
+        input_file = self._write_input_file(tmp_path)
+        output_directory = str(tmp_path / 'output')
+        spawned = {}
+
+        def fake_spawn(output_directory):
+            proc = subprocess.Popen(['bash', '-c', 'sleep 60'], start_new_session=True)
+            spawned['proc'] = proc
+            return proc
+
+        monkeypatch.setattr('t3.runners.rmg_runner._spawn_arkane_subprocess', fake_spawn)
+        result = run_arkane_job(input_file=input_file, output_directory=output_directory, timeout=0.2)
+
+        assert bool(result) is False
+        assert result.timed_out is True
+        assert '0.2' in result.reason and 'timed out' in result.reason
+        assert spawned['proc'].poll() is not None, \
+            'The overrunning process must be dead and reaped, not abandoned to keep writing into ' \
+            'a run directory already declared failed.'
+
+    def test_finishing_within_the_deadline_succeeds(self, tmp_path, monkeypatch):
+        """A run that writes the required artifact and exits before ``timeout`` reports success --
+        the timeout guards the run, it must not fail a run that met it."""
+        input_file = self._write_input_file(tmp_path)
+        output_directory = str(tmp_path / 'output')
+
+        def fake_spawn(output_directory):
+            artifact_dir = os.path.join(output_directory, 'sensitivity')
+            return subprocess.Popen(
+                ['bash', '-c', f'mkdir -p "{artifact_dir}" && echo "some: data" > '
+                               f'"{os.path.join(artifact_dir, "sa_coefficients.yml")}"'],
+                start_new_session=True)
+
+        monkeypatch.setattr('t3.runners.rmg_runner._spawn_arkane_subprocess', fake_spawn)
+        result = run_arkane_job(input_file=input_file, output_directory=output_directory, timeout=30)
+
+        assert bool(result) is True
+        assert result.timed_out is False
+
+    def test_nonzero_exit_within_the_deadline_reports_failure(self, tmp_path, monkeypatch):
+        """A subprocess that dies (nonzero exit) before the deadline is a plain failure, mirroring
+        the in-process path's exception handling -- and is NOT labelled a timeout."""
+        input_file = self._write_input_file(tmp_path)
+        output_directory = str(tmp_path / 'output')
+
+        def fake_spawn(output_directory):
+            return subprocess.Popen(['bash', '-c', 'exit 3'], start_new_session=True)
+
+        monkeypatch.setattr('t3.runners.rmg_runner._spawn_arkane_subprocess', fake_spawn)
+        result = run_arkane_job(input_file=input_file, output_directory=output_directory, timeout=30)
+
+        assert bool(result) is False
+        assert result.timed_out is False
+        assert '3' in result.reason
+
+    @pytest.mark.parametrize('bad_timeout', [0, -5, float('inf'), float('nan'), True, '60'])
+    def test_invalid_timeout_is_refused(self, tmp_path, bad_timeout):
+        """A timeout that is not a positive finite number is an argument error, refused before any
+        side effect (no artifact deletion, no spawn)."""
+        input_file = self._write_input_file(tmp_path)
+        output_directory = str(tmp_path / 'output')
+        with pytest.raises(ValueError, match='timeout'):
+            run_arkane_job(input_file=input_file, output_directory=output_directory, timeout=bad_timeout)
 
 
 def teardown_module():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,6 +4,7 @@
 schema test module
 """
 
+import copy
 import os
 
 import pytest
@@ -17,6 +18,7 @@ from t3.schema import (IDTCriterionEnum,
                        T3Options,
                        T3Sensitivity,
                        T3Uncertainty,
+                       RMG,
                        RMGDatabase,
                        RMGSpecies,
                        RMGReactor,
@@ -1009,6 +1011,38 @@ def test_rmg_pdep_schema():
     with pytest.raises(ValidationError):
         # check that max_atoms is constrained to > 0
         RMGPDep(max_atoms=0)
+
+
+def test_rmg_pdep_requires_an_unreactive_species():
+    """
+    An RMG input with a pdep block and no unreactive species dies deep inside RMG's network
+    generation on ``assert len(bath_gas) > 0`` (rmgpy/rmg/pdep.py:857: the bath gas is every core
+    species with ``not spec.reactive``) -- hours into a run, with an AssertionError that names
+    nothing the user typed. The schema refuses it at input time instead, naming the fix.
+    Originally proposed in PR #60.
+    """
+    input_dict = read_yaml_file(path=os.path.join(EXAMPLES_BASE_PATH, 'pressure_dependence', 'input.yml'))
+    rmg_dict = input_dict['rmg']
+    assert any(spec.get('reactive') is False for spec in rmg_dict['species']), \
+        "fixture precondition: the pressure_dependence example must declare an inert (reactive: " \
+        "false) species -- it enables pdep, so without one it would itself crash RMG's network " \
+        "generation"
+
+    # The example as shipped (with its inert species) validates.
+    RMG(**rmg_dict)
+
+    # The same input with every species reactive is refused, and the message says why and what to do.
+    all_reactive = copy.deepcopy(rmg_dict)
+    for spec in all_reactive['species']:
+        spec.pop('reactive', None)
+    with pytest.raises(ValidationError, match='reactive'):
+        RMG(**all_reactive)
+
+    # Without a pdep block, all-reactive species are fine: the rule is about pdep's bath gas
+    # requirement, not a general demand for inerts.
+    no_pdep = copy.deepcopy(all_reactive)
+    del no_pdep['pdep']
+    RMG(**no_pdep)
 
 
 def test_rmg_species_constraints_schema():


### PR DESCRIPTION
Fixes #183.

## What this PR does

Four commits, one theme: make the PDep PES-explorer path work on real RMG output, and make its collider handling fail early, loudly, and killably.

1. **`fix(pdep)`: inject `reactive=False` for declared bath-gas species** — the core defect. `write_arkane_explorer_input_file` required every bath-gas label to be a `species()` block already carrying a literal `reactive=False` in the *source*. No RMG-written network file can satisfy that: `arkane/pdep.py:654` (`save_input_file`, the writer RMG calls at `rmgpy/rmg/pdep.py:869`) never emits a `reactive` keyword for any species. The rule therefore refused every real `pdep/network<i>_<n>.py` — the whole feature path was unusable on real RMG output, and the suite stayed green only because its fixtures were hand-built strings (the old test-module docstring conceded as much).
2. **`fix(pdep)`: refuse a missing/empty `bath_gas` at config construction** — `PDepExplorerConfig(bath_gas=None)` used to pass construction and only fail at write time, *after* the adapter's rule-0 `os.mkdir` had claimed the run directory (which rule 0 then refuses forever, by design). Now refused where it is built, per the class's own documented validation layering.
3. **`feat(pdep)`: configurable, enforceable timeout for Arkane explorer runs** — `run_arkane_job` had no timeout and no kill path; a hung Arkane hung the campaign. New `timeout` (seconds) on `PDepExplorerConfig`, threaded through `explore_pdep_network → explorer_factory → ArkaneExplorerAdapter → run_arkane_job`. A deadline overrun surfaces as a **`failed` result with a distinguishable `timed_out` reason — never an exception** that would destroy the run record.
4. **`feat(schema)`: refuse an `rmg.pdep` input with no unreactive species** — `rmgpy/rmg/pdep.py:856-858` asserts `len(bath_gas) > 0` (`[spec for spec in core.species if not spec.reactive]`) inside every network update, so a pdep input with all-reactive species parses cleanly and dies hours later with an AssertionError naming nothing the user typed. Refused at schema time with a message naming the fix. **Credit: this is the surviving idea from #60** (closed as superseded). T3's own `examples/pressure_dependence/input.yml` exhibited exactly this bug; it now declares N2 `reactive: false` and doubles as the test fixture.

## The design decision, argued

Issue #183 left open whether to (a) default `config.bath_gas` from the source's `network(...) bathGas` block, (b) inject `reactive=False` on the species blocks T3 emits, or both. This PR implements **(b) only**: the caller's `bath_gas` declaration on `PDepExplorerConfig` is the authority, and the writer emits `reactive = False` into each declared bath-gas `species()` block that carries no `reactive` keyword.

Why injection is legitimate: the destination file is one **T3 generates**, and "this species is the bath gas" is a fact the caller has already declared — writing it in Arkane's encoding is a faithful translation between two encodings of one fact, not a rewrite of user input. And the literal keyword is the only channel that works: the explorer's own `make_new_species(spec, reactive=False)` (`arkane/explorer.py:141`) is overridden when the species enters the core, because `rmgpy/rmg/model.py:475` re-reads `reactive = object.reactive` from the loaded species object (verified directly against RMG-Py source for this PR).

Why **not** network-derived defaulting (considered, deliberately dropped):

- The `network(...)` block's fractions are not a user request to honor. RMG writes them *after* `PDepNetwork.update()` has overwritten the composition with equal weights over every unreactive core species (`rmgpy/rmg/pdep.py:857-863`), so defaulting would launder an RMG artifact into this run's recorded "requested" composition — fabricated provenance for an expensive QM run.
- Requiring the declaration removes the `bath_gas=None` trap *entirely* (commit 2). A default resolved at write time re-creates the same failure class it fixes: a source without a `network(...)` block, or with a non-literal `bathGas`, would again fail only after the run directory was claimed.
- Nothing is lost: any caller driving `explore_pdep_network` necessarily knows which inerts the producing RMG job declared, and the writer still refuses a declared label that is not a `species()` block in the source.

The only cases still refused on the reactive keyword are the genuinely unresolvable ones: an explicit literal `reactive=True` on a declared bath-gas species (a contradiction the writer must not silently resolve in either direction), and a non-literal `reactive` value (verifiable neither as conflict nor as already-unreactive).

## What was verified, and how

- **Issue #183's central claims** were verified against RMG-Py source when the issue was filed (`arkane/pdep.py:654` writes no `reactive`; `rmgpy/rmg/pdep.py:856-869` populates `bathGas` and asserts a non-empty inert set); the `rmgpy/rmg/model.py:475` override was verified additionally for this PR.
- **The real RMG-written fixture** (`tests/data/pdep_network/iteration_1/RMG/pdep/network4_2.py`, whose He/Ne blocks carry no `reactive` keyword — the exact shape of the defect) now round-trips end-to-end in `test_real_rmg_network_file_writes_end_to_end`: generated input parses, He/Ne carry `reactive=False`, `network(...)` dropped, `explorer(...)` appended last.
- **Kill path**: tested against real spawned processes (`bash -c 'sleep 60'` in its own session), asserting the overrun is reported `timed_out` with the deadline named and the process actually dead and reaped; plus deadline-met success, nonzero-exit-not-labelled-timeout, and refusal of unenforceable deadlines (0, negative, inf, nan, bool, str).
- **Suites** (this env's openbabel install is broken independently of this branch, stubbed with a local pytest plugin): `tests/test_pdep` — 371 passed, 0 failed (354 baseline + 17 new); `tests/test_runners/test_rmg_runner.py` + `tests/test_schema.py` — 45 passed plus the 3 pre-existing, unrelated `TestWriteSubmitScript` failures that exist on `main` as well.

**Not verified here**: no live Arkane/RMG exploration was run (environment-bound; the timeout mechanics are exercised with stand-in process trees, and the session/process-group kill is shape-agnostic, but a real `conda run` Arkane tree was not killed in CI). The subprocess timeout path assumes `arc` is importable by `sys.executable` — true wherever `run_arkane_job` itself was imported, since it imports `arc.statmech.arkane` in-process too.

## Compatibility notes

- `run_arkane_job` now returns an `ArkaneJobResult` (truthy exactly on success, `__bool__`), so every existing truthiness caller (`t3.main`, the ME-solver adapter) keeps working; only identity comparisons (`is True`) would break, and the repo had those only in tests (updated).
- `PDepExplorerConfig` now requires a non-empty `bath_gas` — an intentional break: every such config was already guaranteed to fail at write time.
