### PR TITLE
fix(chem): filter ARC species kwargs by the signature ARC actually has

### DIFF
--- a/t3/chem.py
+++ b/t3/chem.py
@@ -7,6 +7,7 @@ underlying chemical definitions found in ARC.
 """
 
 from __future__ import annotations
+import inspect
 from enum import Enum
 from typing import Any
 
@@ -565,9 +566,9 @@ def remove_bad_arc_keys(species_dict: dict) -> dict:
         'recent_md_conformer',
         'rotors_dict',  # Complex internal dictionary
         'number_of_rotors',
-        '_radius',
-        '_is_linear',
-        '_number_of_atoms',
+        'radius',  # ARCSpecies stores it as ``_radius`` but ``as_dict()`` emits it unprefixed
+        'is_linear',
+        'number_of_atoms',
         'mol_list',  # Derived from mol
 
         # Thermo / Transport Outputs
@@ -603,4 +604,31 @@ def remove_bad_arc_keys(species_dict: dict) -> dict:
         'neg_freqs_trshed'
     }
 
-    return {k: v for k, v in species_dict.items() if k not in bad_keys}
+    species_dict = {k: v for k, v in species_dict.items() if k not in bad_keys}
+
+    # A hand-maintained blocklist can only reject the keys someone thought of, and it silently
+    # stops matching whenever ARC renames an attribute or starts serializing a new one. Because
+    # ``ARCSpecies.__init__`` takes no ``**kwargs``, every miss becomes a ``TypeError`` at the
+    # call site rather than an ignored key -- which is how ``radius`` (blocked as ``_radius``,
+    # emitted as ``radius``) broke ``T3Species.copy()``, but only after something had touched the
+    # lazily-computed property, making the failure look intermittent. Filter against the real
+    # signature so an unforeseen key is dropped instead of raising.
+    accepted = _arc_species_init_args()
+    if accepted is None:
+        return species_dict
+    return {k: v for k, v in species_dict.items() if k in accepted}
+
+
+def _arc_species_init_args() -> set | None:
+    """
+    Get the keyword arguments ``ARCSpecies.__init__`` actually accepts.
+
+    Returns: set | None
+        The accepted argument names, or ``None`` if ``ARCSpecies.__init__`` declares ``**kwargs``
+        and therefore tolerates anything -- in which case filtering could only drop keys ARC wants.
+    """
+    params = inspect.signature(ARCSpecies.__init__).parameters
+    if any(param.kind == param.VAR_KEYWORD for param in params.values()):
+        return None
+    return {name for name, param in params.items()
+            if name != 'self' and param.kind != param.VAR_POSITIONAL}

--- a/tests/test_chem.py
+++ b/tests/test_chem.py
@@ -6,7 +6,12 @@ t3 tests test_chem module
 Tests for t3/chem.py - T3Species and T3Reaction classes
 """
 
+import inspect
+import re
+
 import pytest
