### PR TITLE
fix(chem): stop T3Species from clobbering the thermo container it inherits from ARCSpecies

### DIFF
--- a/t3/chem.py
+++ b/t3/chem.py
@@ -156,7 +156,14 @@ class T3Species(ARCSpecies):
         self.formula = self.mol.get_formula()
         _dict_qm_label = _t3_dict.pop('qm_label', None) if _t3_dict else None
         self.qm_label = _dict_qm_label or t3_extras.get('qm_label') or f"s{self.key}_{self.formula}"
-        self.thermo = thermo
+        # Only override when the caller actually supplied thermo. ``ARCSpecies.__init__`` (called
+        # above) guarantees ``self.thermo`` is a ``ThermoData()``, and ARC relies on that invariant:
+        # ``parse_arkane_thermo_output`` does ``spc.thermo.H298 = ...`` on the very objects T3 hands
+        # it, without a None check. An unconditional assignment here therefore reset the attribute
+        # to None for every T3-created species and crashed ARC at the *reporting* stage -- after all
+        # of its QM had already converged, discarding a completed run.
+        if thermo is not None:
+            self.thermo = thermo
 
         if thermo_method is None:
             self.thermo_method: ThermoMethod | None = None

--- a/tests/test_chem.py
+++ b/tests/test_chem.py
@@ -11,7 +11,7 @@ import re
 
 import pytest
 
-from arc.species.species import ARCSpecies
+from arc.species.species import ARCSpecies, ThermoData
 
 from t3.chem import (
     T3Status,
@@ -259,6 +259,30 @@ class TestT3Species:
         assert 'T3Species' in repr_str
         assert 'H2' in repr_str
         assert 'pending' in repr_str
+
+    def test_thermo_defaults_to_arcspecies_container(self):
+        """A T3Species built without ``thermo`` keeps the ThermoData container ARCSpecies sets up.
+
+        ARC writes straight through this attribute -- ``parse_arkane_thermo_output`` does
+        ``spc.thermo.H298 = ...`` with no None check -- on the very objects T3 hands it. Clobbering
+        the inherited default with None crashed ARC at the reporting stage, after its QM had
+        already converged.
+        """
+        spc = T3Species(label='CH2O2', smiles='OC=O')
+
+        assert spc.thermo is not None
+        assert isinstance(spc.thermo, ThermoData)
+
+        # The contract ARC actually relies on: the attribute is writable through.
+        spc.thermo.H298 = -378.6
+        assert spc.thermo.H298 == -378.6
+
+    def test_thermo_is_honoured_when_supplied(self):
+        """An explicitly supplied thermo still wins over the inherited default."""
+        spc = T3Species(label='CH2O2', smiles='OC=O', thermo=ThermoData(comment='supplied'))
+
+        assert spc.thermo.comment == 'supplied'
+
 
 class TestT3Reaction:
     """Tests for T3Reaction class."""


### PR DESCRIPTION
## The bug

`T3Species` subclasses `ARCSpecies`, whose `__init__` unconditionally sets `self.thermo = ThermoData()`. `T3Species.__init__` then ran, at `t3/chem.py:158`:

```python
self.thermo = thermo          # thermo: Any | None = None
```

so **every species T3 creates reached ARC with `thermo is None`** — an invariant no ARCSpecies is supposed to violate.

ARC writes straight through that attribute. `parse_arkane_thermo_output` (`arc/statmech/arkane.py`) does:

```python
spc.thermo.H298 = content[lbl]['H298']
```

with no None check, on the very objects T3 handed it. Hence:

```
AttributeError: 'NoneType' object has no attribute 'H298'
```

## Why it is worth fixing carefully

This fires at the **reporting** stage — *after* every QM job in the run has already converged on the cluster. It discards a complete, successful computation at the last step. It killed a live PDep campaign run whose Gaussian jobs had all finished.

It also presents as an ARC bug, which is where the search naturally starts and where nothing is found: no ARC production code assigns `None` to `thermo`, `ARCSpecies.__init__` sets the default unconditionally, and `from_dict` never touches it. The `None` is injected across the T3→ARC boundary by the subclass.

## The fix

Assign only when the caller actually supplied `thermo`.

`None` was never a meaningful sentinel here:

- nothing in T3 reads the attribute — the only `.thermo` hits in the package are Cantera reactor states (`t3/simulate/*`, `t3/utils/flux.py`) and an unrelated `Entry` class in `t3/utils/rmg_shim.py`;
- `T3Species.as_dict` does not serialise `thermo`, so it never round-trips.

The attribute was write-only, and the write existed only to destroy ARC's default. Callers that *do* pass a real `ThermoData` (several tests in `tests/test_main.py`) are unaffected.

## Verification

The regression test fails on `main`:

```
>       assert spc.thermo is not None
E       AssertionError: assert None is not None
E        +  where None = <T3Species 's0_CH2O2' status: pending>.thermo
```

`s0_CH2O2` is the same species label that appears in the crashed run's `thermo.yaml`.

On this branch:

```
tests/test_chem.py .............................................. 48 passed
tests/test_chem.py tests/test_common.py tests/test_main.py tests/test_schema.py
157 passed, 47 warnings in 326.39s
```

## Relationship to ARC #995

ARC [#995](https://github.com/ReactionMechanismGenerator/ARC/pull/995) guards the same crash at the use site. The two are complementary rather than redundant: #995 keeps ARC robust against *any* caller handing it a species with no thermo container, while this PR removes the only known producer of that state. This PR is the root-cause fix; #995 is the defence in depth.