### PR TITLE
fix(main): keep reaction label/reactants/products/r_species in sync across namespaces

### DIFF
--- a/t3/main.py
+++ b/t3/main.py
@@ -3255,25 +3255,55 @@ class T3:
             reaction.label = ' <=> '.join([' + '.join([spc.label for spc in full_reactants]),
                                            ' + '.join([spc.label for spc in full_products])])
 
+            # reaction.reactants/products (plain string lists) must track reaction.label/r_species/
+            # p_species, or ARC's check_attributes() raises (reverse membership test against
+            # reaction.label). Built from the deduplicated r_species/p_species (not the
+            # stoichiometry-expanded full_reactants/full_products), since multiplicity is encoded
+            # in the label text alone (e.g., "OH[2] + OH[2]") and re-derived from it via
+            # get_species_count().
+            reaction.reactants = [spc.label for spc in reaction.r_species]
+            reaction.products = [spc.label for spc in reaction.p_species]
+
             reaction.reactant_keys = [self.get_species_key(species=spc) for spc in full_reactants]
             reaction.product_keys = [self.get_species_key(species=spc) for spc in full_products]
 
             reaction.rmg_label = reaction.label or str(reaction)
 
-            qm_label = ' <=> '.join([' + '.join([spc.label for spc in species_list])
-                                     for species_list in [full_reactants, full_products]])
-
-            reaction.label = qm_label
-            reaction.qm_label = qm_label
-
             self.reactions[rxn_key] = reaction
 
+            # qm_reaction is a separate object handed off to ARC for QM/TS calculations: its
+            # r_species/p_species get qm-labelled copies (e.g., "s0_CHO"), so its label and
+            # reactants/products must be rebuilt in that same qm-labelled namespace too, or ARC's
+            # Scheduler (which rebuilds species by string-matching label/reactants/products against
+            # r_species/p_species) silently fails to match anything and proceeds with atomless TS
+            # species.
+            # get_species_with_qm_label() is deterministic per species key, so applying it to both
+            # the deduplicated r_species/p_species (for qm_reaction.r_species/p_species and
+            # reactants/products) and to the stoichiometry-expanded full_reactants/full_products
+            # (for the label text only) yields the same qm labels either way, keeping the same
+            # stoichiometry encoding (e.g., "s2_OH + s2_OH") that reaction.label uses.
+            qm_r_species = [get_species_with_qm_label(species=spc, key=self.get_species_key(species=spc))
+                           for spc in reaction.r_species]
+            qm_p_species = [get_species_with_qm_label(species=spc, key=self.get_species_key(species=spc))
+                           for spc in reaction.p_species]
+            full_reactants_qm = [get_species_with_qm_label(species=spc, key=self.get_species_key(species=spc))
+                                 for spc in full_reactants]
+            full_products_qm = [get_species_with_qm_label(species=spc, key=self.get_species_key(species=spc))
+                                for spc in full_products]
+
             qm_reaction = reaction.copy()
-            qm_reaction.r_species = [get_species_with_qm_label(species=spc, key=self.get_species_key(species=spc))
-                                     for spc in full_reactants]
-            qm_reaction.p_species = [get_species_with_qm_label(species=spc, key=self.get_species_key(species=spc))
-                                     for spc in full_products]
-            qm_reaction.label = qm_label
+            qm_reaction.r_species = qm_r_species
+            qm_reaction.p_species = qm_p_species
+            qm_reaction.label = ' <=> '.join([' + '.join([spc.label for spc in full_reactants_qm]),
+                                              ' + '.join([spc.label for spc in full_products_qm])])
+            qm_reaction.reactants = [spc.label for spc in qm_reaction.r_species]
+            qm_reaction.products = [spc.label for spc in qm_reaction.p_species]
+
+            # reaction.qm_label must equal qm_reaction.label exactly: process_arc_run() later looks
+            # up the T3 reaction by get_reaction_key(label=<ARC's reported label>), which compares
+            # against t3_reaction.qm_label. ARC reports results using qm_reaction's own label (the
+            # object it actually ran), so the round trip only closes if these two match.
+            reaction.qm_label = qm_reaction.label
 
             self.qm['reactions'].append(qm_reaction)
             return rxn_key

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1363,12 +1363,151 @@ def test_add_reaction():
     t3.add_reaction(reaction=rmg_rxn_1, reasons='reason 4')
     assert t3.get_reaction_key(reaction=rmg_rxn_1) == 3
     assert t3.reactions[3].rmg_label == 'H + CH4 <=> CH3 + H2'