+
+from arc.species.species import ARCSpecies
 
 from t3.chem import (
     T3Status,
@@ -14,6 +19,7 @@ from t3.chem import (
     KineticsMethod,
     T3Species,
     T3Reaction,
+    remove_bad_arc_keys,
 )
 
 
@@ -551,3 +557,35 @@ class TestT3Reaction:
         assert reconstructed.t3_status == T3Status.CONVERGED
         assert reconstructed.created_at_iteration == 2
         assert reconstructed.reasons == ['sensitivity']
+
+
+class TestRemoveBadArcKeys:
+    """Tests for remove_bad_arc_keys()."""
+
+    def test_no_surviving_key_is_rejected_by_arcspecies(self):
+        """Test that every key ARCSpecies.as_dict() can emit is either dropped or accepted."""
+        # ``ARCSpecies.__init__`` declares no ``**kwargs``, so a key that survives the filter and
+        # is not an init argument is not ignored -- it raises ``TypeError`` at the call site.
+        emitted = set(re.findall(r"species_dict\['([a-zA-Z0-9_]+)'\]",
+                                 inspect.getsource(ARCSpecies.as_dict)))
+        assert 'radius' in emitted, 'as_dict no longer emits radius; update this test'
+        accepted = set(inspect.signature(ARCSpecies.__init__).parameters) - {'self'}
+        survivors = set(remove_bad_arc_keys({key: None for key in emitted}))
+        assert not survivors - accepted
+
+    def test_radius_is_dropped(self):
+        """Test that the lazily-computed radius does not reach ARCSpecies.__init__."""
+        # ARCSpecies stores it as ``_radius`` and emits it as ``radius``; blocking the private
+        # name matched nothing, so the key survived and broke copy() once radius was computed.
+        assert 'radius' not in remove_bad_arc_keys({'label': 'H2O', 'radius': 1.23})
+        assert remove_bad_arc_keys({'label': 'H2O', 'radius': 1.23})['label'] == 'H2O'
+
+    def test_copy_survives_a_computed_radius(self):
+        """Test that copying a species whose radius was computed does not raise."""
+        spc = T3Species(label='H2O', smiles='O', xyz={'symbols': ('O', 'H', 'H'),
+                                                      'isotopes': (16, 1, 1),
+                                                      'coords': ((0.0, 0.0, 0.12),
+                                                                 (0.0, 0.76, -0.48),
+                                                                 (0.0, -0.76, -0.48))})
+        _ = spc.radius  # ARC touches this whenever it lays out a multi-fragment reaction side
+        assert spc.copy().label == 'H2O'


### PR DESCRIPTION
`t3/chem.py`'s `remove_bad_arc_keys()` strips the keys `ARCSpecies.__init__` cannot accept. It listed `'_radius'`, `'_is_linear'` and `'_number_of_atoms'` — the names of the **private attributes**. `ARCSpecies.as_dict()` emits them unprefixed:

```python
if self._radius is not None:
    species_dict['radius'] = self._radius
```

So the blocklist matched nothing. `radius` and `freqs` reached `ARCSpecies.__init__`, which declares no `**kwargs`, so an unexpected key is a `TypeError` rather than an ignored key:

```
TypeError: ARCSpecies.__init__() got an unexpected keyword argument 'freqs'
```

Enumerating both sides mechanically bounds it at exactly two live offenders:

```
Keys as_dict emits that survive remove_bad_arc_keys but ARCSpecies.__init__ REJECTS:
    freqs
    radius
```

### Why it looked intermittent

Both are lazily computed, so `T3Species.copy()` worked fine until something touched the property first — and ARC touches both routinely. `get_reactants_xyz()`/`get_products_xyz()` read `spc.radius` to lay out a multi-fragment reaction side, and any converged frequency job populates `freqs`.

### Why it matters

It lands inside the TS search. `ARCReaction.get_reactants_and_products(return_copies=True)` copies every species, so **every TS-search adapter ARC admitted died on it** — `linear`, `goflow` and `rits`, across both surfaces of a live PDep campaign:

```
File ".../arc/reaction/reaction.py", line 800, in get_reactants_and_products
  reactants.append(r_spc.copy() if return_copies else r_spc)
File ".../t3/chem.py", line 289, in copy
  return self.__class__.from_dict(species_dict)
File ".../t3/chem.py", line 276, in from_dict
  instance = cls(qm_label=qm_label, **t3_kwargs, **species_dict)
TypeError: ARCSpecies.__init__() got an unexpected keyword argument 'freqs'
```

`goflow` and `rits` each reported 0 guesses out of 2 attempts, which reads as a failure of the ML predictors and was not one — neither ever got as far as proposing a geometry.

### The fix

Two changes, not one:

1. Correct the three names to what ARC actually emits.
2. **Stop trusting the blocklist alone.** A hand-maintained list can only reject the keys someone thought of, and it stops matching *silently* whenever ARC renames an attribute or serializes a new one — which is precisely what happened here. What survives is now filtered against `ARCSpecies.__init__`'s real signature, so an unforeseen key is dropped instead of raised on. The filter is skipped if ARC ever grows `**kwargs`, where dropping keys could only lose information ARC wants.

### Tests

Three, all failing on `main` with the production `TypeError` and passing here. The load-bearing one asserts that **no** key `as_dict()` can emit survives into a signature that rejects it — so the next renamed attribute fails in CI rather than in a TS search.

```
$ pytest tests/test_chem.py -q
49 passed
```

Verified against `main` by stashing the `t3/chem.py` change: `3 failed, 46 passed`, the failures reproducing `ARCSpecies.__init__() got an unexpected keyword argument 'radius'`.

Found while running a real CHO2/CH2O2 PDep campaign; full evidence in that campaign's F16.

### Update: it also discards converged QM results

Found after this PR was opened, in the same campaign. A run reached a **converged transition state**
— `linear` guesses clustered, optimized at `wb97xd/def2tzvp`, frequency job confirming exactly one
imaginary frequency — and was then killed by this bug on the next line:

```
Optimized geometry for TS0 of reaction s0_CH2O2 <=> s1_H2O + s2_CO at wb97xd/def2tzvp:
C      -0.15310600    0.37548200    0.01189700
O       1.09495700   -0.15966300   -0.11605600
O      -1.15002700   -0.26552200    0.00781300
H      -0.14099200    1.47603200    0.05640600
H       1.50019000   -0.32744400    0.73815600

TS TS0 has exactly one imaginary frequency: -632.771

ERROR: ARC crashed with <class 'TypeError'>. Got the following error message:
ARCSpecies.__init__() got an unexpected keyword argument 'freqs'
```

The frequency job that *proved the geometry was a saddle point* is what populated `freqs` and made
the species uncopyable. Path is identical to the adapter crashes:

```
arc/family/family.py:546      fwd_products = rxn.get_reactants_and_products(return_copies=True)[1]
arc/reaction/reaction.py:800  reactants.append(r_spc.copy() if return_copies else r_spc)
t3/chem.py:289                return self.__class__.from_dict(species_dict)
t3/chem.py:276                instance = cls(qm_label=qm_label, **t3_kwargs, **species_dict)
```

So this is not a "TS adapters are unavailable" bug — it is a **"finished QM is discarded"** bug, the
same shape as the `thermo` clobber in #187. Two instances of the same class in one campaign is why
this PR pairs the corrected names with a signature-derived backstop rather than adding three more
blocklist entries.