-    # qm_label is built from species labels (these species have simple labels, no RMG index)
-    assert t3.reactions[3].qm_label == 'H + CH4 <=> CH3 + H2'
+    # qm_label is built in the qm-labelled namespace (matching the qm_reaction handed off to ARC),
+    # not in the RMG/core namespace that rmg_label/label use.
+    assert t3.reactions[3].qm_label == t3.qm['reactions'][-1].label
+    assert re.match(r's\d+_H \+ s\d+_CH4 <=> s\d+_CH3 \+ s\d+_H2', t3.reactions[3].qm_label)
     assert isinstance(t3.reactions[3], T3Reaction)
     assert t3.reactions[3].reasons == ['reason 4']
     assert t3.reactions[3].is_converged is False
     assert t3.reactions[3].created_at_iteration == 1
+
+
+def test_add_reaction_resolves_reactant_product_namespace():
+    """
+    Regression test for a reaction whose incoming r_species/p_species labels differ from the
+    labels of the already-stored (isomorphic) species (e.g. the formyl radical spelled 'CHO' in
+    the Chemkin dictionary vs '[CH]=O' in a pdep network file, both resolving to the same stored
+    T3Species by isomorphism). After add_reaction(), reaction.label, reaction.reactants/products
+    and reaction.r_species/p_species must all be mutually consistent in the SAME (stored/core)
+    namespace, or ARC's check_attributes() raises a ReactionError.
+    """
+    t3 = T3(project='test_add_reaction_namespace',
+           project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_reactions'),
+           t3=t3_minimal,
+           rmg=rmg_minimal,
+           qm=qm_minimal,
+           )
+    # Pre-populate self.species with the formyl radical under its "core" label.
+    cho_core = T3Species(label='CHO', smiles='[CH]=O')
+    co_species = T3Species(label='CO', smiles='[C-]#[O+]')
+    o2_species = T3Species(label='O2', smiles='[O][O]')
+    ho2_species = T3Species(label='HO2', smiles='[O]O')
+    t3.add_species(species=cho_core, reasons='seed core species')
+    t3.add_species(species=co_species, reasons='seed core species')
+    t3.add_species(species=o2_species, reasons='seed core species')
+    t3.add_species(species=ho2_species, reasons='seed core species')
+
+    # The incoming reaction uses an isomorphic but differently-spelled label for the formyl
+    # radical ('[CH]=O' instead of the already-stored 'CHO'), simulating the pdep-network vs
+    # Chemkin-dictionary label mismatch.
+    cho_isomorphic = T3Species(label='[CH]=O', smiles='[CH]=O')
+    reaction = T3Reaction(label='[CH]=O + O2 <=> CO + HO2',
+                          r_species=[cho_isomorphic, o2_species],
+                          p_species=[co_species, ho2_species],
+                          kinetics=Arrhenius(A=(1, 'cm^3/(mol*s)'), n=0, Ea=(0, 'kJ/mol'), comment='kinetic comment'))
+    t3.add_reaction(reaction=reaction, reasons='reason')
+
+    rxn_key = t3.get_reaction_key(reaction=reaction)
+    stored_reaction = t3.reactions[rxn_key]
+
+    # label, reactants/products and r_species/p_species must all agree on the same (core) namespace.
+    assert set(stored_reaction.reactants) == {spc.label for spc in stored_reaction.r_species}
+    assert set(stored_reaction.products) == {spc.label for spc in stored_reaction.p_species}
+    stored_reaction.check_attributes()  # must not raise
+
+
+def test_add_reaction_deduplicates_reactants_products_stoichiometry():
+    """
+    Regression test: a reaction with a repeated species on one side (H + HO2 <=> OH + OH) must
+    keep reaction.reactants/products deduplicated (no repeated 'OH' entry), while reaction.label
+    keeps the full stoichiometry-expanded text ('OH + OH'), and check_attributes() passes.
+    """
+    t3 = T3(project='test_add_reaction_stoichiometry',
+           project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_reactions'),
+           t3=t3_minimal,
+           rmg=rmg_minimal,
+           qm=qm_minimal,
+           )
+    h_species = T3Species(label='H', smiles='[H]')
+    ho2_species = T3Species(label='HO2', smiles='[O]O')
+    oh_species_1 = T3Species(label='OH', smiles='[OH]')
+    oh_species_2 = T3Species(label='OH', smiles='[OH]')
+
+    reaction = T3Reaction(label='H + HO2 <=> OH + OH',
+                          r_species=[h_species, ho2_species],
+                          p_species=[oh_species_1, oh_species_2],
+                          kinetics=Arrhenius(A=(1, 'cm^3/(mol*s)'), n=0, Ea=(0, 'kJ/mol'), comment='kinetic comment'))
+    t3.add_reaction(reaction=reaction, reasons='reason')
+
+    rxn_key = t3.get_reaction_key(reaction=reaction)
+    stored_reaction = t3.reactions[rxn_key]
+
+    assert stored_reaction.products.count('OH') == 1
+    assert 'OH + OH' in stored_reaction.label
+    stored_reaction.check_attributes()  # must not raise
+
+
+def test_add_reaction_qm_reaction_namespace_consistency():
+    """
+    Regression test: the qm_reaction object handed off to ARC (self.qm['reactions'][-1]) must have
+    reactants/products matching its own r_species/p_species labels, mimicking ARC's Scheduler
+    string-match logic (arc/scheduler.py:371-378), which rebuilds species objects by testing
+    e.g. 's0_CHO' in qm_reaction.reactants.
+    """
+    t3 = T3(project='test_add_reaction_qm_consistency',
+           project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_reactions'),
+           t3=t3_minimal,
+           rmg=rmg_minimal,
+           qm=qm_minimal,
+           )
+    h_species = T3Species(label='H', smiles='[H]')
+    ch4_species = T3Species(label='CH4', smiles='C')
+    ch3_species = T3Species(label='CH3', smiles='[CH3]')
+    h2_species = T3Species(label='H2', smiles='[H][H]')
+
+    reaction = T3Reaction(label='H + CH4 <=> CH3 + H2',
+                          r_species=[h_species, ch4_species],
+                          p_species=[ch3_species, h2_species],
+                          kinetics=Arrhenius(A=(1, 'cm^3/(mol*s)'), n=0, Ea=(0, 'kJ/mol'), comment='kinetic comment'))
+    t3.add_reaction(reaction=reaction, reasons='reason')
+
+    qm_reaction = t3.qm['reactions'][-1]
+    for spc in qm_reaction.r_species + qm_reaction.p_species:
+        # This is the exact check ARC's Scheduler performs (arc/scheduler.py:371-378) to rebuild
+        # species objects from the reaction's plain reactants/products string lists.
+        assert spc.label in qm_reaction.reactants or spc.label in qm_reaction.products
+
+
+def test_add_reaction_qm_label_round_trip():
+    """
+    Regression test: after add_reaction(), simulating an ARC result reported using the
+    qm_reaction's own label string must round-trip back to the same T3 reaction via
+    get_reaction_key(label=...), which compares against t3_reaction.qm_label.
+    """
+    t3 = T3(project='test_add_reaction_qm_label_round_trip',
+           project_directory=os.path.join(TEST_DATA_BASE_PATH, 'determine_reactions'),
+           t3=t3_minimal,
+           rmg=rmg_minimal,
+           qm=qm_minimal,
+           )
+    h_species = T3Species(label='H', smiles='[H]')
+    ch4_species = T3Species(label='CH4', smiles='C')
+    ch3_species = T3Species(label='CH3', smiles='[CH3]')
+    h2_species = T3Species(label='H2', smiles='[H][H]')
+
+    reaction = T3Reaction(label='H + CH4 <=> CH3 + H2',
+                          r_species=[h_species, ch4_species],
+                          p_species=[ch3_species, h2_species],
+                          kinetics=Arrhenius(A=(1, 'cm^3/(mol*s)'), n=0, Ea=(0, 'kJ/mol'), comment='kinetic comment'))
+    t3.add_reaction(reaction=reaction, reasons='reason')
+
+    rxn_key = t3.get_reaction_key(reaction=reaction)
+    qm_reaction = t3.qm['reactions'][-1]
+
+    # ARC reports results using the label of the reaction object it actually ran (qm_reaction).
+    arc_reported_label = qm_reaction.label
+    assert t3.get_reaction_key(label=arc_reported_label) == rxn_key
 
 
 def test_dump_species():


### PR DESCRIPTION
## Summary

`add_reaction()` in `t3/main.py` treats a reaction's `label`, `reactants`/`products`
(plain string lists), and `r_species`/`p_species` (species objects) as three views of
one fact that ARC requires to stay mutually consistent. Two places broke that
invariant when a species arrives under a label that differs from (but is isomorphic
to) the one already stored in `self.species` -- e.g. formyl radical spelled `CHO`
in the Chemkin dictionary vs `[CH]=O` in a pdep network file, both resolving to the
same stored species via `get_species_key`'s isomorphism match.

### Bug 1 (crash)

`reaction.r_species`/`p_species` and `reaction.label` were resolved to the stored
(core) namespace, but `reaction.reactants`/`products` were never touched -- left in
whatever namespace the incoming species arrived under. ARC's `check_attributes()`
then raises `ReactionError` because e.g. `CHO[6]` (from the label) is not found in
`reaction.reactants` (still `[CH]=O[6]`).

Real-run evidence: `/home/alon/runs/t3-pes-CHO2/t3_stderr.log`,
`/home/alon/runs/t3-pes-CHO2/iteration_1/ARC/input.yml`.

ARC does not self-heal this: `set_label_reactants_products` (`arc/reaction/reaction.py:417,450`)
only fills in `reactants`/`products` when they are empty -- with both already populated
(just stale) it's a no-op.

**Fix**: `reaction.reactants`/`products` are now built from the deduplicated
`reaction.r_species`/`p_species` (not the stoichiometry-expanded `full_reactants`/
`full_products`, which would duplicate entries -- e.g. two `OH` for
`H + HO2 <=> OH + OH` -- and break `check_attributes()`'s reverse membership test).
Multiplicity stays encoded in the label text alone (`"OH[2] + OH[2]"`), which ARC's
`get_species_count()` parses back out.

### Bug 2 (silent, more dangerous than Bug 1)

`qm_reaction` (the copy of `reaction` handed off to ARC for QM/TS calculations) got
qm-labelled `r_species`/`p_species` (e.g. `s0_CHO`), but its `label`/`reactants`/
`products` stayed in the original core namespace. ARC's Scheduler rebuilds species
objects by pure string match against `reactants`/`products`
(`arc/scheduler.py:371-378`), e.g. `'s0_CHO' in ['CHO[6]', 'OH[2]']` -- false for every
species. This does **not** raise: the relevant `check_attributes()` blocks are
guarded by `if len(...)`, `ts_species.number_of_atoms` becomes 0, and
`check_atom_balance` short-circuits via `if r_well:` and returns `True`. ARC silently
proceeds with atomless TS species and reactions with no reactants -- worse than a
crash because nothing flags it.

**Fix**: `qm_reaction.label`, `.reactants`, and `.products` are now all rebuilt in the
qm-labelled namespace, consistent with `qm_reaction.r_species`/`p_species`, using the
same stoichiometry-expansion approach as `reaction.label`.

### qm_label round trip

`reaction.qm_label` is the key `process_arc_run()` uses later to match ARC's reported
results back to the right T3 reaction: `get_reaction_key(label=reaction['label'])`
compares against `t3_reaction.qm_label`. Moving `qm_reaction.label` into the
qm-labelled namespace (required to fix Bug 2) means `reaction.qm_label` must move
with it -- it is now set from `qm_reaction.label` directly, so it matches exactly what
ARC reports (ARC runs `qm_reaction`, not `reaction`). Meanwhile `reaction.label` and
`reaction.rmg_label` stay in the RMG/core namespace, unaffected.

## Test plan

Added 4 regression tests to `tests/test_main.py` (plus updated one existing
assertion in `test_add_reaction` that encoded the old, buggy qm_label value):

- [x] `test_add_reaction_resolves_reactant_product_namespace` -- isomorphic-but-differently-labelled
      species resolve to a mutually consistent `label`/`reactants`/`products`/`r_species`/`p_species`;
      `check_attributes()` does not raise.
- [x] `test_add_reaction_deduplicates_reactants_products_stoichiometry` -- `H + HO2 <=> OH + OH`
      keeps `reactants`/`products` deduplicated while the label retains the full `OH + OH`
      stoichiometry text; `check_attributes()` passes.
- [x] `test_add_reaction_qm_reaction_namespace_consistency` -- `qm_reaction.reactants`/`products`
      match `qm_reaction.r_species`/`p_species` labels, mimicking ARC's Scheduler string-match.
- [x] `test_add_reaction_qm_label_round_trip` -- simulating an ARC result reported using
      `qm_reaction.label` round-trips back to the same T3 reaction via
      `get_reaction_key(label=...)`.

```
source ~/anaconda3/etc/profile.d/conda.sh && conda activate t3_env
cd T3-rxn-namespace
python -m pytest tests/test_main.py -q
```

- Baseline (before fix): 41 passed, 0 failed.
- After fix + new tests: 45 passed, 0 failed.