### PR TITLE
feat(pdep): a PES exploration loop that computes the barriers its diagram shows

### DIFF
--- a/PES.py
+++ b/PES.py
@@ -64,6 +64,10 @@ def parse_command_line_arguments(command_line_args=None):
                         help='a file describing the PES exploration loop to execute')
     parser.add_argument('-p', '--project-directory', type=str, default=None,
                         help="the directory to run in, defaults to the input file's own directory")
+    parser.add_argument('--diagram-only', action='store_true',
+                        help='a dry run: explore the network and draw its PES diagram without '
+                             'launching any quantum chemistry, so an input file can be '
+                             'smoke-tested without submitting ARC jobs')
 
     # Options for controlling the amount of information printed to the console
     # By default a moderate level of information is printed; you can either
@@ -178,7 +182,11 @@ def main():
     # check that ARC is available
     check_dependencies()
 
-    result = run_pes_loop(config, project_directory, qm_runner=arc_qm_runner, logger=logger)
+    # ``qm_runner=None`` is run_pes_loop's own "no QM this run" mode: it explores the seed network
+    # and draws its diagram, and stops there. That is the only way to smoke-test an input file
+    # without submitting real ARC jobs to a cluster.
+    qm_runner = None if args.diagram_only else arc_qm_runner
+    result = run_pes_loop(config, project_directory, qm_runner=qm_runner, logger=logger)
 
     logger.log(f'\n\nThe PES exploration loop terminated with status {result.status!r} '
                f'after {len(result.rounds)} round(s).', level='always')

--- a/PES.py
+++ b/PES.py
@@ -136,6 +136,13 @@ def main():
 
     Returns:
         PESLoopResult: The outcome of the loop.
+
+    Raises:
+        FileNotFoundError: If the input file, or the network file it names, does not exist. The
+                           network is checked here rather than left to the explorer so a mistyped
+                           or wrongly-anchored path fails immediately, with the resolved path in
+                           the message, instead of raising from inside ``t3/pdep/parser.py`` after
+                           a project directory and a log file have already been created.
     """
     args = parse_command_line_arguments()
     input_file = os.path.abspath(args.file)
@@ -154,6 +161,11 @@ def main():
     # chemistry.
     config.reuse.from_t3_projects = [_resolve(path, input_directory)
                                      for path in config.reuse.from_t3_projects]
+    if not os.path.isfile(config.pes.network):
+        raise FileNotFoundError(
+            f'Could not find the pressure-dependent network file {config.pes.network}.\n'
+            f'A relative "pes.network" is resolved against the input file\'s own directory, '
+            f'{input_directory}.')
 
     verbose = verbose_level(args)
 

--- a/PES.py
+++ b/PES.py
@@ -94,6 +94,39 @@ def exit_code_for(status: str) -> int:
     return 1 if status == PES_LOOP_FAILED else 0
 
 
+def _resolve(path: str, directory: str) -> str:
+    """
+    Resolve one path from the input file against the input file's own directory.
+
+    Args:
+        path (str): A path as written in the input file, absolute or relative.
+        directory (str): The input file's directory.
+
+    Returns:
+        str: ``path`` if it is already absolute, otherwise its absolute form anchored at
+        ``directory``.
+    """
+    return path if os.path.isabs(path) else os.path.abspath(os.path.join(directory, path))
+
+
+def verbose_level(args) -> int:
+    """
+    The logging level the command-line verbosity flags ask for.
+
+    Args:
+        args: The parsed command-line arguments.
+
+    Returns:
+        int: ``10`` for ``-d/--debug``, ``30`` for ``-q/--quiet``, ``20`` otherwise -- the same
+        mapping ``T3.py`` uses.
+    """
+    if args.debug:
+        return 10
+    if args.quiet:
+        return 30
+    return 20
+
+
 def main():
     """
     The main PES executable function.
@@ -110,17 +143,19 @@ def main():
         else os.path.abspath(os.path.dirname(input_file))
 
     config = read_pes_input(input_file)
+    input_directory = os.path.dirname(input_file)
     # A relative network path is resolved against the input file's own directory here: left alone
     # it would only fail deep inside an Arkane run, long after the input was accepted.
     if not os.path.isabs(config.pes.network):
-        config.pes.network = os.path.abspath(
-            os.path.join(os.path.dirname(input_file), config.pes.network))
+        config.pes.network = _resolve(config.pes.network, input_directory)
+    # Every path in the input file is anchored the SAME way. A relative reuse path left unresolved
+    # does not fail loudly -- it silently adopts nothing (the prior project simply is not there
+    # from the loop's cwd), and the loop pays for it with a redundant round of real quantum
+    # chemistry.
+    config.reuse.from_t3_projects = [_resolve(path, input_directory)
+                                     for path in config.reuse.from_t3_projects]
 
-    verbose = 20
-    if args.debug:
-        verbose = 10
-    elif args.quiet:
-        verbose = 30
+    verbose = verbose_level(args)
 
     os.makedirs(project_directory, exist_ok=True)
     logger = Logger(project=os.path.basename(os.path.normpath(project_directory)),

--- a/PES.py
+++ b/PES.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+PES executable module
+
+Drives the standalone PES exploration loop (``t3.pdep.pes_loop.run_pes_loop``): explore a
+pressure-dependent network, queue its sensitive transition states to ARC for QM, re-explore with
+the computed barriers, and repeat. A sibling to ``T3.py``, so the loop can be driven externally to
+T3's iteration machinery.
+"""
+
+import argparse
+import datetime
+import os
+import sys
+
+from arc.common import read_yaml_file
+
+from t3.logger import Logger
+from t3.pdep.pes_loop import PES_LOOP_FAILED, run_pes_loop
+from t3.pdep.pes_qm import arc_qm_runner
+from t3.schema import PESLoopConfig
+from t3.utils.dependencies import check_dependencies
+
+
+def read_pes_input(path: str) -> PESLoopConfig:
+    """
+    Read and validate a PES loop input file.
+
+    Args:
+        path (str): The path to the YAML input file.
+
+    Returns:
+        PESLoopConfig: The validated configuration.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist. Checked here rather than left to the YAML
+                           reader so a mistyped path fails with the path in the message instead of
+                           an opaque parser error.
+        pydantic.ValidationError: If the input file does not validate. ``PESLoopConfig`` forbids
+                                  extra top-level keys, so a typo'd section is refused loudly
+                                  rather than silently ignored.
+    """
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f'Could not find the PES input file {path}.')
+    input_dict = read_yaml_file(path=path) or dict()
+    return PESLoopConfig(**input_dict)
+
+
+def parse_command_line_arguments(command_line_args=None):
+    """
+    Parse command-line arguments.
+
+    Args:
+        command_line_args: The command line arguments.
+
+    Returns:
+        The parsed command-line arguments by key words.
+    """
+
+    parser = argparse.ArgumentParser(description='The PES exploration loop')
+    parser.add_argument('file', metavar='FILE', type=str, nargs=1,
+                        help='a file describing the PES exploration loop to execute')
+    parser.add_argument('-p', '--project-directory', type=str, default=None,
+                        help="the directory to run in, defaults to the input file's own directory")
+
+    # Options for controlling the amount of information printed to the console
+    # By default a moderate level of information is printed; you can either
+    # ask for less (quiet), more (verbose), or much more (debug)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-d', '--debug', action='store_true', help='print debug information')
+    group.add_argument('-q', '--quiet', action='store_true', help='only print warnings and errors')
+
+    args = parser.parse_args(command_line_args)
+    args.file = args.file[0]
+
+    return args
+
+
+def exit_code_for(status: str) -> int:
+    """
+    The process exit code corresponding to a ``PESLoopResult`` status.
+
+    Only an outright failure is an error: a stall, a max_rounds stop, or a round with no candidates
+    are findings to read in the log, not crashes, and a wrapper script must not treat them as such.
+
+    Args:
+        status (str): A ``t3.pdep.pes_loop`` ``PES_LOOP_*`` status constant.
+
+    Returns:
+        int: ``1`` for ``PES_LOOP_FAILED``, ``0`` for every other status.
+    """
+    return 1 if status == PES_LOOP_FAILED else 0
+
+
+def main():
+    """
+    The main PES executable function.
+
+    Returns the ``PESLoopResult`` rather than calling ``sys.exit`` so it is callable (and testable)
+    in-process; only the ``__main__`` guard turns the status into an exit code.
+
+    Returns:
+        PESLoopResult: The outcome of the loop.
+    """
+    args = parse_command_line_arguments()
+    input_file = os.path.abspath(args.file)
+    project_directory = os.path.abspath(args.project_directory) if args.project_directory \
+        else os.path.abspath(os.path.dirname(input_file))
+
+    config = read_pes_input(input_file)
+    # A relative network path is resolved against the input file's own directory here: left alone
+    # it would only fail deep inside an Arkane run, long after the input was accepted.
+    if not os.path.isabs(config.pes.network):
+        config.pes.network = os.path.abspath(
+            os.path.join(os.path.dirname(input_file), config.pes.network))
+
+    verbose = 20
+    if args.debug:
+        verbose = 10
+    elif args.quiet:
+        verbose = 30
+
+    os.makedirs(project_directory, exist_ok=True)
+    logger = Logger(project=os.path.basename(os.path.normpath(project_directory)),
+                    project_directory=project_directory,
+                    verbose=verbose,
+                    t0=datetime.datetime.now())
+
+    # check that ARC is available
+    check_dependencies()
+
+    result = run_pes_loop(config, project_directory, qm_runner=arc_qm_runner, logger=logger)
+
+    logger.log(f'\n\nThe PES exploration loop terminated with status {result.status!r} '
+               f'after {len(result.rounds)} round(s).', level='always')
+    if result.reason:
+        logger.log(f'Reason: {result.reason}', level='always')
+    if result.final_network_path is not None:
+        logger.log(f'Final network: {result.final_network_path}', level='always')
+    if result.final_diagram_path is not None:
+        logger.log(f'PES diagram: {result.final_diagram_path}', level='always')
+    logger.log_footer()
+
+    return result
+
+
+if __name__ == '__main__':
+    sys.exit(exit_code_for(main().status))

--- a/examples/pes_loop/input.yml
+++ b/examples/pes_loop/input.yml
@@ -1,0 +1,121 @@
+# The standalone PES exploration loop, driven by PES.py rather than by T3.py.
+#
+# Run it with:
+#
+#     python PES.py examples/pes_loop/input.yml
+#
+# What the loop does, one round at a time:
+#
+#   1. Runs Arkane's explorer on the pressure-dependent network, which discovers
+#      new isomers and channels reachable from the source.
+#   2. Runs a master-equation sensitivity analysis on the explored network to
+#      find which transition states the rate coefficients of interest actually
+#      depend on.
+#   3. Sends those transition states to ARC for quantum chemistry, and captures
+#      the computed statistical-mechanics artifacts.
+#   4. Writes a hybrid network that carries the computed barriers, and explores
+#      again from there.
+#
+# It stops when a round adds no new transition state worth computing, when the
+# round budget runs out, or when nothing measurable is left above the sensitivity
+# floor. Each round leaves a round_<n>/ directory under the project directory,
+# and the PES energy diagram is drawn from the LAST round -- so it carries the
+# computed barriers, not RMG's rate-rule estimates.
+#
+# The project directory defaults to this file's own directory. Override it with
+# `python PES.py <input> -p /some/other/directory`.
+
+pes:
+  # The pressure-dependent network file to start from, as written by RMG or by a
+  # previous Arkane run. A relative path is resolved against THIS file's
+  # directory. Every label used under `source` below must appear in that file's
+  # species dictionary, spelled exactly as the file spells it -- RMG's labels
+  # carry their index, e.g. 'HCOOH(3)'.
+  network: network1_full.py
+
+  # The entry channel the explorer starts from. One species for a unimolecular
+  # well, or two for a bimolecular entry channel (A + B). Arkane's explorer
+  # accepts nothing else -- never three, and never a transition state.
+  source:
+    - HCO(9)
+    - OH(4)
+
+  # The master-equation method. MSC (modified strong collision) is the robust
+  # default; CSE (chemically significant eigenvalues) is more accurate but fails
+  # on networks where the eigenvalues do not separate, which is common on small
+  # surfaces at high temperature.
+  method: MSC
+
+  bath_gas:
+    Ar: 1.0
+
+  # Explorer tolerances. Leave them unset to use Arkane's own defaults; tighten
+  # `explore_tol` to discover more channels at the cost of a longer run.
+  explore_tol: 0.01
+  energy_tol: 1.0e+01
+  flux_tol: 1.0e-06
+
+  # The largest number of radical electrons a discovered species may carry.
+  # Without it the explorer happily generates biradicals whose thermochemistry
+  # nothing in the model can support.
+  maximum_radical_electrons: 2
+
+  # Explorer runtime is otherwise unbounded, and one pathological network parks
+  # the loop forever. Seconds.
+  timeout: 7200.0
+
+qm:
+  # Levels of theory are written UNDASHED. A dashed form ('wb97x-d/def2-tzvp')
+  # makes ARC miss the cached frequency scale factor and makes Gaussian reject
+  # the route line. `freq_level` must equal `opt_level` so frequencies belong to
+  # a real minimum of the same surface, `scan_level` must equal `freq_level` so
+  # rotors project out correctly, and `irc_level` must equal `opt_level`.
+  opt_level: wb97xd/def2tzvp
+  freq_level: wb97xd/def2tzvp
+  sp_level: wb97xd/def2tzvp
+  irc_level: wb97xd/def2tzvp
+  scan_level: wb97xd/def2tzvp
+
+  # The TS search adapters ARC will try, in order. `heuristics` and `linear` are
+  # cheap and cover most abstractions; `kinbot`, `goflow` and `rits` are the
+  # expensive fallbacks. An adapter your installed ARC does not register makes
+  # ARC refuse the whole job at startup, so trim this list to what you have.
+  ts_adapters:
+    - heuristics
+    - linear
+    - kinbot
+    - goflow
+    - rits
+
+  # Rotors and IRC are off by default: both multiply the cost per transition
+  # state, and neither changes which channels the loop discovers. Turn them on
+  # for a production surface, off while corroborating the loop itself.
+  rotors: false
+  irc: false
+
+  # 'sensitive' computes only the transition states the master-equation analysis
+  # says the rate coefficients depend on; 'all' computes every candidate. Under
+  # BOTH scopes a transition state whose measured |dln(k)/dE0| falls below
+  # `min_delta_ln_k` is skipped -- a barrier that never moved a rate coefficient
+  # cannot justify the quantum chemistry it would cost.
+  scope: sensitive
+  max_transition_states_per_round: 10
+  min_delta_ln_k: 1.0e-03
+
+termination:
+  # Each round costs a full ARC project, so this is a real spending cap.
+  max_rounds: 5
+  # Stop as soon as a round turns up no new transition state worth computing,
+  # rather than re-exploring an already-converged surface until the budget runs
+  # out.
+  stop_when_no_new_ts: true
+
+reuse:
+  # Directories of previous T3 or PES-loop projects whose captured quantum
+  # chemistry should be adopted instead of recomputed. A transition state is
+  # adopted only when its channel matches structurally -- same reactants and
+  # products, same spin states -- and only when it was computed at the same
+  # level of theory as the one requested above. Anything that does not match
+  # exactly is recomputed rather than guessed at. Relative paths are resolved
+  # against this file's directory.
+  from_t3_projects: []

--- a/examples/pes_loop/input.yml
+++ b/examples/pes_loop/input.yml
@@ -30,15 +30,17 @@ pes:
   # previous Arkane run. A relative path is resolved against THIS file's
   # directory. Every label used under `source` below must appear in that file's
   # species dictionary, spelled exactly as the file spells it -- RMG's labels
-  # carry their index, e.g. 'HCOOH(3)'.
-  network: network1_full.py
+  # carry their index, e.g. 'CO2(11)'.
+  # This example points at a real, vendored RMG network so the command in the
+  # header above actually runs as written. Swap it for your own network file.
+  network: ../../tests/data/pdep_real_networks/network799_1/network799_1.py
 
   # The entry channel the explorer starts from. One species for a unimolecular
   # well, or two for a bimolecular entry channel (A + B). Arkane's explorer
   # accepts nothing else -- never three, and never a transition state.
   source:
-    - HCO(9)
-    - OH(4)
+    - O-2(13598)
+    - CO2(11)
 
   # The master-equation method. MSC (modified strong collision) is the robust
   # default; CSE (chemically significant eigenvalues) is more accurate but fails

--- a/t3/pdep/barrierless.py
+++ b/t3/pdep/barrierless.py
@@ -51,9 +51,9 @@ BARRIERLESS_FAMILIES = frozenset({
 #   "Estimated from node Root_N-1R->H_N-1CNOS->N in family R_Recombination."
 #   "family: 1,2_Insertion_CO"
 # A family name is not [A-Za-z_]+ -- '1,2_Insertion_CO' and '1,3_Insertion_CO2' both start with a
-# digit and contain a comma -- so the character class has to admit those or the two insertion
-# families silently come back as None.
-_FAMILY_CHARS = r"[A-Za-z0-9_,\-]+"
+# digit and contain a comma, and '1+2_Cycloaddition' contains a '+' -- so the character class has
+# to admit those or these families silently come back as None.
+_FAMILY_CHARS = r"[A-Za-z0-9_,+\-]+"
 _FAMILY_IN_NODE_RE = re.compile(rf'\bin family ({_FAMILY_CHARS})')
 _FAMILY_LABELLED_RE = re.compile(rf'^family:\s*({_FAMILY_CHARS})\s*$', re.MULTILINE)
 

--- a/t3/pdep/barrierless.py
+++ b/t3/pdep/barrierless.py
@@ -1,0 +1,124 @@
+"""
+t3 pdep barrierless module
+
+Which path reactions must never be sent to a transition-state search.
+
+A barrierless reaction has no saddle point on its potential energy surface, so a TS search for it
+cannot succeed no matter how many adapters are tried or how long they run. The group's own
+reference note is unambiguous about the canonical case:
+
+    R_Recombination reactions are barrierless -- there is no saddle point and ARC cannot compute
+    them. Exclude during generation and record the reason.
+    -- Vault/Code/ARC/Canonical Levels of Theory.md
+
+This is not a theoretical concern. On the CHO2 surface T3 admitted ``HO + CHO <=> CH2O2`` -- two
+radicals recombining to a closed-shell molecule -- for TS search via
+``ts_adapters_for_unknown_unimolecular``, because ``ARCReaction.is_unimolecular()`` is
+direction-agnostic and a bimolecular->unimolecular recombination therefore qualifies. One adapter
+dutifully returned three guesses for a saddle point that does not exist, and they were optimized
+on a cluster.
+
+An automatically exploring loop makes this failure mode structural rather than incidental:
+exploration generates recombination channels faster than any other kind, so a loop without this
+gate spends its entire QM budget on reactions that cannot converge.
+
+**This module fails OPEN.** An unrecognized family is reported as *not* barrierless and gets its
+TS search. Wrongly skipping a real barrier silently loses physics from the surface; wrongly
+attempting a barrierless one wastes one job and says so in the log. The asymmetry is deliberate,
+and it is why the barrierless set is an explicit allowlist rather than a heuristic.
+
+The zero-activation-energy signal is deliberately NOT used as a classifier. Every barrierless
+Arrhenius fit in an RMG network carries ``Ea=(0,'kJ/mol')``, but so do plenty of barriered
+reactions whose fitted Ea collapsed to zero, and acting on that would fail CLOSED on real
+chemistry. Family is the only signal here.
+"""
+
+import re
+from dataclasses import dataclass
+
+from t3.pdep.parser import PDepPathReaction
+
+# RMG families whose reactions proceed without a saddle point. Additions belong here rather than
+# at a call site, so that every consumer of this module agrees on the set.
+BARRIERLESS_FAMILIES = frozenset({
+    'R_Recombination',
+    'Birad_recombination',
+    'Diradical_formation',
+})
+
+# RMG writes the family into the kinetics comment in exactly two forms, both seen in the CHO2
+# network files this module was written against:
+#   "Estimated from node Root_N-1R->H_N-1CNOS->N in family R_Recombination."
+#   "family: 1,2_Insertion_CO"
+# A family name is not [A-Za-z_]+ -- '1,2_Insertion_CO' and '1,3_Insertion_CO2' both start with a
+# digit and contain a comma -- so the character class has to admit those or the two insertion
+# families silently come back as None.
+_FAMILY_CHARS = r"[A-Za-z0-9_,\-]+"
+_FAMILY_IN_NODE_RE = re.compile(rf'\bin family ({_FAMILY_CHARS})')
+_FAMILY_LABELLED_RE = re.compile(rf'^family:\s*({_FAMILY_CHARS})\s*$', re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class BarrierlessVerdict:
+    """
+    Why a path reaction may or may not be sent to a TS search.
+
+    Attributes:
+        is_barrierless (bool): Whether the reaction has no saddle point and must not be queued.
+        family (str | None): The RMG family the verdict was made from, or ``None`` if the kinetics
+                             comment named none.
+        reason (str): A human-readable justification, recorded alongside the decision so a skipped
+                      channel is never silently skipped.
+    """
+    is_barrierless: bool
+    family: str | None
+    reason: str
+
+
+def rmg_family(path_reaction: PDepPathReaction) -> str | None:
+    """
+    Extract the RMG family name from a path reaction's kinetics comment.
+
+    Args:
+        path_reaction (PDepPathReaction): The parsed path reaction.
+
+    Returns:
+        str | None: The family name, or ``None`` if the comment names none. Never guessed at:
+                    a comment without a family yields ``None`` rather than a best effort.
+    """
+    comment = path_reaction.kinetics_comment or ''
+    match = _FAMILY_IN_NODE_RE.search(comment)
+    if match is not None:
+        return match.group(1).rstrip('.')
+    match = _FAMILY_LABELLED_RE.search(comment)
+    if match is not None:
+        return match.group(1).rstrip('.')
+    return None
+
+
+def classify_barrierless(path_reaction: PDepPathReaction) -> BarrierlessVerdict:
+    """
+    Decide whether a path reaction is barrierless and must be kept out of QM.
+
+    Args:
+        path_reaction (PDepPathReaction): The parsed path reaction.
+
+    Returns:
+        BarrierlessVerdict: The verdict, carrying the family it was made from and a reason string
+                            suitable for logging and for the round record.
+    """
+    family = rmg_family(path_reaction)
+    if family is None:
+        return BarrierlessVerdict(
+            is_barrierless=False, family=None,
+            reason=f"'{path_reaction.label}': the kinetics comment names no RMG family, so no "
+                   f'barrierless determination can be made; queueing it for TS search.')
+    if family in BARRIERLESS_FAMILIES:
+        return BarrierlessVerdict(
+            is_barrierless=True, family=family,
+            reason=f"'{path_reaction.label}': family {family} is barrierless -- it has no saddle "
+                   f'point, so a TS search cannot converge. Taking RMG/ILT kinetics instead.')
+    return BarrierlessVerdict(
+        is_barrierless=False, family=family,
+        reason=f"'{path_reaction.label}': family {family} is not a known barrierless family; "
+               f'queueing it for TS search.')

--- a/t3/pdep/capture.py
+++ b/t3/pdep/capture.py
@@ -99,6 +99,28 @@ _CAPTURE_PROVENANCE_SUBDIR = 'provenance'
 # downstream hybrid-network writing must read -- never the (long-gone) RMG ``pdep/`` directory.
 _CAPTURE_NETWORKS_SUBDIR = 'networks'
 
+
+def captured_qm_artifact_path(capture_dir: str, arc_ts_label: str) -> str:
+    """
+    Where ``capture_ts_artifacts`` vendors the QM artifact for one transition state.
+
+    This layout -- ``<capture_dir>/qm/<arc_ts_label>.py`` -- is a stable invariant of this module
+    (``_CAPTURE_QM_SUBDIR``; ``verify_capture`` re-verifies it, and ``t3.pdep.pes_qm`` already
+    relies on it to recover an adopted artifact's own capture directory). Naming it as a function
+    lets a caller that only knows a converged transition state's label (e.g.
+    ``t3.pdep.pes_loop``, carrying QM artifacts across round boundaries) derive the vendored
+    path without re-encoding the layout.
+
+    Args:
+        capture_dir (str): The capture directory the artifact was vendored into.
+        arc_ts_label (str): The ARC transition state label (``t3.pdep.join.arc_ts_label``).
+
+    Returns:
+        str: The vendored artifact's path.
+    """
+    return os.path.join(capture_dir, _CAPTURE_QM_SUBDIR, f'{arc_ts_label}.py')
+
+
 # Sibling-of-capture_dir naming convention for the atomic-swap machinery in
 # _capture_ts_artifacts_locked and its crash-recovery counterpart, _recover_capture_swap_state.
 # Both live in the same parent_dir as capture_dir itself (never inside it), so a fresh capture's

--- a/t3/pdep/capture.py
+++ b/t3/pdep/capture.py
@@ -130,6 +130,12 @@ def captured_qm_artifact_path(capture_dir: str, arc_ts_label: str) -> str:
 # silently compared against a T3-written one on the same field name.
 SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS = 'all_directions_max_abs'
 
+# Every marker value this module will write or verify. An advisory field is still not a free-text
+# field: a value outside this set reaching a consumer means a hand-edited or newer-format
+# manifest, and both the write path and verify_capture refuse it rather than pass it through --
+# the same fail-closed stance verify_capture already takes on an unrecognized artifact status.
+SENSITIVITY_AGGREGATIONS = (SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS,)
+
 # Sibling-of-capture_dir naming convention for the atomic-swap machinery in
 # _capture_ts_artifacts_locked and its crash-recovery counterpart, _recover_capture_swap_state.
 # Both live in the same parent_dir as capture_dir itself (never inside it), so a fresh capture's
@@ -364,6 +370,11 @@ def capture_ts_artifacts(join_records: list,
     Returns:
         CaptureResult: The populated capture directory, its manifest path, and the frozen records.
     """
+    if sensitivity_aggregation is not None and sensitivity_aggregation not in SENSITIVITY_AGGREGATIONS:
+        raise ValueError(f"Unrecognized 'sensitivity_aggregation' value {sensitivity_aggregation!r}; "
+                         f"expected None (T3's unmarked in-run convention) or one of "
+                         f"{sorted(SENSITIVITY_AGGREGATIONS)}. A free-text marker would defeat the "
+                         f"comparison guard this field exists to provide.")
     lock_path = _acquire_capture_lock(capture_dir=capture_dir)
     try:
         # Recover from a crash inside a PRIOR call's atomic swap (see _recover_capture_swap_state)
@@ -1702,11 +1713,20 @@ def verify_capture(capture_dir: str) -> VerifyResult:
                 f"records {entry['source_sha256']}. Refusing to use it."
             )
 
+    sensitivity_aggregation = content.get('sensitivity_aggregation')
+    if sensitivity_aggregation is not None and sensitivity_aggregation not in SENSITIVITY_AGGREGATIONS:
+        raise ValueError(
+            f"Refusing to verify '{capture_dir}': the manifest at '{manifest_path}' carries an "
+            f"unrecognized 'sensitivity_aggregation' value {sensitivity_aggregation!r}; expected "
+            f"the key to be absent (T3's unmarked in-run convention) or one of "
+            f"{sorted(SENSITIVITY_AGGREGATIONS)}. An unrecognized marker means the manifest is "
+            f"hand-edited or from a newer capture format."
+        )
     return VerifyResult(capture_dir=capture_dir, manifest_path=manifest_path, record_count=record_count,
                         captured_artifact_count=captured_artifact_count,
                         networks=networks, energy_settings=content.get('energy_settings'),
                         ts_records=tuple(ts_records),
-                        sensitivity_aggregation=content.get('sensitivity_aggregation'))
+                        sensitivity_aggregation=sensitivity_aggregation)
 
 
 def _verify_one_captured_file(capture_dir: str, relpath: str, expected_sha256: str | None, ts_label) -> None:

--- a/t3/pdep/capture.py
+++ b/t3/pdep/capture.py
@@ -843,6 +843,7 @@ def _manifest_entry(record: TSArtifactRecord, source_hashes: dict | None, captur
         'source_logs': source_logs,
         'coefficient': record.coefficient,
         'delta_ln_k': record.delta_ln_k,
+        'path_reaction_labels': list(record.path_reaction_labels),
         'captured_artifact_path': captured_artifact_path,
         'captured_log_paths': captured_log_paths or dict(),
         'captured_artifact_sha256': captured_artifact_sha256,
@@ -1571,6 +1572,7 @@ def verify_capture(capture_dir: str) -> VerifyResult:
             reason=entry.get('reason') or '',
             coefficient=entry.get('coefficient'),
             delta_ln_k=entry.get('delta_ln_k'),
+            path_reaction_labels=tuple(entry.get('path_reaction_labels') or ()),
         ))
 
     if captured_artifact_count > 0:

--- a/t3/pdep/capture.py
+++ b/t3/pdep/capture.py
@@ -121,6 +121,15 @@ def captured_qm_artifact_path(capture_dir: str, arc_ts_label: str) -> str:
     return os.path.join(capture_dir, _CAPTURE_QM_SUBDIR, f'{arc_ts_label}.py')
 
 
+# The value the standalone PES loop records under a manifest's 'sensitivity_aggregation' key:
+# its per-TS evidence is the maximum-|coefficient| row across EVERY network reaction direction
+# key and every condition of the Arkane ME SA output, ungated (see t3.pdep.pes_sa). T3's in-run
+# path records nothing under this key: its evidence is taken from ONE observable-selected
+# direction key and has already passed the selector's relative/absolute gates. The two are NOT
+# comparable numbers, and this marker is what keeps a loop-written manifest from ever being
+# silently compared against a T3-written one on the same field name.
+SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS = 'all_directions_max_abs'
+
 # Sibling-of-capture_dir naming convention for the atomic-swap machinery in
 # _capture_ts_artifacts_locked and its crash-recovery counterpart, _recover_capture_swap_state.
 # Both live in the same parent_dir as capture_dir itself (never inside it), so a fresh capture's
@@ -203,6 +212,12 @@ class VerifyResult:
         energy_settings (dict, optional): The manifest's AUTHORITATIVE ``'energy_settings'`` block
                                           (``None`` only for a verified zero-artifact capture),
                                           surfaced for the same reason as ``networks``.
+        sensitivity_aggregation (str, optional): The manifest's ``'sensitivity_aggregation'``
+                                                 marker, or ``None`` for a manifest written under
+                                                 T3's in-run convention (see
+                                                 ``capture_ts_artifacts``). Surfaced so a consumer
+                                                 comparing sensitivity evidence across captures can
+                                                 refuse to compare incompatible aggregations.
         ts_records (tuple): One ``TSArtifactRecord`` per transition-state manifest entry, built
                             from EXACTLY the fields this function itself just validated (including
                             the status/captured_artifact_path consistency check below) -- never a
@@ -223,6 +238,7 @@ class VerifyResult:
     networks: dict | None = None
     energy_settings: dict | None = None
     ts_records: tuple = ()
+    sensitivity_aggregation: str | None = None
 
 
 def capture_ts_artifacts(join_records: list,
@@ -231,6 +247,7 @@ def capture_ts_artifacts(join_records: list,
                          networks: dict,
                          sensitivity_by_ts: dict | None = None,
                          supersede: bool = False,
+                         sensitivity_aggregation: str | None = None,
                          ) -> CaptureResult:
     """
     Discover, capture and freeze every network transition state's QM statmech artifact, in one
@@ -303,6 +320,20 @@ def capture_ts_artifacts(join_records: list,
                                    inferred from context. Has no effect when the existing
                                    ``capture_dir`` is empty, unowned-but-refused earlier, or itself
                                    fails ``verify_capture`` (nothing valid to protect in that case).
+        sensitivity_aggregation (str, optional): How the per-transition-state
+                                                ``coefficient``/``delta_ln_k`` evidence in
+                                                ``sensitivity_by_ts`` was aggregated, recorded
+                                                verbatim under the manifest's
+                                                ``'sensitivity_aggregation'`` key when given.
+                                                ``None`` (the default, and T3's in-run
+                                                convention) records nothing: that evidence comes
+                                                from one observable-selected direction key and has
+                                                passed the selector's gates. The standalone PES
+                                                loop passes
+                                                ``SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS``
+                                                -- an ungated max over ALL direction keys -- whose
+                                                values are NOT comparable to the in-run ones; the
+                                                marker is what prevents a silent comparison.
 
     Raises:
         RuntimeError: If ``capture_dir``'s interprocess lock is already held by another (live, or
@@ -347,6 +378,7 @@ def capture_ts_artifacts(join_records: list,
             networks=networks,
             sensitivity_by_ts=sensitivity_by_ts,
             supersede=supersede,
+            sensitivity_aggregation=sensitivity_aggregation,
         )
     finally:
         _release_capture_lock(lock_path)
@@ -358,6 +390,7 @@ def _capture_ts_artifacts_locked(join_records: list,
                                  networks: dict,
                                  sensitivity_by_ts: dict | None,
                                  supersede: bool,
+                                 sensitivity_aggregation: str | None,
                                  ) -> CaptureResult:
     """
     The body of ``capture_ts_artifacts``, run only once the caller already holds ``capture_dir``'s
@@ -638,7 +671,8 @@ def _capture_ts_artifacts_locked(join_records: list,
 
         _write_manifest(capture_dir=staging_dir, arc_project_directory=arc_project_directory,
                         manifest_entries=manifest_entries, provenance_entries=provenance_entries,
-                        energy_settings=energy_settings, networks=manifest_networks)
+                        energy_settings=energy_settings, networks=manifest_networks,
+                        sensitivity_aggregation=sensitivity_aggregation)
 
         # Self-check the fully staged capture with the same verifier a downstream consumer would
         # use, BEFORE it is ever swapped into capture_dir's place. This is the natural post-write
@@ -875,7 +909,8 @@ def _manifest_entry(record: TSArtifactRecord, source_hashes: dict | None, captur
 
 def _write_manifest(capture_dir: str, arc_project_directory: str, manifest_entries: list,
                     provenance_entries: list | None = None, energy_settings: dict | None = None,
-                    networks: dict | None = None) -> str:
+                    networks: dict | None = None,
+                    sensitivity_aggregation: str | None = None) -> str:
     """
     Write the capture manifest atomically: stage it under a temp name inside ``capture_dir``, then
     ``os.replace`` it onto ``CAPTURE_MANIFEST_FILE_NAME``, so a write failure partway through (e.g.
@@ -932,6 +967,14 @@ def _write_manifest(capture_dir: str, arc_project_directory: str, manifest_entri
         # rely on for each network's vendored source file and frozen ME method.
         'networks': networks or dict(),
     }
+    if sensitivity_aggregation is not None:
+        # How the per-TS coefficient/delta_ln_k evidence in 'transition_states' was aggregated,
+        # when it was NOT T3's in-run convention (one observable-selected, threshold-gated
+        # direction key -- the unmarked default). A manifest carrying
+        # SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS holds ungated max-|coefficient| values
+        # over ALL direction keys (the standalone PES loop's convention); the two conventions'
+        # admissible ranges are incompatible and must never be compared on the shared field name.
+        content['sensitivity_aggregation'] = sensitivity_aggregation
 
     fd, staged_path = tempfile.mkstemp(prefix='.capture-manifest-', dir=capture_dir)
     os.close(fd)
@@ -1662,7 +1705,8 @@ def verify_capture(capture_dir: str) -> VerifyResult:
     return VerifyResult(capture_dir=capture_dir, manifest_path=manifest_path, record_count=record_count,
                         captured_artifact_count=captured_artifact_count,
                         networks=networks, energy_settings=content.get('energy_settings'),
-                        ts_records=tuple(ts_records))
+                        ts_records=tuple(ts_records),
+                        sensitivity_aggregation=content.get('sensitivity_aggregation'))
 
 
 def _verify_one_captured_file(capture_dir: str, relpath: str, expected_sha256: str | None, ts_label) -> None:

--- a/t3/pdep/discovery.py
+++ b/t3/pdep/discovery.py
@@ -444,12 +444,18 @@ class TSArtifactRecord:
             sensitivity evidence was supplied for this transition state.
         path_reaction_labels (tuple): The labels of the path reactions this transition state owns,
             carried through from the ``t3.pdep.join.TSJoinRecord`` this record was resolved from.
-            This is the structural identity of the transition state -- unlike ``network_ts_label``
-            (positional: Arkane numbers ``TS1``, ``TS2``, ... by path-reaction index, so pruning a
-            reaction shifts every later label) or ``network_id`` (Arkane's final network artifact is
-            named by explorer run index, e.g. ``network0_full``, not by any stem a caller controls),
-            this tuple identifies the actual saddle point and is what any cross-capture matching
-            (e.g. reusing a prior capture's QM for a differently-named network) must key on.
+            Provenance and diagnostics only -- NEVER an identity, and never what a cross-capture
+            match may key on. These labels are exactly as positional as ``network_ts_label``:
+            Arkane names path reactions ``reaction1``, ``reaction2``, ... by index
+            (``arkane/pdep.py``), a remove-then-append can even leave two blocks labelled
+            ``reaction3`` in one file, and neither label survives a re-exploration that prunes or
+            renumbers. ``TSJoinRecord`` documents the same thing about them, and
+            ``t3.pdep.pes_qm.adopt_prior_qm`` deliberately ignores them, resolving each record's
+            transition state through the capture's own VENDORED network copy instead and matching
+            on the structural channel key
+            (``t3.pdep.pes_rounds.adoption_channel_keys_by_ts_label``: canonical species
+            structures, direction-insensitive, qualified by the RMG family). That is what any
+            cross-capture matching must key on.
     """
 
     def __init__(self,

--- a/t3/pdep/discovery.py
+++ b/t3/pdep/discovery.py
@@ -442,6 +442,14 @@ class TSArtifactRecord:
             evidence was supplied for this transition state.
         delta_ln_k (float, optional): The corresponding dimensionless rate response, when
             sensitivity evidence was supplied for this transition state.
+        path_reaction_labels (tuple): The labels of the path reactions this transition state owns,
+            carried through from the ``t3.pdep.join.TSJoinRecord`` this record was resolved from.
+            This is the structural identity of the transition state -- unlike ``network_ts_label``
+            (positional: Arkane numbers ``TS1``, ``TS2``, ... by path-reaction index, so pruning a
+            reaction shifts every later label) or ``network_id`` (Arkane's final network artifact is
+            named by explorer run index, e.g. ``network0_full``, not by any stem a caller controls),
+            this tuple identifies the actual saddle point and is what any cross-capture matching
+            (e.g. reusing a prior capture's QM for a differently-named network) must key on.
     """
 
     def __init__(self,
@@ -454,6 +462,7 @@ class TSArtifactRecord:
                  reason: str = '',
                  coefficient: float | None = None,
                  delta_ln_k: float | None = None,
+                 path_reaction_labels: tuple = tuple(),
                  ):
         if status not in TS_ARTIFACT_STATUSES:
             raise ValueError(f"Unrecognized transition state artifact status '{status}'; "
@@ -467,6 +476,7 @@ class TSArtifactRecord:
         self.reason = reason
         self.coefficient = coefficient
         self.delta_ln_k = delta_ln_k
+        self.path_reaction_labels = tuple(path_reaction_labels)
 
     @property
     def key(self) -> tuple:
@@ -495,6 +505,7 @@ class TSArtifactRecord:
             'reason': self.reason,
             'coefficient': self.coefficient,
             'delta_ln_k': self.delta_ln_k,
+            'path_reaction_labels': list(self.path_reaction_labels),
         }
 
     @classmethod
@@ -525,6 +536,7 @@ class TSArtifactRecord:
             reason=record_dict.get('reason') or '',
             coefficient=record_dict.get('coefficient'),
             delta_ln_k=record_dict.get('delta_ln_k'),
+            path_reaction_labels=tuple(record_dict.get('path_reaction_labels') or ()),
         )
 
     def __repr__(self) -> str:
@@ -581,6 +593,7 @@ def discover_ts_artifacts(join_records: list, arc_project_directory: str, sensit
             records.append(TSArtifactRecord(
                 network_id=join_record.network_id,
                 network_ts_label=join_record.network_ts_label,
+                path_reaction_labels=join_record.path_reaction_labels,
                 arc_ts_label=join_record.arc_ts_label,
                 status=ARTIFACT_STATUS_NOT_QUEUED,
                 artifact_path=None,
@@ -595,6 +608,7 @@ def discover_ts_artifacts(join_records: list, arc_project_directory: str, sensit
             records.append(TSArtifactRecord(
                 network_id=join_record.network_id,
                 network_ts_label=join_record.network_ts_label,
+                path_reaction_labels=join_record.path_reaction_labels,
                 arc_ts_label=join_record.arc_ts_label,
                 status=ARTIFACT_STATUS_MISSING,
                 artifact_path=None,
@@ -638,6 +652,7 @@ def discover_ts_artifacts(join_records: list, arc_project_directory: str, sensit
             records.append(TSArtifactRecord(
                 network_id=join_record.network_id,
                 network_ts_label=join_record.network_ts_label,
+                path_reaction_labels=join_record.path_reaction_labels,
                 arc_ts_label=recomputed_label,
                 status=ARTIFACT_STATUS_UNUSABLE,
                 artifact_path=None,
@@ -655,6 +670,7 @@ def discover_ts_artifacts(join_records: list, arc_project_directory: str, sensit
             records.append(TSArtifactRecord(
                 network_id=join_record.network_id,
                 network_ts_label=join_record.network_ts_label,
+                path_reaction_labels=join_record.path_reaction_labels,
                 arc_ts_label=recomputed_label,
                 status=ARTIFACT_STATUS_UNUSABLE,
                 artifact_path=None,
@@ -682,6 +698,7 @@ def discover_ts_artifacts(join_records: list, arc_project_directory: str, sensit
             records.append(TSArtifactRecord(
                 network_id=join_record.network_id,
                 network_ts_label=join_record.network_ts_label,
+                path_reaction_labels=join_record.path_reaction_labels,
                 arc_ts_label=recomputed_label,
                 status=ARTIFACT_STATUS_UNUSABLE,
                 artifact_path=None,
@@ -698,6 +715,7 @@ def discover_ts_artifacts(join_records: list, arc_project_directory: str, sensit
             records.append(TSArtifactRecord(
                 network_id=join_record.network_id,
                 network_ts_label=join_record.network_ts_label,
+                path_reaction_labels=join_record.path_reaction_labels,
                 arc_ts_label=recomputed_label,
                 status=ARTIFACT_STATUS_MISSING,
                 artifact_path=None,
@@ -717,6 +735,7 @@ def discover_ts_artifacts(join_records: list, arc_project_directory: str, sensit
             records.append(TSArtifactRecord(
                 network_id=join_record.network_id,
                 network_ts_label=join_record.network_ts_label,
+                path_reaction_labels=join_record.path_reaction_labels,
                 arc_ts_label=recomputed_label,
                 status=ARTIFACT_STATUS_UNUSABLE,
                 artifact_path=None,
@@ -741,6 +760,7 @@ def discover_ts_artifacts(join_records: list, arc_project_directory: str, sensit
         records.append(TSArtifactRecord(
             network_id=join_record.network_id,
             network_ts_label=join_record.network_ts_label,
+            path_reaction_labels=join_record.path_reaction_labels,
             arc_ts_label=recomputed_label,
             status=artifact_status,
             artifact_path=recomputed_path,

--- a/t3/pdep/parser.py
+++ b/t3/pdep/parser.py
@@ -13,7 +13,7 @@ import ast
 import io
 import tokenize
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -244,6 +244,17 @@ class PDepNetwork:
                                      what lets a decision made about one revision be refused as a
                                      gate for a run against another (see
                                      ``t3.pdep.api.explore_pdep_network``).
+        species_structures (dict): Species label -> the RMG adjacency-list text from that
+                                   species' ``structure = adjacencyList('''...''')`` keyword, for
+                                   every ``species(...)`` call that declares one. A label with no
+                                   ``structure`` keyword (or one that is not a bare
+                                   ``adjacencyList("<literal string>")`` call) is simply absent from
+                                   this dict rather than raising: most callers (net reaction
+                                   counting, join bookkeeping) never need structures at all, and
+                                   only a species actually queued for QM (``t3.pdep.pes_qm``) needs
+                                   one to hand ARC a real molecule. Default ``{}`` so every existing
+                                   ``PDepNetwork(...)`` construction site (which never passes this
+                                   keyword) keeps working unchanged.
     """
     network_id: str
     path: str
@@ -256,6 +267,7 @@ class PDepNetwork:
     product_channels: tuple
     product_channels_declared: bool = False
     source_hash: str | None = None
+    species_structures: dict = field(default_factory=dict)
 
     def expected_net_reaction_count(self) -> int:
         """
@@ -764,6 +776,7 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
         raise ValueError(f"Could not parse the pdep network file at '{path}' as Python: {e}")
 
     species_labels = list()
+    species_structures = dict()
     transition_state_labels = list()
     path_reactions = list()
     network_label = None
@@ -786,6 +799,9 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
                                       action="omit it from the species labels")
             if label is not None:
                 species_labels.append(label)
+                structure = _species_structure(kwargs.get('structure'))
+                if structure is not None:
+                    species_structures[label] = structure
 
         elif call_name == 'transitionState':
             label = _literal_or_raise(kwargs.get('label'), path=path, keyword='label',
@@ -848,6 +864,7 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
         product_channels=product_channels,
         product_channels_declared=product_channels_declared,
         source_hash=source_hash,
+        species_structures=species_structures,
     )
 
 
@@ -1270,6 +1287,38 @@ def _call_keywords(call: ast.Call, path: str = '', call_name: Optional[str] = No
                              f"would actually supply.")
         keywords[kw.arg] = kw.value
     return keywords
+
+
+def _species_structure(node) -> str | None:
+    """
+    Extract the adjacency-list text from a species' ``structure`` keyword value node, if possible.
+
+    A ``species(...)`` call's ``structure`` keyword is written as
+    ``structure = adjacencyList('''...''')`` -- an ``ast.Call`` node, not a literal, so neither
+    ``_literal_or_none`` nor ``_literal_or_raise`` can read it (``ast.literal_eval`` always refuses
+    a ``Call`` node), and ``_call_keywords`` cannot be reused on the nested ``adjacencyList(...)``
+    call either, since it refuses ANY positional argument and ``adjacencyList('''...''')`` is called
+    with exactly one. This fails open (returns ``None``) rather than raising for any shape other
+    than the exact one RMG writes: unlike the top-level DSL calls this module otherwise refuses to
+    guess about, an unreadable ``structure`` keyword only costs the QM path a species it cannot
+    build a molecule for (see ``PDepNetwork.species_structures``) -- it does not change what network
+    topology gets reported, so there is nothing here worth failing the whole parse over.
+
+    Args:
+        node: The AST value node bound to a ``structure`` keyword (or ``None``).
+
+    Returns:
+        str: The adjacency-list text, or ``None`` if ``node`` is ``None`` or is not a bare
+            ``adjacencyList("<literal string>")`` call.
+    """
+    if node is None:
+        return None
+    if not (isinstance(node, ast.Call) and _get_call_name(node) == 'adjacencyList' and len(node.args) == 1):
+        return None
+    arg = node.args[0]
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return arg.value
+    return None
 
 
 def _literal_or_none(node):

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -27,8 +27,9 @@ saddle point.
 Why ``qm_runner`` is injected rather than called directly: this loop's own job is sequencing --
 explore, draw, split candidates from skips, decide whether to stop -- and none of that requires an
 ARC cluster to test. Injecting the QM step as a callable with the signature
-``qm_runner(candidates, paths, config, network_id) -> frozenset[str]`` lets every round-sequencing
-decision (no-candidates, converged, stalled, diagram-only, max-rounds, failed-explore) be covered
+``qm_runner(candidates, paths, config, network_id) -> tuple[frozenset[str], frozenset[str]]``
+(``converged_ts_labels, queued_ts_labels``) lets every round-sequencing decision (no-candidates,
+converged, stalled, diagram-only, max-rounds, failed-explore) be covered
 by tests that never touch ARC. Task 6 supplies the real ARC-backed implementation; ``qm_runner=None``
 is not a placeholder for "not implemented yet", it is the honest, permanent behaviour for a caller
 who wants explore-and-draw only, with no QM spend at all -- so it must never raise, and it is
@@ -129,7 +130,11 @@ class RoundRecord:
             re-exploration), or the freshly explored network if exploration succeeded.
         diagram_path (str | None): Where this round's PES diagram was written, or ``None`` if
             drawing it was refused (a species with no ``E0``) or exploration itself failed.
-        queued_ts_labels (tuple): The network-local TS labels sent to ``qm_runner`` this round.
+        queued_ts_labels (tuple): The network-local TS labels ``qm_runner`` actually queued this
+            round. For a real ``qm_runner`` this is its own reported ``queued_ts_labels`` (N3: it
+            can silently drop a candidate the loop offered, e.g. for missing structure, so this is
+            not simply every candidate the loop handed it); for ``qm_runner=None`` or a round that
+            never reaches a runner, it is every candidate the loop would have offered.
         skipped (tuple): The ``SkippedChannel`` entries for this round, each carrying its reason.
         status (str): This round's outcome. ``'continuing'`` for a round that queued QM and is not
             the loop's last one; otherwise one of the ``PES_LOOP_*`` status constants, matching the
@@ -226,8 +231,10 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         project_directory (str): The loop's project directory. Must be absolute (see
             ``t3.pdep.pes_rounds.round_paths``).
         qm_runner: An injected callable, ``qm_runner(candidates, paths, config, network_id) ->
-            frozenset[str]``, returning the network-local TS labels that converged this round.
-            ``None`` (the default) means "no QM this run" -- explore and draw the first round's
+            tuple[frozenset[str], frozenset[str]]`` -- ``(converged_ts_labels, queued_ts_labels)``,
+            the network-local TS labels that converged this round and the ones the runner actually
+            queued (not necessarily every candidate it was handed -- N3). ``None`` (the default)
+            means "no QM this run" -- explore and draw the first round's
             diagram only, which is the honest behaviour when no QM runner is configured, not a
             crash.
         adopted_ts_labels (frozenset, optional): Network-local TS labels already computed before
@@ -320,11 +327,15 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                  final_diagram_path=diagram_path)
 
         candidates = _trim_candidates(split.candidates, config, logger)
-        queued_ts_labels = tuple(candidate.ts_label for candidate in candidates)
+        # Offered, not yet queued -- qm_runner=None never runs a runner at all, so nothing can be
+        # dropped, and this is the honest record. A real qm_runner's own reported queued_ts_labels
+        # (below) supersedes this once it runs, because build_arc_input can silently drop a
+        # candidate the loop offered (N3).
+        offered_ts_labels = tuple(candidate.ts_label for candidate in candidates)
 
         if qm_runner is None:
             rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
-                                      diagram_path=diagram_path, queued_ts_labels=queued_ts_labels,
+                                      diagram_path=diagram_path, queued_ts_labels=offered_ts_labels,
                                       skipped=split.skipped, status=PES_LOOP_DIAGRAM_ONLY,
                                       reason='no qm_runner configured: explored and drew the '
                                             'diagram only, nothing was computed.'))
@@ -332,8 +343,9 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                  reason=rounds[-1].reason, final_network_path=explored_network_path,
                                  final_diagram_path=diagram_path)
 
-        newly_computed = qm_runner(candidates, paths, config, network.network_id)
+        newly_computed, actually_queued = qm_runner(candidates, paths, config, network.network_id)
         computed_ts_labels = computed_ts_labels | newly_computed
+        queued_ts_labels = tuple(actually_queued)
 
         if config.termination.stop_when_no_new_ts and not newly_computed:
             reason = ('qm_runner returned no newly-converged transition states and '

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -270,13 +270,21 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
             means "no QM this run" -- explore and draw the first round's
             diagram only, which is the honest behaviour when no QM runner is configured, not a
             crash.
-        adopted_ts_labels (frozenset, optional): TS labels of the SEED network
+        adopted_ts_labels (dict | frozenset, optional): TS labels of the SEED network
             (``config.pes.network``) already computed before this loop started (e.g. reused from
-            an earlier T3 project). Each is translated to its structural channel key through the
-            seed network (labels are positional and do not survive re-exploration -- see the
-            keying comment at the top of this function's body) and seeded as computed before
-            round 0; a label with no unambiguous structural identity is warned about and
-            re-decided each round instead. This is unioned with -- not replaced by -- whatever
+            an earlier T3 project), preferably as a MAPPING of TS label -> QM artifact path --
+            the same shape ``config.reuse.from_t3_projects`` resolves to. Each label is
+            translated to its structural channel key through the seed network (labels are
+            positional and do not survive re-exploration -- see the keying comment at the top of
+            this function's body) and seeded as computed before round 0; a label with no
+            unambiguous structural identity is warned about and re-decided each round instead.
+            A label whose artifact is missing (a bare set of labels, or a path that does not
+            exist) is NOT marked computed: without an artifact there is nothing to fold into any
+            round's hybrid network, so the channel would keep its RMG/ILT rate line and the final
+            diagram would show an ESTIMATED barrier while the run reported quantum chemistry for
+            it -- and if such a label were the only candidate, round 0 would return
+            ``'no_candidates'`` before ``qm_runner`` was ever called. It is warned about and
+            queued normally instead. This is unioned with -- not replaced by -- whatever
             ``config.reuse.from_t3_projects`` itself resolves to (see below); passing this
             explicitly is for callers (e.g. tests) that already have the adopted set in hand and
             want to skip re-discovering it.
@@ -331,7 +339,11 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         seed_network = parse_pdep_network_file(path=config.pes.network)
         seed_channel_keys = channel_keys_by_ts_label(seed_network)
     if adopted_ts_labels:
-        for ts_label in sorted(adopted_ts_labels):
+        # A mapping supplies the artifact for each label; a bare iterable supplies none, and every
+        # label in it therefore resolves to None below and is refused (see the fail-closed check).
+        adopted_artifacts = (dict(adopted_ts_labels) if isinstance(adopted_ts_labels, dict)
+                             else {ts_label: None for ts_label in adopted_ts_labels})
+        for ts_label, artifact_path in sorted(adopted_artifacts.items()):
             key = seed_channel_keys.get(ts_label)
             if key is None:
                 message = (f'PES loop: adopted_ts_labels names {ts_label!r}, but that transition '
@@ -342,7 +354,34 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                 if logger is not None:
                     logger.warning(message)
                 continue
+            # Fail closed. Marking a channel computed WITHOUT an artifact to fold is a claim the
+            # loop cannot honour: qm_runner is never handed anything for it, so the hybrid network
+            # keeps that channel's RMG/ILT rate line and the final diagram shows an ESTIMATED
+            # barrier -- while the run reports the channel as having quantum chemistry. Worse, if
+            # such a label is the only candidate, the round returns 'no_candidates' before the
+            # runner is even called. Refusing to mark it costs a re-computation; accepting it
+            # costs the correctness of the number this whole loop exists to produce.
+            if not artifact_path:
+                message = (f'PES loop: adopted_ts_labels names {ts_label!r} with no artifact path, '
+                           f'so there is nothing to fold into this run\'s hybrid network. Marking '
+                           f'it computed would leave that channel on its RMG estimate while '
+                           f'reporting it as computed, so it is NOT marked computed and will be '
+                           f'queued normally. Pass a mapping of TS label -> artifact path (the '
+                           f'way config.reuse.from_t3_projects resolves one) to actually reuse it.')
+                _logger.warning(message)
+                if logger is not None:
+                    logger.warning(message)
+                continue
+            if not os.path.isfile(artifact_path):
+                message = (f'PES loop: adopted_ts_labels gives {ts_label!r} the artifact '
+                           f'{artifact_path!r}, which does not exist; it is NOT marked computed '
+                           f'and will be queued normally.')
+                _logger.warning(message)
+                if logger is not None:
+                    logger.warning(message)
+                continue
             computed_channels.add(key)
+            qm_artifacts_by_channel[key] = artifact_path
     if config.reuse.from_t3_projects:
         network_id = Path(config.pes.network).stem
         # Adoption is matched on the FAMILY-QUALIFIED key, never the endpoints-only one the

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -345,17 +345,31 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                  final_network_path=explored_network_path,
                                  final_diagram_path=diagram_path)
 
+        # A round that converges nothing correctly does NOT write a hybrid file (qm_runner's
+        # empty-convergence contract -- see t3.pdep.pes_qm.arc_qm_runner). Advancing
+        # current_network_path to hybrid_network_path anyway would make the next round's
+        # file-existence check (above) blame qm_runner for "failing to write" a file it was never
+        # supposed to write. So only advance to the hybrid file when qm_runner actually converged
+        # something this round; otherwise stay on the network just explored and let max_rounds
+        # bound the (otherwise honest) repetition.
+        no_progress_reason = ('' if newly_computed else
+                              'qm_runner converged no new transition states this round; '
+                              're-exploring the same network next round rather than advancing to '
+                              'a hybrid file that was never written.')
         rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
                                   diagram_path=diagram_path, queued_ts_labels=queued_ts_labels,
-                                  skipped=split.skipped, status='continuing'))
+                                  skipped=split.skipped, status='continuing',
+                                  reason=no_progress_reason))
 
         # The next round explores the QM-informed surface: a real qm_runner (Task 6) writes this
         # round's hybrid network input file (t3.pdep.hybrid) to hybrid_network_path(paths,
         # network.network_id) from its captured statmech artifacts, folding the newly converged
         # transition states in as Log(...) references. This driver trusts that contract rather than
         # writing the hybrid file itself -- that write belongs with the capture step that knows what
-        # it captured -- and enforces it explicitly at the top of the next round (above).
-        current_network_path = hybrid_network_path(paths, network.network_id)
+        # it captured -- and enforces it explicitly at the top of the next round (above). When
+        # nothing converged this round, there is no hybrid file to trust -- see no_progress_reason.
+        current_network_path = (hybrid_network_path(paths, network.network_id) if newly_computed
+                                else explored_network_path)
 
     reason = f'the round budget ({max_rounds}) was exhausted without converging.'
     return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_MAX_ROUNDS, reason=reason,

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -284,6 +284,12 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
     # exists to prevent).
     computed_channels = set()
     qm_artifacts_by_channel = dict()
+    # Initialised unconditionally, not only inside the branch that needs it: the two consumers
+    # below are guarded by exactly the same condition, so an uninitialised read is unreachable --
+    # but a reader (and a static analyser: CodeQL flagged this) cannot see that without checking
+    # three conditions against each other. The seed network is still parsed only when something
+    # actually needs its keys; an empty map is the truthful value when nothing does.
+    seed_channel_keys = dict()
     if adopted_ts_labels or config.reuse.from_t3_projects:
         seed_network = parse_pdep_network_file(path=config.pes.network)
         seed_channel_keys = channel_keys_by_ts_label(seed_network)

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -276,7 +276,7 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         if round_index > 0 and not os.path.isfile(current_network_path):
             reason = (f"round {round_index}: the expected hybrid network file "
                      f"{current_network_path!r} does not exist. The previous round's qm_runner "
-                     "must write it (see t3.pdep.pes_loop.hybrid_network_path) before returning.")
+                     "must write it (see t3.pdep.pes_rounds.hybrid_network_path) before returning.")
             prior = rounds[-1] if rounds else None
             rounds.append(RoundRecord(index=round_index, network_path=current_network_path,
                                       diagram_path=None, queued_ts_labels=(), skipped=(),
@@ -322,7 +322,14 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
 
         split = split_qm_candidates(network, computed_ts_labels)
 
-        if not split.candidates:
+        # C2: a round that adopted prior QM at round 0 must not early-return here just because it
+        # has no NEW candidates to queue -- every candidate having been satisfied by reuse is the
+        # headline success case for reuse, not "nothing to do". qm_runner is still called below
+        # (with an empty candidates tuple) so it can fold the adopted artifacts into a hybrid
+        # network; only when there is also no qm_runner to do that (no way to write a hybrid at
+        # all) does this fall through to the diagram-only return below.
+        round0_has_adopted = round_index == 0 and bool(adopted)
+        if not split.candidates and not round0_has_adopted:
             status = PES_LOOP_NO_CANDIDATES if round_index == 0 else PES_LOOP_CONVERGED
             rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
                                       diagram_path=diagram_path, queued_ts_labels=(),
@@ -348,7 +355,7 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                  reason=rounds[-1].reason, final_network_path=explored_network_path,
                                  final_diagram_path=diagram_path)
 
-        if round_index == 0 and adopted:
+        if round0_has_adopted:
             newly_computed, actually_queued = qm_runner(candidates, paths, config,
                                                          network.network_id, adopted=adopted)
         else:
@@ -356,7 +363,16 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         computed_ts_labels = computed_ts_labels | newly_computed
         queued_ts_labels = tuple(actually_queued)
 
-        if config.termination.stop_when_no_new_ts and not newly_computed:
+        # Important: qm_runner's returned newly_computed excludes adopted TS labels by contract
+        # (t3.pdep.pes_qm.arc_qm_runner's converged_ts_labels is what ARC itself converged THIS
+        # round; adopted artifacts were already usable before this round even ran). Folding
+        # `adopted` in was still real progress -- a hybrid network carrying them was written this
+        # round (see t3.pdep.pes_qm.arc_qm_runner's C2) -- so "no progress" and "advance to the
+        # hybrid file" must both look at newly_computed OR round0_has_adopted, not newly_computed
+        # alone.
+        made_progress = bool(newly_computed) or round0_has_adopted
+
+        if config.termination.stop_when_no_new_ts and not made_progress:
             reason = ('qm_runner returned no newly-converged transition states and '
                      'termination.stop_when_no_new_ts is set: continuing would not make progress.')
             rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
@@ -366,14 +382,14 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                  final_network_path=explored_network_path,
                                  final_diagram_path=diagram_path)
 
-        # A round that converges nothing correctly does NOT write a hybrid file (qm_runner's
-        # empty-convergence contract -- see t3.pdep.pes_qm.arc_qm_runner). Advancing
+        # A round that converges nothing AND adopted nothing correctly does NOT write a hybrid file
+        # (qm_runner's empty-convergence contract -- see t3.pdep.pes_qm.arc_qm_runner). Advancing
         # current_network_path to hybrid_network_path anyway would make the next round's
         # file-existence check (above) blame qm_runner for "failing to write" a file it was never
-        # supposed to write. So only advance to the hybrid file when qm_runner actually converged
-        # something this round; otherwise stay on the network just explored and let max_rounds
-        # bound the (otherwise honest) repetition.
-        no_progress_reason = ('' if newly_computed else
+        # supposed to write. So only advance to the hybrid file when qm_runner actually converged or
+        # folded in something this round; otherwise stay on the network just explored and let
+        # max_rounds bound the (otherwise honest) repetition.
+        no_progress_reason = ('' if made_progress else
                               'qm_runner converged no new transition states this round; '
                               're-exploring the same network next round rather than advancing to '
                               'a hybrid file that was never written.')
@@ -385,11 +401,12 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         # The next round explores the QM-informed surface: a real qm_runner (Task 6) writes this
         # round's hybrid network input file (t3.pdep.hybrid) to hybrid_network_path(paths,
         # network.network_id) from its captured statmech artifacts, folding the newly converged
-        # transition states in as Log(...) references. This driver trusts that contract rather than
-        # writing the hybrid file itself -- that write belongs with the capture step that knows what
-        # it captured -- and enforces it explicitly at the top of the next round (above). When
-        # nothing converged this round, there is no hybrid file to trust -- see no_progress_reason.
-        current_network_path = (hybrid_network_path(paths, network.network_id) if newly_computed
+        # (and any adopted) transition states in as Log(...) references. This driver trusts that
+        # contract rather than writing the hybrid file itself -- that write belongs with the capture
+        # step that knows what it captured -- and enforces it explicitly at the top of the next
+        # round (above). When nothing converged or was adopted this round, there is no hybrid file
+        # to trust -- see no_progress_reason.
+        current_network_path = (hybrid_network_path(paths, network.network_id) if made_progress
                                 else explored_network_path)
 
     reason = f'the round budget ({max_rounds}) was exhausted without converging.'

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -62,7 +62,8 @@ from t3.pdep.explorer.config import PDepExplorerConfig
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED
 from t3.pdep.parser import parse_pdep_network_file
 from t3.pdep.pes_qm import adopt_prior_qm
-from t3.pdep.pes_rounds import (RoundPaths, attach_sensitivity_evidence,
+from t3.pdep.pes_rounds import (RoundPaths, adoption_channel_keys_by_ts_label,
+                                attach_sensitivity_evidence,
                                 channel_keys_by_ts_label, hybrid_network_path, round_paths,
                                 split_qm_candidates)
 from t3.pdep.pes_sa import run_round_me_sensitivity
@@ -344,8 +345,15 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
             computed_channels.add(key)
     if config.reuse.from_t3_projects:
         network_id = Path(config.pes.network).stem
+        # Adoption is matched on the FAMILY-QUALIFIED key, never the endpoints-only one the
+        # within-run carry uses: the two files compared here are unrelated, so a different pathway
+        # between the same endpoints would key identically and the prior artifact would land on a
+        # saddle point it was never computed for. See
+        # t3.pdep.pes_rounds.adoption_channel_keys_by_ts_label. freq_level goes with sp_level
+        # because ARC's own model_chemistry string depends on both.
         adopted = adopt_prior_qm(config.reuse.from_t3_projects, network_id, config.qm.sp_level,
-                                 seed_channel_keys)
+                                 adoption_channel_keys_by_ts_label(seed_network),
+                                 freq_level=config.qm.freq_level)
         if adopted:
             message = (f"PES loop: reusing {len(adopted)} prior QM result(s) for network "
                       f"{network_id!r}: {sorted(adopted)}.")

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -380,6 +380,28 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         # Translate the structural cross-round memory into THIS round's own labels through the
         # freshly explored network -- the only labels this round's file, runner, and hybrid speak.
         keys_by_ts = channel_keys_by_ts_label(network)
+        declared_ts_labels = tuple(sorted(network.path_reactions_by_ts()))
+        if declared_ts_labels and not keys_by_ts:
+            # The network declares transition states but NOT ONE of them could be structurally
+            # keyed (no parseable structures, or every channel duplicated). The refusal semantics
+            # alone are fail-closed but operationally silent: nothing is ever "already computed",
+            # so every round would re-submit the SAME transition states to ARC until max_rounds --
+            # up to a full budget of duplicate QM spend, with only a log line to explain it. This
+            # is a diagnosable fault of the network/exploration, so the ROUND fails, carrying the
+            # unkeyable labels in its reason.
+            reason = (f'round {round_index}: none of the transition states '
+                      f'{list(declared_ts_labels)} declared by network {network.network_id!r} has '
+                      f'an unambiguous structural channel identity (missing/unparseable species '
+                      f'structures, or structurally duplicated channels). QM computed for them '
+                      f'could not be carried across rounds, so every round would re-submit the '
+                      f'same transition states to ARC; refusing to spend the budget on that.')
+            rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
+                                      diagram_path=diagram_path, queued_ts_labels=(),
+                                      skipped=split_qm_candidates(network, frozenset()).skipped,
+                                      status=PES_LOOP_FAILED, reason=reason))
+            return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED, reason=reason,
+                                 final_network_path=explored_network_path,
+                                 final_diagram_path=diagram_path)
         computed_ts_labels = frozenset(
             ts_label for ts_label, key in keys_by_ts.items() if key in computed_channels)
         split = split_qm_candidates(network, computed_ts_labels)
@@ -470,12 +492,17 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                 # as having no candidates at all -- each skip carries its measured value in the
                 # round record. Never 'failed' (nothing malfunctioned) and never a queue of
                 # below-floor transition states (their manifests would record a coefficient that
-                # justified nothing).
+                # justified nothing). The reason clause is what separates this, at the summary
+                # level, from "everything was already computed".
                 status = PES_LOOP_NO_CANDIDATES if round_index == 0 else PES_LOOP_CONVERGED
+                reason = (f'round {round_index}: every remaining QM candidate of network '
+                          f'{network.network_id!r} measured a ln(k) response below the '
+                          f'min_delta_ln_k floor ({config.qm.min_delta_ln_k:.3e}); see the round '
+                          f"record's skipped entries for the measured values.")
                 rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
                                           diagram_path=diagram_path, queued_ts_labels=(),
-                                          skipped=split.skipped, status=status))
-                return PESLoopResult(rounds=tuple(rounds), status=status, reason='',
+                                          skipped=split.skipped, status=status, reason=reason))
+                return PESLoopResult(rounds=tuple(rounds), status=status, reason=reason,
                                      final_network_path=explored_network_path,
                                      final_diagram_path=diagram_path)
 

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -356,11 +356,17 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         if result.status != EXPLORATION_STATUS_SUCCEEDED:
             reason = '; '.join(result.reasons) if result.reasons else \
                 f"exploration ended with status {result.status!r} and no stated reason."
+            prior = rounds[-1] if rounds else None
             rounds.append(RoundRecord(index=round_index, network_path=current_network_path,
                                       diagram_path=None, queued_ts_labels=(), skipped=(),
                                       status=PES_LOOP_FAILED, reason=reason))
+            # The same rule as the missing-hybrid branch above: this round failed, but rounds
+            # 0..N-1 explored real networks and drew real diagrams, and those remain the best
+            # result this run has. Reporting None here throws them away and makes the caller (e.g.
+            # PES.py, which logs both paths) report a run that produced nothing at all.
             return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED, reason=reason,
-                                 final_network_path=None, final_diagram_path=None)
+                                 final_network_path=prior.network_path if prior else None,
+                                 final_diagram_path=prior.diagram_path if prior else None)
 
         explored_network_path = result.network_paths[0]
         network = parse_pdep_network_file(explored_network_path)

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -60,7 +60,9 @@ from t3.pdep.explorer.config import PDepExplorerConfig
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED
 from t3.pdep.parser import parse_pdep_network_file
 from t3.pdep.pes_qm import adopt_prior_qm
-from t3.pdep.pes_rounds import RoundPaths, hybrid_network_path, round_paths, split_qm_candidates
+from t3.pdep.pes_rounds import (RoundPaths, attach_sensitivity_evidence, hybrid_network_path,
+                                round_paths, split_qm_candidates)
+from t3.pdep.pes_sa import run_round_me_sensitivity
 from t3.schema import PESLoopConfig
 
 _logger = logging.getLogger(__name__)
@@ -170,30 +172,35 @@ def _trim_candidates(candidates: tuple, config: PESLoopConfig, logger) -> tuple:
     """
     Apply ``config.qm.scope`` and ``config.qm.max_transition_states_per_round`` to ``candidates``.
 
-    Standalone mode has no sensitivity-analysis dict to rank candidates by -- that ranking only
-    exists inside a T3 iteration, where ``t3.pdep.budget`` has a whole field of networks and an SA
-    result to weigh them against. So ``scope == 'sensitive'`` degrades to the network file's own
-    order here, and that degradation is logged at WARNING level rather than applied silently: a
-    caller who asked for sensitivity-ranked spend and silently got file order instead has no way to
-    notice unless the degradation is loud.
+    Every candidate reaching this function already carries the REAL sensitivity evidence this
+    round's own master-equation SA measured for it (``t3.pdep.pes_sa.run_round_me_sensitivity``,
+    stamped by ``t3.pdep.pes_rounds.attach_sensitivity_evidence``), so ``scope == 'sensitive'``
+    ranks by that evidence -- descending ``abs(coefficient)``, ties keeping network-file order --
+    rather than degrading to file order the way it had to before the loop had an SA of its own.
+    ``scope == 'all'`` keeps the network file's own order. Both take the first ``limit``.
 
     Args:
-        candidates (tuple): The ``QMCandidate`` entries to trim, in network-file order.
+        candidates (tuple): The ``QMCandidate`` entries to trim, in network-file order, each
+                            already stamped with its sensitivity evidence.
         config (PESLoopConfig): The loop's configuration.
         logger: A T3 ``Logger``, or ``None``.
 
     Returns:
-        tuple: The trimmed candidates, in network-file order.
+        tuple: The trimmed candidates -- evidence-ranked for ``scope == 'sensitive'``,
+        network-file order for ``scope == 'all'``.
     """
     limit = config.qm.max_transition_states_per_round
-    if config.qm.scope == 'sensitive' and len(candidates) > limit:
-        message = ("PES loop: qm.scope='sensitive' was requested, but standalone mode has no "
-                   "sensitivity-analysis dict to rank candidates by. Degrading to the network "
-                   f"file's own order and taking the first {limit} of {len(candidates)} "
-                   f"candidate(s).")
-        _logger.warning(message)
+    if config.qm.scope == 'sensitive':
+        # sorted() is stable, so equal |coefficient| keeps network-file order -- the determinism
+        # split_qm_candidates' own docstring promises.
+        candidates = tuple(sorted(candidates, key=lambda candidate: -abs(candidate.coefficient)))
+    if len(candidates) > limit:
+        message = (f"PES loop: taking the {'most sensitive' if config.qm.scope == 'sensitive' else 'first'} "
+                   f'{limit} of {len(candidates)} candidate(s) '
+                   f'(qm.max_transition_states_per_round).')
+        _logger.info(message)
         if logger is not None:
-            logger.warning(message)
+            logger.info(message)
     return candidates[:limit]
 
 
@@ -338,22 +345,70 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                  final_network_path=explored_network_path,
                                  final_diagram_path=diagram_path)
 
-        candidates = _trim_candidates(split.candidates, config, logger)
-        # Offered, not yet queued -- qm_runner=None never runs a runner at all, so nothing can be
-        # dropped, and this is the honest record. A real qm_runner's own reported queued_ts_labels
-        # (below) supersedes this once it runs, because build_arc_input can silently drop a
-        # candidate the loop offered (N3).
-        offered_ts_labels = tuple(candidate.ts_label for candidate in candidates)
-
         if qm_runner is None:
+            # Offered, not queued -- no runner ever runs, so nothing can be dropped, and this is
+            # the honest record. No ME SA runs on this path either (there is no QM spend to
+            # justify and no capture to evidence), so scope='sensitive' cannot rank here: the
+            # record simply reports the first `limit` candidates in network-file order.
+            offered = split.candidates[:config.qm.max_transition_states_per_round]
             rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
-                                      diagram_path=diagram_path, queued_ts_labels=offered_ts_labels,
+                                      diagram_path=diagram_path,
+                                      queued_ts_labels=tuple(candidate.ts_label
+                                                             for candidate in offered),
                                       skipped=split.skipped, status=PES_LOOP_DIAGRAM_ONLY,
                                       reason='no qm_runner configured: explored and drew the '
                                             'diagram only, nothing was computed.'))
             return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_DIAGRAM_ONLY,
                                  reason=rounds[-1].reason, final_network_path=explored_network_path,
                                  final_diagram_path=diagram_path)
+
+        if split.candidates:
+            # Defect-1 fix: every queued transition state must carry REAL sensitivity evidence --
+            # capture_ts_artifacts refuses (fail-closed, by design) any captured artifact without
+            # it, so a loop with no evidence source could never complete a round that converged
+            # anything. The evidence is measured, never invented: this round's own Arkane ME SA
+            # on the freshly explored network, through the same production seams T3's in-iteration
+            # pipeline uses (see t3.pdep.pes_sa). An SA that fails, or leaves every candidate
+            # without a finite row, fails the ROUND loudly -- a stall reported honestly, never a
+            # fabricated coefficient shimmed past the capture guard.
+            try:
+                evidence = run_round_me_sensitivity(network_path=explored_network_path,
+                                                    sa_dir=paths.sa,
+                                                    method=config.pes.method,
+                                                    timeout=config.pes.timeout,
+                                                    logger=logger)
+            except (OSError, ValueError) as e:
+                reason = (f'round {round_index}: could not obtain master-equation sensitivity '
+                          f'evidence for network {network.network_id!r}: {e} Every queued '
+                          f'transition state must carry real sensitivity evidence '
+                          f'(t3.pdep.capture refuses a captured artifact without it), so this '
+                          f'round cannot queue QM.')
+                rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
+                                          diagram_path=diagram_path, queued_ts_labels=(),
+                                          skipped=split.skipped, status=PES_LOOP_FAILED,
+                                          reason=reason))
+                return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED, reason=reason,
+                                     final_network_path=explored_network_path,
+                                     final_diagram_path=diagram_path)
+            split = attach_sensitivity_evidence(split, evidence)
+            if not split.candidates and not round0_has_adopted:
+                reason = (f'round {round_index}: the master-equation sensitivity analysis for '
+                          f'network {network.network_id!r} measured no finite sensitivity '
+                          f'evidence for any QM candidate, so nothing can be queued (see the '
+                          f"round record's skipped entries for the per-candidate reasons).")
+                rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
+                                          diagram_path=diagram_path, queued_ts_labels=(),
+                                          skipped=split.skipped, status=PES_LOOP_FAILED,
+                                          reason=reason))
+                return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED, reason=reason,
+                                     final_network_path=explored_network_path,
+                                     final_diagram_path=diagram_path)
+
+        candidates = _trim_candidates(split.candidates, config, logger)
+        # Offered, not yet queued. A real qm_runner's own reported queued_ts_labels (below)
+        # supersedes this once it runs, because build_arc_input can silently drop a candidate the
+        # loop offered (N3).
+        offered_ts_labels = tuple(candidate.ts_label for candidate in candidates)
 
         if round0_has_adopted:
             newly_computed, actually_queued = qm_runner(candidates, paths, config,

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -62,8 +62,9 @@ from t3.pdep.explorer.config import PDepExplorerConfig
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED
 from t3.pdep.parser import parse_pdep_network_file
 from t3.pdep.pes_qm import adopt_prior_qm
-from t3.pdep.pes_rounds import (RoundPaths, attach_sensitivity_evidence, hybrid_network_path,
-                                round_paths, split_qm_candidates)
+from t3.pdep.pes_rounds import (RoundPaths, attach_sensitivity_evidence,
+                                channel_keys_by_ts_label, hybrid_network_path, round_paths,
+                                split_qm_candidates)
 from t3.pdep.pes_sa import run_round_me_sensitivity
 from t3.schema import PESLoopConfig
 
@@ -232,22 +233,27 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
             means "no QM this run" -- explore and draw the first round's
             diagram only, which is the honest behaviour when no QM runner is configured, not a
             crash.
-        adopted_ts_labels (frozenset, optional): Network-local TS labels already computed before
-            this loop started (e.g. reused from an earlier T3 project), seeded into
-            ``computed_ts_labels`` before round 0. This is unioned with -- not replaced by --
-            whatever ``config.reuse.from_t3_projects`` itself resolves to (see below); passing this
+        adopted_ts_labels (frozenset, optional): TS labels of the SEED network
+            (``config.pes.network``) already computed before this loop started (e.g. reused from
+            an earlier T3 project). Each is translated to its structural channel key through the
+            seed network (labels are positional and do not survive re-exploration -- see the
+            keying comment at the top of this function's body) and seeded as computed before
+            round 0; a label with no unambiguous structural identity is warned about and
+            re-decided each round instead. This is unioned with -- not replaced by -- whatever
+            ``config.reuse.from_t3_projects`` itself resolves to (see below); passing this
             explicitly is for callers (e.g. tests) that already have the adopted set in hand and
             want to skip re-discovering it.
         logger: A T3 ``Logger``, or ``None``.
 
     When ``config.reuse.from_t3_projects`` is non-empty, this function itself calls
-    ``t3.pdep.pes_qm.adopt_prior_qm(config.reuse.from_t3_projects, network_id, config.qm.sp_level)``
-    before round 0 (``network_id`` derived the same way ``t3.pdep.parser.parse_pdep_network_file``
-    would derive it from ``config.pes.network``, i.e. ``Path(config.pes.network).stem``) and unions
-    the result into ``computed_ts_labels``'s round-0 seed. A TS adopted this way is therefore never
-    offered to ``qm_runner`` at round 0 (``t3.pdep.pes_rounds.split_qm_candidates`` treats any label
-    already in ``computed_ts_labels`` as already computed) -- it is not merely available for the
-    caller to use, it actually prevents the redundant ARC submission.
+    ``t3.pdep.pes_qm.adopt_prior_qm`` before round 0 (``network_id`` derived the same way
+    ``t3.pdep.parser.parse_pdep_network_file`` would derive it from ``config.pes.network``, i.e.
+    ``Path(config.pes.network).stem``), handing it the seed network's structural channel keys
+    (``t3.pdep.pes_rounds.channel_keys_by_ts_label``) to match prior captures against, and seeds
+    every adopted channel as computed. A channel adopted this way is therefore never offered to
+    ``qm_runner`` (its per-round label is translated into ``split_qm_candidates``'s computed set)
+    -- it is not merely available for the caller to use, it actually prevents the redundant ARC
+    submission.
 
     Returns:
         PESLoopResult: The rounds that ran and why the loop stopped.
@@ -262,35 +268,56 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
             at the top of every round after the first).
     """
     rounds = []
-    computed_ts_labels = frozenset(adopted_ts_labels) if adopted_ts_labels else frozenset()
-    adopted = dict()
-    # Defect-3 fix: every QM artifact this loop can fold into a hybrid, cumulative across rounds --
-    # network-local TS label -> the artifact's path in the capture where it was FIRST captured
-    # (or in the prior project's own capture, for adopted ones). Passed to qm_runner EVERY round
-    # (as `adopted`), because arc_qm_runner builds each round's hybrid from that round's own
-    # capture plus exactly this map: without it, a TS converged in round N silently reverts to an
-    # RMG/ILT Arrhenius line in round N+1's hybrid -- the fail-open shape t3.pdep.hybrid's
-    # invariant 2 exists to prevent. The path always points at the ORIGINATING capture (which has
-    # the verified manifest _adopted_energy_settings needs), never at a later round's re-vendored
-    # copy.
-    qm_artifacts = dict()
+    # Cross-round memory is keyed STRUCTURALLY (t3.pdep.pes_rounds.structural_channel_key), never
+    # by TS or reaction label: every label Arkane writes into a network file is purely positional
+    # (rmgpy/rmg/pdep.py:854 replaces every path reaction's transition state with a fresh,
+    # label-less object before each write, and path_reactions is append-with-remove), so a
+    # label-keyed carry can attach a computed barrier to the WRONG saddle point after a pruning or
+    # discovery renumbers the file. computed_channels is every channel whose QM is already in
+    # hand; qm_artifacts_by_channel maps those that have an artifact to its path in the capture
+    # where it was FIRST captured (or the prior project's own capture, for adopted ones) -- the
+    # ORIGINATING capture, whose verified manifest still exists, never a later round's re-vendored
+    # copy. Every round translates both through the freshly explored network's own
+    # channel_keys_by_ts_label map, so the runner always speaks THAT round's labels (defect-3
+    # fix: without the per-round fold, a TS converged in round N silently reverts to an RMG/ILT
+    # Arrhenius line in round N+1's hybrid -- the fail-open shape t3.pdep.hybrid's invariant 2
+    # exists to prevent).
+    computed_channels = set()
+    qm_artifacts_by_channel = dict()
+    if adopted_ts_labels or config.reuse.from_t3_projects:
+        seed_network = parse_pdep_network_file(path=config.pes.network)
+        seed_channel_keys = channel_keys_by_ts_label(seed_network)
+    if adopted_ts_labels:
+        for ts_label in sorted(adopted_ts_labels):
+            key = seed_channel_keys.get(ts_label)
+            if key is None:
+                message = (f'PES loop: adopted_ts_labels names {ts_label!r}, but that transition '
+                           f'state has no unambiguous structural channel identity in '
+                           f'{config.pes.network!r}; it cannot be carried and will be re-decided '
+                           f'each round.')
+                _logger.warning(message)
+                if logger is not None:
+                    logger.warning(message)
+                continue
+            computed_channels.add(key)
     if config.reuse.from_t3_projects:
         network_id = Path(config.pes.network).stem
-        seed_network = parse_pdep_network_file(path=config.pes.network)
-        path_reaction_labels_by_ts_label = {
-            ts_label: tuple(sorted(path_reaction.label for path_reaction in path_reactions))
-            for ts_label, path_reactions in seed_network.path_reactions_by_ts().items()
-        }
         adopted = adopt_prior_qm(config.reuse.from_t3_projects, network_id, config.qm.sp_level,
-                                 path_reaction_labels_by_ts_label)
+                                 seed_channel_keys)
         if adopted:
             message = (f"PES loop: reusing {len(adopted)} prior QM result(s) for network "
                       f"{network_id!r}: {sorted(adopted)}.")
             _logger.info(message)
             if logger is not None:
                 logger.info(message)
-        computed_ts_labels = computed_ts_labels | frozenset(adopted)
-        qm_artifacts.update(adopted)
+        for ts_label, artifact_path in adopted.items():
+            # adopt_prior_qm only ever returns labels taken from the keys of seed_channel_keys.
+            key = seed_channel_keys[ts_label]
+            computed_channels.add(key)
+            qm_artifacts_by_channel[key] = artifact_path
+    # Whether round 0 starts with adopted ARTIFACTS to fold (reuse), as opposed to labels merely
+    # marked computed (adopted_ts_labels carries no artifact paths) -- the round-0 fold decision.
+    prior_adopted_artifacts = bool(qm_artifacts_by_channel)
     current_network_path = config.pes.network
     max_rounds = config.termination.max_rounds
 
@@ -350,6 +377,11 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
             if logger is not None:
                 logger.warning(message)
 
+        # Translate the structural cross-round memory into THIS round's own labels through the
+        # freshly explored network -- the only labels this round's file, runner, and hybrid speak.
+        keys_by_ts = channel_keys_by_ts_label(network)
+        computed_ts_labels = frozenset(
+            ts_label for ts_label, key in keys_by_ts.items() if key in computed_channels)
         split = split_qm_candidates(network, computed_ts_labels)
 
         # C2: a round that adopted prior QM at round 0 must not early-return here just because it
@@ -358,7 +390,7 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         # (with an empty candidates tuple) so it can fold the adopted artifacts into a hybrid
         # network; only when there is also no qm_runner to do that (no way to write a hybrid at
         # all) does this fall through to the diagram-only return below.
-        round0_has_adopted = round_index == 0 and bool(adopted)
+        round0_has_adopted = round_index == 0 and prior_adopted_artifacts
         if not split.candidates and not round0_has_adopted:
             status = PES_LOOP_NO_CANDIDATES if round_index == 0 else PES_LOOP_CONVERGED
             rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
@@ -455,17 +487,36 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
 
         # Defect-3 fix: EVERY round's qm_runner call carries every previously computed artifact
         # (adopted from prior projects at round 0, converged by any earlier round of this loop),
-        # uniformly -- the previous round0-only special case is exactly what let QM die at the
-        # round boundary. A copy is passed so a runner cannot mutate the loop's own record.
+        # uniformly, translated into THIS round's own labels through keys_by_ts -- the previous
+        # round0-only special case is exactly what let QM die at the round boundary. A channel
+        # carried in qm_artifacts_by_channel but absent from this round's network (pruned, or no
+        # longer unambiguously keyable) is simply not folded this round; it stays in the memory.
+        adopted_for_round = {
+            ts_label: qm_artifacts_by_channel[key]
+            for ts_label, key in keys_by_ts.items() if key in qm_artifacts_by_channel
+        }
         newly_computed, actually_queued = qm_runner(candidates, paths, config, network.network_id,
-                                                    adopted=dict(qm_artifacts))
-        computed_ts_labels = computed_ts_labels | newly_computed
+                                                    adopted=adopted_for_round)
         for ts_label in newly_computed:
+            key = keys_by_ts.get(ts_label)
+            if key is None:
+                # Converged but structurally unkeyable (see channel_keys_by_ts_label): it cannot
+                # be carried without risking a wrong-saddle-point attribution, so it will be
+                # re-decided (and possibly re-queued) next round -- duplicated spend, loudly, in
+                # preference to a misattributed barrier.
+                message = (f'PES loop: transition state {ts_label!r} of network '
+                           f'{network.network_id!r} converged but has no unambiguous structural '
+                           f'channel identity; its artifact cannot be carried across rounds.')
+                _logger.warning(message)
+                if logger is not None:
+                    logger.warning(message)
+                continue
+            computed_channels.add(key)
             # Where this round's capture vendored the converged artifact -- a stable layout
             # invariant of t3.pdep.capture (see captured_qm_artifact_path). Recorded off the
             # ORIGINATING round's capture so later rounds always re-vendor from a directory whose
             # own verified manifest still exists.
-            qm_artifacts[ts_label] = captured_qm_artifact_path(
+            qm_artifacts_by_channel[key] = captured_qm_artifact_path(
                 paths.capture, arc_ts_label(network.network_id, ts_label))
         queued_ts_labels = tuple(actually_queued)
 

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -335,9 +335,11 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
     # three conditions against each other. The seed network is still parsed only when something
     # actually needs its keys; an empty map is the truthful value when nothing does.
     seed_channel_keys = dict()
+    seed_adoption_keys = dict()
     if adopted_ts_labels or config.reuse.from_t3_projects:
         seed_network = parse_pdep_network_file(path=config.pes.network)
         seed_channel_keys = channel_keys_by_ts_label(seed_network)
+        seed_adoption_keys = adoption_channel_keys_by_ts_label(seed_network)
     if adopted_ts_labels:
         # A mapping supplies the artifact for each label; a bare iterable supplies none, and every
         # label in it therefore resolves to None below and is refused (see the fail-closed check).
@@ -391,7 +393,7 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         # t3.pdep.pes_rounds.adoption_channel_keys_by_ts_label. freq_level goes with sp_level
         # because ARC's own model_chemistry string depends on both.
         adopted = adopt_prior_qm(config.reuse.from_t3_projects, network_id, config.qm.sp_level,
-                                 adoption_channel_keys_by_ts_label(seed_network),
+                                 seed_adoption_keys,
                                  freq_level=config.qm.freq_level)
         if adopted:
             message = (f"PES loop: reusing {len(adopted)} prior QM result(s) for network "

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -513,10 +513,9 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                      final_diagram_path=diagram_path)
 
         candidates = _trim_candidates(split.candidates, config, logger)
-        # Offered, not yet queued. A real qm_runner's own reported queued_ts_labels (below)
-        # supersedes this once it runs, because build_arc_input can silently drop a candidate the
-        # loop offered (N3).
-        offered_ts_labels = tuple(candidate.ts_label for candidate in candidates)
+        # The candidates are OFFERED, not yet queued: the round record's queued_ts_labels comes
+        # from qm_runner's own reported queued half (below), never from this list, because
+        # build_arc_input can silently drop a candidate the loop offered (N3).
 
         # Defect-3 fix: EVERY round's qm_runner call carries every previously computed artifact
         # (adopted from prior projects at round 0, converged by any earlier round of this loop),

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -28,10 +28,14 @@ Why ``qm_runner`` is injected rather than called directly: this loop's own job i
 explore, draw, split candidates from skips, decide whether to stop -- and none of that requires an
 ARC cluster to test. Injecting the QM step as a callable with the signature
 ``qm_runner(candidates, paths, config, network_id) -> frozenset[str]`` lets every round-sequencing
-decision (no-candidates, converged, stalled, max-rounds, failed-explore) be covered by tests that
-never touch ARC. Task 6 supplies the real ARC-backed implementation; ``qm_runner=None`` is not a
-placeholder for "not implemented yet", it is the honest, permanent behaviour for a caller who wants
-explore-and-draw only, with no QM spend at all -- so it must never raise.
+decision (no-candidates, converged, stalled, diagram-only, max-rounds, failed-explore) be covered
+by tests that never touch ARC. Task 6 supplies the real ARC-backed implementation; ``qm_runner=None``
+is not a placeholder for "not implemented yet", it is the honest, permanent behaviour for a caller
+who wants explore-and-draw only, with no QM spend at all -- so it must never raise, and it is
+recorded as ``PES_LOOP_DIAGRAM_ONLY``, never ``PES_LOOP_STALLED``: the two look similar (a round
+that computed no new TS) but differ in kind -- ``stalled`` is an operational fault worth
+investigating (ARC ran and made no progress), ``diagram_only`` is complete success of exactly what
+was asked (no QM was ever requested).
 
 Why every round gets its own ARC project directory (``t3.pdep.pes_rounds.round_paths``): ARC
 recreates its ``calcs/statmech/`` directory with ``delete_existing_subdir=True`` on every rate
@@ -58,6 +62,33 @@ from t3.schema import PESLoopConfig
 
 _logger = logging.getLogger(__name__)
 
+
+def hybrid_network_path(paths: RoundPaths, network_id: str) -> str:
+    """
+    Where a round's ``qm_runner`` must write its hybrid network input file.
+
+    ``RoundPaths.hybrid`` (``t3.pdep.pes_rounds``) is a directory, not a file, and this loop needs
+    a file path to hand the next round's explorer. It also needs that file's stem to carry
+    ``network_id`` rather than the literal ``'hybrid'``, because ``parse_pdep_network_file`` derives
+    ``network_id = Path(path).stem`` (``t3/pdep/parser.py:729``) -- every round writing to a
+    ``hybrid.py`` stem would collapse distinct networks onto one ``network_id``, and with it one ARC
+    job-label namespace (the exact failure ruling C4 exists to prevent).
+
+    This is a module-level function, not an inline expression, so Task 6's real ``qm_runner`` can
+    import and call it directly rather than re-deriving the convention -- the contract lives in
+    code, not in a comment.
+
+    Args:
+        paths (RoundPaths): This round's paths.
+        network_id (str): The network id to preserve in the file's stem (normally the just-explored
+            network's own ``network_id``).
+
+    Returns:
+        str: The hybrid network file path this round's ``qm_runner`` must write to, and the path
+        the next round explores from.
+    """
+    return os.path.join(paths.hybrid, f'{network_id}.py')
+
 # Status values for PESLoopResult.status / RoundRecord.status.
 #
 # - 'converged'      every barriered channel the network declares now has QM (round > 0).
@@ -67,18 +98,23 @@ _logger = logging.getLogger(__name__)
 # - 'stalled'        a round ran the QM runner and it returned no newly-converged TS labels, and
 #                     ``config.termination.stop_when_no_new_ts`` says that is a reason to stop now
 #                     rather than spend the rest of the round budget on a runner that is not making
-#                     progress. Also used for the ``qm_runner=None`` case -- no QM was ever going to
-#                     be attempted, so there is equally nothing to make progress -- because in both
-#                     cases the honest statement is the same: this loop is not going to move the
-#                     network closer to convergence on its own from here.
+#                     progress. This is an OPERATIONAL FAULT: ARC ran, spent time, and produced
+#                     nothing usable, which is worth investigating.
+# - 'diagram_only'    ``qm_runner=None``: no QM was ever going to be attempted, so the loop explored
+#                     and drew one diagram and stopped, exactly as asked. This is the COMPLETE
+#                     SUCCESS of a diagram-only request, not a fault, and must be distinguishable
+#                     from 'stalled' so that a monitor alerting on 'stalled' does not page on every
+#                     diagram-only run.
 # - 'max_rounds'      the round budget was exhausted without converging, without stalling, and
 #                     without a failed explore.
-# - 'failed'          a round could not explore its network at all; never papered over as
-#                     convergence.
+# - 'failed'          a round could not explore its network at all -- including a round whose
+#                     expected hybrid network input file was never written by ``qm_runner`` -- never
+#                     papered over as convergence.
 PES_LOOP_CONVERGED = 'converged'
 PES_LOOP_MAX_ROUNDS = 'max_rounds'
 PES_LOOP_NO_CANDIDATES = 'no_candidates'
 PES_LOOP_STALLED = 'stalled'
+PES_LOOP_DIAGRAM_ONLY = 'diagram_only'
 PES_LOOP_FAILED = 'failed'
 
 
@@ -169,7 +205,7 @@ def _trim_candidates(candidates: tuple, config: PESLoopConfig, logger) -> tuple:
         tuple: The trimmed candidates, in network-file order.
     """
     limit = config.qm.max_transition_states_per_round
-    if config.qm.scope == 'sensitive' and candidates:
+    if config.qm.scope == 'sensitive' and len(candidates) > limit:
         message = ("PES loop: qm.scope='sensitive' was requested, but standalone mode has no "
                    "sensitivity-analysis dict to rank candidates by. Degrading to the network "
                    f"file's own order and taking the first {limit} of {len(candidates)} "
@@ -201,6 +237,15 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
 
     Returns:
         PESLoopResult: The rounds that ran and why the loop stopped.
+
+    Raises:
+        ValueError: If ``config.pes`` cannot build a valid ``PDepExplorerConfig`` (e.g. no
+            ``bath_gas``), propagated from ``PDepExplorerConfig.__post_init__``.
+        FileNotFoundError: If a successfully explored network's own output file cannot be read,
+            propagated from ``parse_pdep_network_file``. A round-N ``qm_runner`` that fails to
+            write its hybrid network file is NOT this case -- that is caught explicitly and
+            returned as ``PES_LOOP_FAILED`` rather than left to raise (see the file-existence check
+            at the top of every round after the first).
     """
     rounds = []
     computed_ts_labels = frozenset(adopted_ts_labels) if adopted_ts_labels else frozenset()
@@ -210,6 +255,23 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
     for round_index in range(max_rounds):
         paths = round_paths(project_directory, round_index)
         os.makedirs(paths.root, exist_ok=True)
+
+        # Rounds after the first explore a hybrid network that a previous round's qm_runner is
+        # contractually obliged to have written (see hybrid_network_path). If it did not, letting
+        # that reach parse_pdep_network_file would raise a bare FileNotFoundError here -- after the
+        # PREVIOUS round already spent real ARC time -- with no round record explaining why. Fail
+        # the round explicitly instead, naming the contract that was broken.
+        if round_index > 0 and not os.path.isfile(current_network_path):
+            reason = (f"round {round_index}: the expected hybrid network file "
+                     f"{current_network_path!r} does not exist. The previous round's qm_runner "
+                     "must write it (see t3.pdep.pes_loop.hybrid_network_path) before returning.")
+            prior = rounds[-1] if rounds else None
+            rounds.append(RoundRecord(index=round_index, network_path=current_network_path,
+                                      diagram_path=None, queued_ts_labels=(), skipped=(),
+                                      status=PES_LOOP_FAILED, reason=reason))
+            return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED, reason=reason,
+                                 final_network_path=prior.network_path if prior else None,
+                                 final_diagram_path=prior.diagram_path if prior else None)
 
         explorer_config = _build_explorer_config(config, project_directory, paths)
         # No selection is available in standalone mode: there is no PDepNetworkSelection to bind
@@ -263,10 +325,10 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         if qm_runner is None:
             rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
                                       diagram_path=diagram_path, queued_ts_labels=queued_ts_labels,
-                                      skipped=split.skipped, status=PES_LOOP_STALLED,
+                                      skipped=split.skipped, status=PES_LOOP_DIAGRAM_ONLY,
                                       reason='no qm_runner configured: explored and drew the '
                                             'diagram only, nothing was computed.'))
-            return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_STALLED,
+            return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_DIAGRAM_ONLY,
                                  reason=rounds[-1].reason, final_network_path=explored_network_path,
                                  final_diagram_path=diagram_path)
 
@@ -288,11 +350,12 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                   skipped=split.skipped, status='continuing'))
 
         # The next round explores the QM-informed surface: a real qm_runner (Task 6) writes this
-        # round's hybrid network input file (t3.pdep.hybrid) into paths.hybrid from its captured
-        # statmech artifacts, folding the newly converged transition states in as Log(...)
-        # references. This driver trusts that contract rather than writing the hybrid file itself --
-        # that write belongs with the capture step that knows what it captured.
-        current_network_path = paths.hybrid
+        # round's hybrid network input file (t3.pdep.hybrid) to hybrid_network_path(paths,
+        # network.network_id) from its captured statmech artifacts, folding the newly converged
+        # transition states in as Log(...) references. This driver trusts that contract rather than
+        # writing the hybrid file itself -- that write belongs with the capture step that knows what
+        # it captured -- and enforces it explicitly at the top of the next round (above).
+        current_network_path = hybrid_network_path(paths, network.network_id)
 
     reason = f'the round budget ({max_rounds}) was exhausted without converging.'
     return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_MAX_ROUNDS, reason=reason,

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -55,7 +55,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from t3.pdep.api import explore_pdep_network
+from t3.pdep.capture import captured_qm_artifact_path
 from t3.pdep.diagram import draw_pes_diagram
+from t3.pdep.join import arc_ts_label
 from t3.pdep.explorer.config import PDepExplorerConfig
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED
 from t3.pdep.parser import parse_pdep_network_file
@@ -213,10 +215,16 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         config (PESLoopConfig): The loop's configuration.
         project_directory (str): The loop's project directory. Must be absolute (see
             ``t3.pdep.pes_rounds.round_paths``).
-        qm_runner: An injected callable, ``qm_runner(candidates, paths, config, network_id) ->
-            tuple[frozenset[str], frozenset[str]]`` -- ``(converged_ts_labels, queued_ts_labels)``,
-            the network-local TS labels that converged this round and the ones the runner actually
-            queued (not necessarily every candidate it was handed -- N3). ``None`` (the default)
+        qm_runner: An injected callable, ``qm_runner(candidates, paths, config, network_id,
+            adopted=...) -> tuple[frozenset[str], frozenset[str]]`` -- ``(converged_ts_labels,
+            queued_ts_labels)``, the network-local TS labels that converged this round and the
+            ones the runner actually queued (not necessarily every candidate it was handed -- N3).
+            ``adopted`` is passed EVERY round: a dict of network-local TS label -> artifact path
+            for every QM artifact already in hand before this round ran (reused from prior
+            projects, or converged by an earlier round of this loop), which the runner must fold
+            into this round's hybrid network alongside whatever converges now -- every round's
+            hybrid carries the CUMULATIVE QM, never just that round's (a TS that ever converged
+            must never revert to an RMG/ILT rate line in a later hybrid). ``None`` (the default)
             means "no QM this run" -- explore and draw the first round's
             diagram only, which is the honest behaviour when no QM runner is configured, not a
             crash.
@@ -252,6 +260,16 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
     rounds = []
     computed_ts_labels = frozenset(adopted_ts_labels) if adopted_ts_labels else frozenset()
     adopted = dict()
+    # Defect-3 fix: every QM artifact this loop can fold into a hybrid, cumulative across rounds --
+    # network-local TS label -> the artifact's path in the capture where it was FIRST captured
+    # (or in the prior project's own capture, for adopted ones). Passed to qm_runner EVERY round
+    # (as `adopted`), because arc_qm_runner builds each round's hybrid from that round's own
+    # capture plus exactly this map: without it, a TS converged in round N silently reverts to an
+    # RMG/ILT Arrhenius line in round N+1's hybrid -- the fail-open shape t3.pdep.hybrid's
+    # invariant 2 exists to prevent. The path always points at the ORIGINATING capture (which has
+    # the verified manifest _adopted_energy_settings needs), never at a later round's re-vendored
+    # copy.
+    qm_artifacts = dict()
     if config.reuse.from_t3_projects:
         network_id = Path(config.pes.network).stem
         seed_network = parse_pdep_network_file(path=config.pes.network)
@@ -268,6 +286,7 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
             if logger is not None:
                 logger.info(message)
         computed_ts_labels = computed_ts_labels | frozenset(adopted)
+        qm_artifacts.update(adopted)
     current_network_path = config.pes.network
     max_rounds = config.termination.max_rounds
 
@@ -410,12 +429,20 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         # loop offered (N3).
         offered_ts_labels = tuple(candidate.ts_label for candidate in candidates)
 
-        if round0_has_adopted:
-            newly_computed, actually_queued = qm_runner(candidates, paths, config,
-                                                         network.network_id, adopted=adopted)
-        else:
-            newly_computed, actually_queued = qm_runner(candidates, paths, config, network.network_id)
+        # Defect-3 fix: EVERY round's qm_runner call carries every previously computed artifact
+        # (adopted from prior projects at round 0, converged by any earlier round of this loop),
+        # uniformly -- the previous round0-only special case is exactly what let QM die at the
+        # round boundary. A copy is passed so a runner cannot mutate the loop's own record.
+        newly_computed, actually_queued = qm_runner(candidates, paths, config, network.network_id,
+                                                    adopted=dict(qm_artifacts))
         computed_ts_labels = computed_ts_labels | newly_computed
+        for ts_label in newly_computed:
+            # Where this round's capture vendored the converged artifact -- a stable layout
+            # invariant of t3.pdep.capture (see captured_qm_artifact_path). Recorded off the
+            # ORIGINATING round's capture so later rounds always re-vendor from a directory whose
+            # own verified manifest still exists.
+            qm_artifacts[ts_label] = captured_qm_artifact_path(
+                paths.capture, arc_ts_label(network.network_id, ts_label))
         queued_ts_labels = tuple(actually_queued)
 
         # Important: qm_runner's returned newly_computed excludes adopted TS labels by contract

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -72,9 +72,13 @@ _logger = logging.getLogger(__name__)
 
 # Status values for PESLoopResult.status / RoundRecord.status.
 #
-# - 'converged'      every barriered channel the network declares now has QM (round > 0).
+# - 'converged'      every barriered channel the network declares now has QM, or every channel
+#                     still lacking it measured a ln(k) response below qm.min_delta_ln_k -- a
+#                     measured "not worth the spend", recorded per channel in the round's skipped
+#                     entries (round > 0).
 # - 'no_candidates'  the very first round already had nothing to compute (round == 0): a network
-#                     that is barrierless end to end is not a loop that "converged" after doing
+#                     that is barrierless end to end, or whose every barriered channel measured a
+#                     response below the floor, is not a loop that "converged" after doing
 #                     work, it never had any to do.
 # - 'stalled'        a round ran the QM runner and it returned no newly-converged TS labels, and
 #                     ``config.termination.stop_when_no_new_ts`` says that is a reason to stop now
@@ -409,17 +413,37 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                 return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED, reason=reason,
                                      final_network_path=explored_network_path,
                                      final_diagram_path=diagram_path)
-            split = attach_sensitivity_evidence(split, evidence)
+            any_finite_evidence = any(candidate.ts_label in evidence
+                                      for candidate in split.candidates)
+            split = attach_sensitivity_evidence(split, evidence,
+                                                min_delta_ln_k=config.qm.min_delta_ln_k)
             if not split.candidates and not round0_has_adopted:
-                reason = (f'round {round_index}: the master-equation sensitivity analysis for '
-                          f'network {network.network_id!r} measured no finite sensitivity '
-                          f'evidence for any QM candidate, so nothing can be queued (see the '
-                          f"round record's skipped entries for the per-candidate reasons).")
+                if not any_finite_evidence:
+                    # The SA ran but measured nothing finite for ANY candidate -- an operational
+                    # fault in the evidence pipeline, not a legitimate "nothing worth computing".
+                    reason = (f'round {round_index}: the master-equation sensitivity analysis for '
+                              f'network {network.network_id!r} measured no finite sensitivity '
+                              f'evidence for any QM candidate, so nothing can be queued (see the '
+                              f"round record's skipped entries for the per-candidate reasons).")
+                    rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
+                                              diagram_path=diagram_path, queued_ts_labels=(),
+                                              skipped=split.skipped, status=PES_LOOP_FAILED,
+                                              reason=reason))
+                    return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED,
+                                         reason=reason,
+                                         final_network_path=explored_network_path,
+                                         final_diagram_path=diagram_path)
+                # Every remaining candidate measured a real response BELOW the floor: a measured
+                # "nothing here is worth the QM spend", which is the same honest terminal outcome
+                # as having no candidates at all -- each skip carries its measured value in the
+                # round record. Never 'failed' (nothing malfunctioned) and never a queue of
+                # below-floor transition states (their manifests would record a coefficient that
+                # justified nothing).
+                status = PES_LOOP_NO_CANDIDATES if round_index == 0 else PES_LOOP_CONVERGED
                 rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
                                           diagram_path=diagram_path, queued_ts_labels=(),
-                                          skipped=split.skipped, status=PES_LOOP_FAILED,
-                                          reason=reason))
-                return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED, reason=reason,
+                                          skipped=split.skipped, status=status))
+                return PESLoopResult(rounds=tuple(rounds), status=status, reason='',
                                      final_network_path=explored_network_path,
                                      final_diagram_path=diagram_path)
 

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -52,43 +52,19 @@ file: everything at that boundary flows through ``t3.pdep.parser`` (``ast.parse`
 import logging
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 from t3.pdep.api import explore_pdep_network
 from t3.pdep.diagram import draw_pes_diagram
 from t3.pdep.explorer.config import PDepExplorerConfig
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED
 from t3.pdep.parser import parse_pdep_network_file
-from t3.pdep.pes_rounds import RoundPaths, round_paths, split_qm_candidates
+from t3.pdep.pes_qm import adopt_prior_qm
+from t3.pdep.pes_rounds import RoundPaths, hybrid_network_path, round_paths, split_qm_candidates
 from t3.schema import PESLoopConfig
 
 _logger = logging.getLogger(__name__)
 
-
-def hybrid_network_path(paths: RoundPaths, network_id: str) -> str:
-    """
-    Where a round's ``qm_runner`` must write its hybrid network input file.
-
-    ``RoundPaths.hybrid`` (``t3.pdep.pes_rounds``) is a directory, not a file, and this loop needs
-    a file path to hand the next round's explorer. It also needs that file's stem to carry
-    ``network_id`` rather than the literal ``'hybrid'``, because ``parse_pdep_network_file`` derives
-    ``network_id = Path(path).stem`` (``t3/pdep/parser.py:729``) -- every round writing to a
-    ``hybrid.py`` stem would collapse distinct networks onto one ``network_id``, and with it one ARC
-    job-label namespace (the exact failure ruling C4 exists to prevent).
-
-    This is a module-level function, not an inline expression, so Task 6's real ``qm_runner`` can
-    import and call it directly rather than re-deriving the convention -- the contract lives in
-    code, not in a comment.
-
-    Args:
-        paths (RoundPaths): This round's paths.
-        network_id (str): The network id to preserve in the file's stem (normally the just-explored
-            network's own ``network_id``).
-
-    Returns:
-        str: The hybrid network file path this round's ``qm_runner`` must write to, and the path
-        the next round explores from.
-    """
-    return os.path.join(paths.hybrid, f'{network_id}.py')
 
 # Status values for PESLoopResult.status / RoundRecord.status.
 #
@@ -239,8 +215,20 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
             crash.
         adopted_ts_labels (frozenset, optional): Network-local TS labels already computed before
             this loop started (e.g. reused from an earlier T3 project), seeded into
-            ``computed_ts_labels`` before round 0.
+            ``computed_ts_labels`` before round 0. This is unioned with -- not replaced by --
+            whatever ``config.reuse.from_t3_projects`` itself resolves to (see below); passing this
+            explicitly is for callers (e.g. tests) that already have the adopted set in hand and
+            want to skip re-discovering it.
         logger: A T3 ``Logger``, or ``None``.
+
+    When ``config.reuse.from_t3_projects`` is non-empty, this function itself calls
+    ``t3.pdep.pes_qm.adopt_prior_qm(config.reuse.from_t3_projects, network_id, config.qm.sp_level)``
+    before round 0 (``network_id`` derived the same way ``t3.pdep.parser.parse_pdep_network_file``
+    would derive it from ``config.pes.network``, i.e. ``Path(config.pes.network).stem``) and unions
+    the result into ``computed_ts_labels``'s round-0 seed. A TS adopted this way is therefore never
+    offered to ``qm_runner`` at round 0 (``t3.pdep.pes_rounds.split_qm_candidates`` treats any label
+    already in ``computed_ts_labels`` as already computed) -- it is not merely available for the
+    caller to use, it actually prevents the redundant ARC submission.
 
     Returns:
         PESLoopResult: The rounds that ran and why the loop stopped.
@@ -256,6 +244,13 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
     """
     rounds = []
     computed_ts_labels = frozenset(adopted_ts_labels) if adopted_ts_labels else frozenset()
+    if config.reuse.from_t3_projects:
+        network_id = Path(config.pes.network).stem
+        adopted = adopt_prior_qm(config.reuse.from_t3_projects, network_id, config.qm.sp_level)
+        if adopted and logger is not None:
+            logger.info(f"PES loop: reusing {len(adopted)} prior QM result(s) for network "
+                       f"{network_id!r}: {sorted(adopted)}.")
+        computed_ts_labels = computed_ts_labels | frozenset(adopted)
     current_network_path = config.pes.network
     max_rounds = config.termination.max_rounds
 

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -146,9 +146,14 @@ class PESLoopResult:
         reason (str): Why the loop stopped, when ``status`` alone does not say (chiefly
             ``'failed'``). ``''`` otherwise.
         final_network_path (str | None): The last successfully explored network file, or ``None``
-            if the very first round failed to explore.
-        final_diagram_path (str | None): The last round's PES diagram, or ``None`` if no round ever
-            managed to draw one.
+            if the very first round failed to explore. On ``'max_rounds'`` with the last round
+            having converged (or adopted) anything, this is the re-exploration of THAT round's
+            hybrid network -- the surface carrying the barriers that round computed -- not the
+            pre-QM network its own ``RoundRecord`` carries.
+        final_diagram_path (str | None): The PES diagram drawn from ``final_network_path``, or
+            ``None`` if no diagram could be drawn. Same rule as above: on ``'max_rounds'`` after a
+            productive final round this is the QM-informed diagram, drawn after that round's
+            quantum chemistry was folded in, never the last ``RoundRecord``'s pre-QM one.
     """
     rounds: tuple
     status: str
@@ -209,6 +214,37 @@ def _trim_candidates(candidates: tuple, config: PESLoopConfig, logger) -> tuple:
         if logger is not None:
             logger.info(message)
     return candidates[:limit]
+
+
+def _draw_round_diagram(explored_network_path: str, diagram_path: str, logger) -> str | None:
+    """
+    Draw one round's PES diagram -- strictly best-effort, exactly as
+    ``t3.pdep.explorer.arkane.ArkaneExplorer._draw_pes_diagram`` already treats it.
+
+    Every exception is swallowed and logged, not only the ``ValueError`` a parser/data refusal
+    raises: a matplotlib backend problem, a full disk, or a read-only output directory has nothing
+    to do with whether the exploration this diagram describes succeeded, and must never flip a
+    round that genuinely explored into an aborted loop. The diagram describes the result; it is
+    not part of it.
+
+    Args:
+        explored_network_path (str): The freshly explored network to draw from.
+        diagram_path (str): Where to write the diagram.
+        logger: A T3 ``Logger``, or ``None``.
+
+    Returns:
+        str | None: ``diagram_path`` if the diagram was drawn, ``None`` if drawing failed.
+    """
+    try:
+        draw_pes_diagram(network_path=explored_network_path, output_path=diagram_path)
+    except Exception as e:
+        message = (f'PES loop: could not draw the diagram for {explored_network_path} '
+                   f'({type(e).__name__}): {e}')
+        _logger.warning(message)
+        if logger is not None:
+            logger.warning(message)
+        return None
+    return diagram_path
 
 
 def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
@@ -326,6 +362,9 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
     prior_adopted_artifacts = bool(qm_artifacts_by_channel)
     current_network_path = config.pes.network
     max_rounds = config.termination.max_rounds
+    # Whether the round that ran last folded QM into a hybrid network -- read only by the
+    # final-draw pass below, which is reachable only after at least one round ran.
+    last_round_made_progress = False
 
     for round_index in range(max_rounds):
         paths = round_paths(project_directory, round_index)
@@ -377,17 +416,7 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         explored_network_path = result.network_paths[0]
         network = parse_pdep_network_file(explored_network_path)
 
-        diagram_path = None
-        try:
-            draw_pes_diagram(network_path=explored_network_path, output_path=paths.diagram)
-            diagram_path = paths.diagram
-        except ValueError as e:
-            # A legitimate refusal (a species with no E0), not a bug -- record it and keep going
-            # rather than let a diagram problem kill an otherwise-working exploration round.
-            message = f'PES loop: could not draw the diagram for {explored_network_path}: {e}'
-            _logger.warning(message)
-            if logger is not None:
-                logger.warning(message)
+        diagram_path = _draw_round_diagram(explored_network_path, paths.diagram, logger)
 
         # Translate the structural cross-round memory into THIS round's own labels through the
         # freshly explored network -- the only labels this round's file, runner, and hybrid speak.
@@ -603,8 +632,52 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
         # to trust -- see no_progress_reason.
         current_network_path = (hybrid_network_path(paths, network.network_id) if made_progress
                                 else explored_network_path)
+        last_round_made_progress = made_progress
 
     reason = f'the round budget ({max_rounds}) was exhausted without converging.'
+    final_network_path = rounds[-1].network_path
+    final_diagram_path = rounds[-1].diagram_path
+
+    # THE defect this whole loop exists to eliminate, re-entering by the back door. The last
+    # permitted round's hybrid network -- the one carrying every barrier ARC just converged -- is
+    # written AFTER that round's own diagram was already drawn from its pre-QM explored network.
+    # Returning rounds[-1] here therefore hands the caller (PES.py logs both paths, and a campaign
+    # reads the diagram) the RMG-estimate surface, silently, in exactly the configuration a user is
+    # most likely to run first (max_rounds: 1). So the loop completes one final
+    # exploration-and-draw from that hybrid before returning. This charges NO further QM: no
+    # candidate split, no ME SA, no qm_runner call, no ARC project directory -- only the explore
+    # and the draw. It gets round_paths(max_rounds) as its own directory so its explorer output and
+    # diagram never overwrite the last real round's, and it appends no RoundRecord: no round of QM
+    # happened, and claiming one would misreport the budget that was actually spent.
+    if last_round_made_progress and os.path.isfile(current_network_path):
+        final_paths = round_paths(project_directory, max_rounds)
+        os.makedirs(final_paths.root, exist_ok=True)
+        final_result = explore_pdep_network(
+            network_path=current_network_path,
+            config=_build_explorer_config(config, project_directory, final_paths), logger=logger)
+        if final_result.status == EXPLORATION_STATUS_SUCCEEDED and final_result.network_paths:
+            final_network_path = final_result.network_paths[0]
+            final_diagram_path = _draw_round_diagram(final_network_path, final_paths.diagram,
+                                                     logger)
+            reason = (f'{reason} The final network and diagram are the QM-informed re-exploration '
+                      f'of round {max_rounds - 1}\'s hybrid network {current_network_path!r}, '
+                      f'drawn after that round\'s quantum chemistry was folded in.')
+        else:
+            # Fail OPEN, loudly: the last round's own explored network and diagram remain the best
+            # result this run has, and reporting them is truthful -- they simply predate this
+            # round's QM. Turning a bonus re-exploration into PES_LOOP_FAILED would throw away
+            # every round that did work.
+            failure = ('; '.join(final_result.reasons) if final_result.reasons
+                       else f'status {final_result.status!r}')
+            message = (f'PES loop: could not re-explore the final round\'s hybrid network '
+                       f'{current_network_path!r} to draw a QM-informed diagram ({failure}); '
+                       f'reporting round {max_rounds - 1}\'s own explored network and diagram, '
+                       f'which predate that round\'s quantum chemistry.')
+            _logger.warning(message)
+            if logger is not None:
+                logger.warning(message)
+            reason = f'{reason} {message}'
+
     return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_MAX_ROUNDS, reason=reason,
-                         final_network_path=rounds[-1].network_path,
-                         final_diagram_path=rounds[-1].diagram_path)
+                         final_network_path=final_network_path,
+                         final_diagram_path=final_diagram_path)

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -1,0 +1,300 @@
+"""
+t3 pdep pes_loop module
+
+The standalone PES exploration loop: explore a network with Arkane, draw the PES diagram Arkane's
+own output supports, queue the barriered channels that still lack a transition-state QM result,
+run QM, fold the results back into the network, and re-explore -- round after round until the
+network converges, the round budget runs out, or a round cannot explore at all.
+
+Why this lives here, standalone, rather than inside ``t3.main``'s own iteration loop: the whole
+point is to let this loop be run and corroborated on its own, against a single network, before it
+is trusted to influence what T3's kinetic-model iteration spends its QM budget on. ``t3.main``
+folding directly into an unreviewed loop that sequences real ARC submissions would make every bug
+here a live-campaign bug; a standalone entry point lets Task 6's real ARC-backed ``qm_runner`` and
+this driver be exercised and debugged in isolation first.
+
+Why the PES diagram is redrawn from EACH round's freshly explored network, never from the input
+network some earlier round started with: T3's hybrid network file (``t3.pdep.hybrid``) represents
+a QM'd transition state as a statmech artifact reference -- a ``Log(...)`` chain into a Gaussian
+output file -- never as an inline ``E0`` (see ``t3/pdep/hybrid.py:46``). The computed barrier does
+not exist as a NUMBER until Arkane actually runs and applies its atom-energy corrections to that
+statmech data. Drawing from any input file, hybrid or otherwise, can therefore never show a
+computed barrier; only Arkane's own output network can. This is the bug this whole loop exists to
+fix: T3 has been observed to draw its PES diagram once, from the pre-QM network, and never redraw
+it, producing byte-identical diagrams across two runs even though one of them converged a genuine
+saddle point.
+
+Why ``qm_runner`` is injected rather than called directly: this loop's own job is sequencing --
+explore, draw, split candidates from skips, decide whether to stop -- and none of that requires an
+ARC cluster to test. Injecting the QM step as a callable with the signature
+``qm_runner(candidates, paths, config, network_id) -> frozenset[str]`` lets every round-sequencing
+decision (no-candidates, converged, stalled, max-rounds, failed-explore) be covered by tests that
+never touch ARC. Task 6 supplies the real ARC-backed implementation; ``qm_runner=None`` is not a
+placeholder for "not implemented yet", it is the honest, permanent behaviour for a caller who wants
+explore-and-draw only, with no QM spend at all -- so it must never raise.
+
+Why every round gets its own ARC project directory (``t3.pdep.pes_rounds.round_paths``): ARC
+recreates its ``calcs/statmech/`` directory with ``delete_existing_subdir=True`` on every rate
+pass, so a second ARC run sharing one project directory would destroy the first round's
+un-captured artifacts. Giving each round a fresh, self-contained directory tree makes that
+structurally impossible instead of merely a discipline to remember.
+
+This module never imports ``rmgpy`` or ``arkane``, and never ``exec``s or ``import``s a network
+file: everything at that boundary flows through ``t3.pdep.parser`` (``ast.parse`` only) and
+``t3.pdep.diagram``.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+
+from t3.pdep.api import explore_pdep_network
+from t3.pdep.diagram import draw_pes_diagram
+from t3.pdep.explorer.config import PDepExplorerConfig
+from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED
+from t3.pdep.parser import parse_pdep_network_file
+from t3.pdep.pes_rounds import RoundPaths, round_paths, split_qm_candidates
+from t3.schema import PESLoopConfig
+
+_logger = logging.getLogger(__name__)
+
+# Status values for PESLoopResult.status / RoundRecord.status.
+#
+# - 'converged'      every barriered channel the network declares now has QM (round > 0).
+# - 'no_candidates'  the very first round already had nothing to compute (round == 0): a network
+#                     that is barrierless end to end is not a loop that "converged" after doing
+#                     work, it never had any to do.
+# - 'stalled'        a round ran the QM runner and it returned no newly-converged TS labels, and
+#                     ``config.termination.stop_when_no_new_ts`` says that is a reason to stop now
+#                     rather than spend the rest of the round budget on a runner that is not making
+#                     progress. Also used for the ``qm_runner=None`` case -- no QM was ever going to
+#                     be attempted, so there is equally nothing to make progress -- because in both
+#                     cases the honest statement is the same: this loop is not going to move the
+#                     network closer to convergence on its own from here.
+# - 'max_rounds'      the round budget was exhausted without converging, without stalling, and
+#                     without a failed explore.
+# - 'failed'          a round could not explore its network at all; never papered over as
+#                     convergence.
+PES_LOOP_CONVERGED = 'converged'
+PES_LOOP_MAX_ROUNDS = 'max_rounds'
+PES_LOOP_NO_CANDIDATES = 'no_candidates'
+PES_LOOP_STALLED = 'stalled'
+PES_LOOP_FAILED = 'failed'
+
+
+@dataclass(frozen=True)
+class RoundRecord:
+    """
+    What one round of the PES exploration loop did.
+
+    Attributes:
+        index (int): The zero-based round number.
+        network_path (str): The network file this round explored from (before this round's own
+            re-exploration), or the freshly explored network if exploration succeeded.
+        diagram_path (str | None): Where this round's PES diagram was written, or ``None`` if
+            drawing it was refused (a species with no ``E0``) or exploration itself failed.
+        queued_ts_labels (tuple): The network-local TS labels sent to ``qm_runner`` this round.
+        skipped (tuple): The ``SkippedChannel`` entries for this round, each carrying its reason.
+        status (str): This round's outcome. ``'continuing'`` for a round that queued QM and is not
+            the loop's last one; otherwise one of the ``PES_LOOP_*`` status constants, matching the
+            ``PESLoopResult.status`` this round ended the loop with.
+        reason (str): Why, for a non-obvious status (chiefly ``'failed'``). ``''`` otherwise.
+    """
+    index: int
+    network_path: str
+    diagram_path: str | None
+    queued_ts_labels: tuple
+    skipped: tuple
+    status: str
+    reason: str = ''
+
+
+@dataclass(frozen=True)
+class PESLoopResult:
+    """
+    The outcome of running the PES exploration loop to a stop.
+
+    Attributes:
+        rounds (tuple): The ``RoundRecord`` for every round that ran, in order.
+        status (str): One of the ``PES_LOOP_*`` status constants.
+        reason (str): Why the loop stopped, when ``status`` alone does not say (chiefly
+            ``'failed'``). ``''`` otherwise.
+        final_network_path (str | None): The last successfully explored network file, or ``None``
+            if the very first round failed to explore.
+        final_diagram_path (str | None): The last round's PES diagram, or ``None`` if no round ever
+            managed to draw one.
+    """
+    rounds: tuple
+    status: str
+    reason: str
+    final_network_path: str | None
+    final_diagram_path: str | None
+
+
+def _build_explorer_config(config: PESLoopConfig, project_directory: str,
+                           paths: RoundPaths) -> PDepExplorerConfig:
+    """Build this round's ``PDepExplorerConfig`` from ``config.pes``."""
+    return PDepExplorerConfig(
+        explorer='arkane',
+        trusted_output_root=project_directory,
+        output_directory=paths.explorer_output,
+        seed_species=tuple(config.pes.source),
+        method=config.pes.method,
+        bath_gas=config.pes.bath_gas,
+        explore_tol=config.pes.explore_tol,
+        energy_tol=config.pes.energy_tol,
+        flux_tol=config.pes.flux_tol,
+        maximum_radical_electrons=config.pes.maximum_radical_electrons,
+        timeout=config.pes.timeout,
+    )
+
+
+def _trim_candidates(candidates: tuple, config: PESLoopConfig, logger) -> tuple:
+    """
+    Apply ``config.qm.scope`` and ``config.qm.max_transition_states_per_round`` to ``candidates``.
+
+    Standalone mode has no sensitivity-analysis dict to rank candidates by -- that ranking only
+    exists inside a T3 iteration, where ``t3.pdep.budget`` has a whole field of networks and an SA
+    result to weigh them against. So ``scope == 'sensitive'`` degrades to the network file's own
+    order here, and that degradation is logged at WARNING level rather than applied silently: a
+    caller who asked for sensitivity-ranked spend and silently got file order instead has no way to
+    notice unless the degradation is loud.
+
+    Args:
+        candidates (tuple): The ``QMCandidate`` entries to trim, in network-file order.
+        config (PESLoopConfig): The loop's configuration.
+        logger: A T3 ``Logger``, or ``None``.
+
+    Returns:
+        tuple: The trimmed candidates, in network-file order.
+    """
+    limit = config.qm.max_transition_states_per_round
+    if config.qm.scope == 'sensitive' and candidates:
+        message = ("PES loop: qm.scope='sensitive' was requested, but standalone mode has no "
+                   "sensitivity-analysis dict to rank candidates by. Degrading to the network "
+                   f"file's own order and taking the first {limit} of {len(candidates)} "
+                   f"candidate(s).")
+        _logger.warning(message)
+        if logger is not None:
+            logger.warning(message)
+    return candidates[:limit]
+
+
+def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
+                 adopted_ts_labels: frozenset | None = None, logger=None) -> PESLoopResult:
+    """
+    Run the PES exploration loop to a stop.
+
+    Args:
+        config (PESLoopConfig): The loop's configuration.
+        project_directory (str): The loop's project directory. Must be absolute (see
+            ``t3.pdep.pes_rounds.round_paths``).
+        qm_runner: An injected callable, ``qm_runner(candidates, paths, config, network_id) ->
+            frozenset[str]``, returning the network-local TS labels that converged this round.
+            ``None`` (the default) means "no QM this run" -- explore and draw the first round's
+            diagram only, which is the honest behaviour when no QM runner is configured, not a
+            crash.
+        adopted_ts_labels (frozenset, optional): Network-local TS labels already computed before
+            this loop started (e.g. reused from an earlier T3 project), seeded into
+            ``computed_ts_labels`` before round 0.
+        logger: A T3 ``Logger``, or ``None``.
+
+    Returns:
+        PESLoopResult: The rounds that ran and why the loop stopped.
+    """
+    rounds = []
+    computed_ts_labels = frozenset(adopted_ts_labels) if adopted_ts_labels else frozenset()
+    current_network_path = config.pes.network
+    max_rounds = config.termination.max_rounds
+
+    for round_index in range(max_rounds):
+        paths = round_paths(project_directory, round_index)
+        os.makedirs(paths.root, exist_ok=True)
+
+        explorer_config = _build_explorer_config(config, project_directory, paths)
+        # No selection is available in standalone mode: there is no PDepNetworkSelection to bind
+        # this run to, only a network path and a config. The default admission policy
+        # ('qualified_selection' with selection=None) is what explore_pdep_network's own contract
+        # calls the 'ungated' outcome -- nothing gated the run because nothing was there to gate it
+        # -- which is the truthful record here, not 'caller_admitted': that policy REQUIRES a
+        # selection to bind the run to (explore_pdep_network raises ValueError without one), because
+        # its whole point is recording that the caller looked at a selection and admitted it anyway.
+        result = explore_pdep_network(network_path=current_network_path, config=explorer_config,
+                                      logger=logger)
+
+        if result.status != EXPLORATION_STATUS_SUCCEEDED:
+            reason = '; '.join(result.reasons) if result.reasons else \
+                f"exploration ended with status {result.status!r} and no stated reason."
+            rounds.append(RoundRecord(index=round_index, network_path=current_network_path,
+                                      diagram_path=None, queued_ts_labels=(), skipped=(),
+                                      status=PES_LOOP_FAILED, reason=reason))
+            return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED, reason=reason,
+                                 final_network_path=None, final_diagram_path=None)
+
+        explored_network_path = result.network_paths[0]
+        network = parse_pdep_network_file(explored_network_path)
+
+        diagram_path = None
+        try:
+            draw_pes_diagram(network_path=explored_network_path, output_path=paths.diagram)
+            diagram_path = paths.diagram
+        except ValueError as e:
+            # A legitimate refusal (a species with no E0), not a bug -- record it and keep going
+            # rather than let a diagram problem kill an otherwise-working exploration round.
+            message = f'PES loop: could not draw the diagram for {explored_network_path}: {e}'
+            _logger.warning(message)
+            if logger is not None:
+                logger.warning(message)
+
+        split = split_qm_candidates(network, computed_ts_labels)
+
+        if not split.candidates:
+            status = PES_LOOP_NO_CANDIDATES if round_index == 0 else PES_LOOP_CONVERGED
+            rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
+                                      diagram_path=diagram_path, queued_ts_labels=(),
+                                      skipped=split.skipped, status=status))
+            return PESLoopResult(rounds=tuple(rounds), status=status, reason='',
+                                 final_network_path=explored_network_path,
+                                 final_diagram_path=diagram_path)
+
+        candidates = _trim_candidates(split.candidates, config, logger)
+        queued_ts_labels = tuple(candidate.ts_label for candidate in candidates)
+
+        if qm_runner is None:
+            rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
+                                      diagram_path=diagram_path, queued_ts_labels=queued_ts_labels,
+                                      skipped=split.skipped, status=PES_LOOP_STALLED,
+                                      reason='no qm_runner configured: explored and drew the '
+                                            'diagram only, nothing was computed.'))
+            return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_STALLED,
+                                 reason=rounds[-1].reason, final_network_path=explored_network_path,
+                                 final_diagram_path=diagram_path)
+
+        newly_computed = qm_runner(candidates, paths, config, network.network_id)
+        computed_ts_labels = computed_ts_labels | newly_computed
+
+        if config.termination.stop_when_no_new_ts and not newly_computed:
+            reason = ('qm_runner returned no newly-converged transition states and '
+                     'termination.stop_when_no_new_ts is set: continuing would not make progress.')
+            rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
+                                      diagram_path=diagram_path, queued_ts_labels=queued_ts_labels,
+                                      skipped=split.skipped, status=PES_LOOP_STALLED, reason=reason))
+            return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_STALLED, reason=reason,
+                                 final_network_path=explored_network_path,
+                                 final_diagram_path=diagram_path)
+
+        rounds.append(RoundRecord(index=round_index, network_path=explored_network_path,
+                                  diagram_path=diagram_path, queued_ts_labels=queued_ts_labels,
+                                  skipped=split.skipped, status='continuing'))
+
+        # The next round explores the QM-informed surface: a real qm_runner (Task 6) writes this
+        # round's hybrid network input file (t3.pdep.hybrid) into paths.hybrid from its captured
+        # statmech artifacts, folding the newly converged transition states in as Log(...)
+        # references. This driver trusts that contract rather than writing the hybrid file itself --
+        # that write belongs with the capture step that knows what it captured.
+        current_network_path = paths.hybrid
+
+    reason = f'the round budget ({max_rounds}) was exhausted without converging.'
+    return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_MAX_ROUNDS, reason=reason,
+                         final_network_path=rounds[-1].network_path,
+                         final_diagram_path=rounds[-1].diagram_path)

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -244,12 +244,22 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
     """
     rounds = []
     computed_ts_labels = frozenset(adopted_ts_labels) if adopted_ts_labels else frozenset()
+    adopted = dict()
     if config.reuse.from_t3_projects:
         network_id = Path(config.pes.network).stem
-        adopted = adopt_prior_qm(config.reuse.from_t3_projects, network_id, config.qm.sp_level)
-        if adopted and logger is not None:
-            logger.info(f"PES loop: reusing {len(adopted)} prior QM result(s) for network "
-                       f"{network_id!r}: {sorted(adopted)}.")
+        seed_network = parse_pdep_network_file(path=config.pes.network)
+        path_reaction_labels_by_ts_label = {
+            ts_label: tuple(sorted(path_reaction.label for path_reaction in path_reactions))
+            for ts_label, path_reactions in seed_network.path_reactions_by_ts().items()
+        }
+        adopted = adopt_prior_qm(config.reuse.from_t3_projects, network_id, config.qm.sp_level,
+                                 path_reaction_labels_by_ts_label)
+        if adopted:
+            message = (f"PES loop: reusing {len(adopted)} prior QM result(s) for network "
+                      f"{network_id!r}: {sorted(adopted)}.")
+            _logger.info(message)
+            if logger is not None:
+                logger.info(message)
         computed_ts_labels = computed_ts_labels | frozenset(adopted)
     current_network_path = config.pes.network
     max_rounds = config.termination.max_rounds
@@ -338,7 +348,11 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                  reason=rounds[-1].reason, final_network_path=explored_network_path,
                                  final_diagram_path=diagram_path)
 
-        newly_computed, actually_queued = qm_runner(candidates, paths, config, network.network_id)
+        if round_index == 0 and adopted:
+            newly_computed, actually_queued = qm_runner(candidates, paths, config,
+                                                         network.network_id, adopted=adopted)
+        else:
+            newly_computed, actually_queued = qm_runner(candidates, paths, config, network.network_id)
         computed_ts_labels = computed_ts_labels | newly_computed
         queued_ts_labels = tuple(actually_queued)
 

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -341,6 +341,15 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
                were actually queued. Reporting this back, rather than letting the caller assume
                every offered candidate was queued, is what lets
                ``t3.pdep.pes_loop.RoundRecord.queued_ts_labels`` stay honest.
+
+    Raises:
+        ValueError: If any candidate that would be queued carries no sensitivity evidence
+                   (``QMCandidate.coefficient``/``delta_ln_k`` is ``None``) -- refused BEFORE ARC
+                   runs, because ``capture_ts_artifacts`` would refuse the artifact AFTER the QM
+                   spend; anything ``capture_ts_artifacts`` itself raises; anything the hybrid
+                   write raises.
+        KeyError: If the capture did not vendor a copy of ``network_id`` even though something
+                 converged for it.
     """
     source_path = _explored_network_path(paths, network_id)
     network = parse_pdep_network_file(path=source_path)
@@ -356,6 +365,25 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         if arc_ts_label(network_id, candidate.ts_label) in queued_arc_ts_labels
     )
     queued_ts_labels = frozenset(candidate.ts_label for candidate in queued_candidates)
+
+    # Defect-1 fix (fail-closed, BEFORE any QM is spent): every queued transition state must carry
+    # the real sensitivity evidence that justified selecting it -- capture_ts_artifacts (below)
+    # refuses, by deliberate design, any captured artifact without a finite coefficient/delta_ln_k,
+    # and that refusal would land AFTER ARC already ran, losing the QM result with no second
+    # chance. run_pes_loop stamps this evidence from the round's own master-equation SA
+    # (t3.pdep.pes_sa via t3.pdep.pes_rounds.attach_sensitivity_evidence); a caller driving this
+    # function directly must supply QMCandidate.coefficient/delta_ln_k itself. Refused here rather
+    # than defaulted: no rate-determining parameter may ever be invented.
+    missing_evidence = sorted(candidate.ts_label for candidate in queued_candidates
+                              if candidate.coefficient is None or candidate.delta_ln_k is None)
+    if missing_evidence:
+        raise ValueError(
+            f'Refusing to queue transition state(s) {missing_evidence} of network {network_id!r}: '
+            f'they carry no sensitivity evidence (QMCandidate.coefficient/delta_ln_k is None). '
+            f'capture_ts_artifacts would refuse their artifacts AFTER the QM spend, so this is '
+            f'refused BEFORE ARC runs. Evidence comes from the round\'s own master-equation '
+            f'sensitivity analysis (t3.pdep.pes_sa.run_round_me_sensitivity, stamped by '
+            f't3.pdep.pes_rounds.attach_sensitivity_evidence); it is never defaulted or invented.')
 
     if not os.path.isdir(paths.arc_project):
         os.makedirs(paths.arc_project)
@@ -386,6 +414,11 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
             status=JOIN_STATUS_QUEUED,
             arc_ts_label=arc_ts_label(network_id, candidate.ts_label),
             path_reaction_labels=(candidate.path_reaction.label,) if candidate.path_reaction is not None else (),
+            # The sensitivity evidence that justified selecting this transition state, frozen onto
+            # the join record at queue time exactly as t3.main.T3.queue_pdep_transition_states
+            # freezes it -- the guaranteed-present-by-now evidence the refusal above enforced.
+            coefficient=candidate.coefficient,
+            delta_ln_k=candidate.delta_ln_k,
         )
         # N3: only candidates that actually reached ARC (queued_candidates), not every candidate
         # this function was handed -- a candidate build_arc_input dropped for missing structure
@@ -398,6 +431,12 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         arc_project_directory=paths.arc_project,
         capture_dir=paths.capture,
         networks=networks,
+        # Derived off the join records' own frozen evidence, mirroring
+        # t3.main.T3._capture_pdep_ts_artifacts byte for byte -- the argument whose omission was
+        # defect 1: without it every captured artifact carries coefficient=None/delta_ln_k=None
+        # and capture's own verify_capture self-check (rightly) refuses the staged capture.
+        sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)
+                           for record in join_records},
     )
 
     converged_labels = frozenset(

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -244,6 +244,35 @@ def _vendor_adopted_artifacts(adopted: dict, capture_dir: str) -> dict[str, str]
     return {ts_label: os.path.join(adopted_dir, f'{ts_label}.py') for ts_label in adopted}
 
 
+# Keys of a frozen ``energy_settings`` block that record WHERE the settings were read from rather
+# than WHAT energy reference they describe. Two captures made under byte-identical atom energies,
+# scale factor and rotor treatment always disagree on these -- each round's ARC project directory
+# is its own, by construction (``t3.pdep.pes_rounds.round_paths``) -- so comparing raw dicts would
+# refuse every legitimate cross-round adoption while catching no real energy-reference conflict.
+_ENERGY_SETTINGS_PROVENANCE_KEYS = frozenset({'source_paths'})
+
+
+def _energy_reference(energy_settings: dict | None) -> dict | None:
+    """
+    The part of a frozen ``energy_settings`` block that can actually move a computed barrier.
+
+    Everything Arkane applies to a statmech artifact -- the model chemistry, atom energies, bond
+    additivity corrections, frequency scale factor, rotor treatment -- is kept; the provenance
+    fields (``_ENERGY_SETTINGS_PROVENANCE_KEYS``) are dropped. This is the view two settings blocks
+    must agree on before their artifacts may share one hybrid network's single header.
+
+    Args:
+        energy_settings (dict, optional): A frozen ``energy_settings`` block, or ``None``.
+
+    Returns:
+        dict, optional: The comparable view, or ``None`` if ``energy_settings`` is ``None``.
+    """
+    if energy_settings is None:
+        return None
+    return {key: value for key, value in energy_settings.items()
+            if key not in _ENERGY_SETTINGS_PROVENANCE_KEYS}
+
+
 def _adopted_energy_settings(adopted: dict) -> dict | None:
     """
     Recover the frozen energy-reference settings adopted artifacts were computed under, from their
@@ -283,7 +312,7 @@ def _adopted_energy_settings(adopted: dict) -> dict | None:
     settings_values = list(settings_by_capture_dir.values())
     first = settings_values[0]
     for capture_dir, other in list(settings_by_capture_dir.items())[1:]:
-        if other != first:
+        if _energy_reference(other) != _energy_reference(first):
             raise ValueError(
                 f"PES loop: adopted artifacts come from prior captures with conflicting "
                 f"energy_settings ({first!r} vs {other!r} at {capture_dir!r}); refusing to guess "
@@ -495,9 +524,28 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
     # would otherwise crash QMEnergySettings.from_frozen. The adopted artifacts were computed
     # under settings recorded in their OWN prior manifest -- and those, not a guess, are the
     # correct provenance for them.
-    energy_settings_frozen = capture_result.energy_settings if capture_result is not None else None
-    if energy_settings_frozen is None:
-        energy_settings_frozen = _adopted_energy_settings(adopted or dict())
+    #
+    # C4 (fail closed): the adopted settings are loaded UNCONDITIONALLY, never only as a fallback
+    # for "this round captured nothing". A hybrid network carries ONE energy_settings header --
+    # atom energies, bond corrections, frequency scale factor, rotor treatment -- and Arkane
+    # applies it to every statmech artifact the file references, adopted ones included. So when a
+    # round both captures new QM and folds in adopted artifacts, letting this round's capture
+    # settings win silently re-references the adopted artifacts against a DIFFERENT energy
+    # reference than the one they were computed under, shifting their barriers by however much the
+    # two headers disagree -- a wrong number, presented as a computed one. There is no correct
+    # combined header, so the two must agree or the round must refuse.
+    captured_settings = capture_result.energy_settings if capture_result is not None else None
+    adopted_settings = _adopted_energy_settings(adopted or dict())
+    if (captured_settings is not None and adopted_settings is not None
+            and _energy_reference(captured_settings) != _energy_reference(adopted_settings)):
+        raise ValueError(
+            f"Refusing to write a hybrid network for {network_id!r}: this round's own capture was "
+            f"made under energy settings {captured_settings!r}, but the adopted artifacts "
+            f"{sorted(adopted or dict())} were computed under {adopted_settings!r}. A hybrid "
+            f"network carries a single energy_settings header that Arkane applies to every "
+            f"artifact it references, so combining these would render the adopted barriers "
+            f"against an energy reference they were never computed under.")
+    energy_settings_frozen = captured_settings if captured_settings is not None else adopted_settings
     energy_settings = QMEnergySettings.from_frozen(energy_settings_frozen)
     if capture_result is not None:
         # I1: the hybrid network is built from the CAPTURE's own vendored network copy and

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -46,7 +46,7 @@ from t3.pdep.hybrid import (QMEnergySettings, _read_qm_artifact, _vendor_qm_arti
                             write_hybrid_network_input_file)
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label
 from t3.pdep.parser import parse_pdep_network_file
-from t3.pdep.pes_rounds import RoundPaths, hybrid_network_path
+from t3.pdep.pes_rounds import RoundPaths, channel_keys_by_ts_label, hybrid_network_path
 from t3.schema import PESLoopConfig
 
 _logger = logging.getLogger(__name__)
@@ -567,7 +567,7 @@ def _normalized_model_chemistry(sp_level: str) -> str | None:
 
 
 def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str,
-                   path_reaction_labels_by_ts_label: dict) -> dict[str, str]:
+                   channel_key_by_ts_label: dict) -> dict[str, str]:
     """
     Reuse transition states a previous T3 (or standalone PES loop) run already computed.
 
@@ -595,14 +595,22 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
       never matches across independent PES-loop runs (Arkane names its own output by index, e.g.
       ``network0_full.py``, disjoint from T3's ``network<digits>_<digits>`` convention) -- gating
       on it would refuse the exact case this function exists to serve. The real match is
-      structural: the record's ``path_reaction_labels`` (the path reaction label(s) its transition
-      state actually joined) against THIS run's own network-local candidates, supplied via
-      ``path_reaction_labels_by_ts_label``. A record with no recorded ``path_reaction_labels``,
-      or one that matches no local candidate, is refused (logged).
+      STRUCTURAL, and deliberately not by ``path_reaction_labels`` either: reaction labels are
+      just as positional as TS labels (``arkane/pdep.py:665``), and a remove-then-append can even
+      leave two ``reaction(label='reaction3')`` blocks in one file (which ``arkane/input.py``
+      silently renames). Instead, the record's transition state is resolved to its channel in the
+      capture's own VENDORED network copy (the authoritative ``networks`` block every verified
+      capture carries), reduced to a structural channel key
+      (``t3.pdep.pes_rounds.channel_keys_by_ts_label`` -- canonical species structures, direction
+      insensitive, immune to renumbering and to per-project species label indices), and matched
+      against THIS run's own keys, supplied via ``channel_key_by_ts_label``. A record whose
+      vendored network cannot be parsed, or whose transition state has no unambiguous structural
+      identity there, or whose key matches no local transition state, is refused (logged).
 
     If two prior captures offer conflicting artifacts for what structurally matches the same
     local TS label, adoption for that label is refused (not a last-write-wins guess) and a
-    warning is logged.
+    warning is logged. Likewise, if two of THIS run's own transition states share one structural
+    key, neither can be matched unambiguously and both are excluded up front.
 
     A project directory that does not exist, or whose manifest fails ``verify_capture`` (corrupt,
     torn, tampered, or simply absent), is skipped with a logged warning rather than raised -- a
@@ -615,10 +623,11 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                           (see above).
         level_of_theory (str): The level of theory ``model_chemistry`` must match to be adopted
                                (e.g. ``config.qm.sp_level``), undashed.
-        path_reaction_labels_by_ts_label (dict): THIS run's own network-local TS label -> tuple
-                                                 of path reaction labels it joins, e.g. derived
-                                                 from ``PDepNetwork.path_reactions_by_ts()``. The
-                                                 structural key adoption is matched against.
+        channel_key_by_ts_label (dict): THIS run's own network-local TS label -> structural
+                                        channel key, from
+                                        ``t3.pdep.pes_rounds.channel_keys_by_ts_label`` over the
+                                        run's own (seed) network. The identity adoption is
+                                        matched against.
 
     Returns:
         dict[str, str]: Network-local TS label -> the adopted artifact path (already resolved,
@@ -630,6 +639,20 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
             f"PES loop: ARC could not resolve a model_chemistry for the requested level of "
             f"theory {level_of_theory!r}; every prior capture's model_chemistry will therefore "
             f"fail to match and nothing will be adopted from {from_t3_projects!r}.")
+    # Invert THIS run's map up front, refusing local transition states whose keys collide: a key
+    # shared by two local labels cannot be matched unambiguously, and picking either would be the
+    # wrong-saddle-point misattribution this structural matching exists to prevent.
+    local_label_by_key = dict()
+    ambiguous_local_keys = set()
+    for local_label, key in channel_key_by_ts_label.items():
+        if key in local_label_by_key:
+            ambiguous_local_keys.add(key)
+        local_label_by_key[key] = local_label
+    for key in ambiguous_local_keys:
+        _logger.warning(f'PES loop: several of this run\'s own transition states share the '
+                        f'structural channel key {key!r}; none of them can adopt prior QM '
+                        f'unambiguously.')
+        del local_label_by_key[key]
     adopted = dict()
     conflicted = set()
     for project_directory in from_t3_projects:
@@ -656,19 +679,33 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                     f"{manifest_model_chemistry!r} does not match the requested level of theory "
                     f"{level_of_theory!r} (normalized: {normalized_requested!r}).")
                 continue
+            # The capture's own VENDORED network copy is the authoritative structural record of
+            # what each of its transition states connects (verified.networks -- see
+            # t3.pdep.capture); parse each referenced network once and reduce its transition
+            # states to structural channel keys. A network copy that cannot be parsed yields no
+            # keys, so every record referencing it is refused below (logged per record).
+            capture_keys_by_network_id = dict()
+            for capture_network_id, network_entry in (verified.networks or dict()).items():
+                captured_path = (network_entry or dict()).get('captured_path')
+                if not captured_path:
+                    _logger.warning(
+                        f"PES loop: the capture at {root!r} records no vendored copy "
+                        f"('captured_path') for network {capture_network_id!r}; no prior QM can "
+                        f"be adopted from that network's records.")
+                    capture_keys_by_network_id[capture_network_id] = dict()
+                    continue
+                vendored_network_path = os.path.join(root, captured_path)
+                try:
+                    capture_keys_by_network_id[capture_network_id] = channel_keys_by_ts_label(
+                        parse_pdep_network_file(path=vendored_network_path))
+                except (OSError, ValueError) as e:
+                    _logger.warning(
+                        f"PES loop: could not parse the vendored network copy "
+                        f"{vendored_network_path!r} of the capture at {root!r} ({e}); no prior QM "
+                        f"can be adopted from that network's records.")
+                    capture_keys_by_network_id[capture_network_id] = dict()
             for record in verified.ts_records:
                 if record.status != ARTIFACT_STATUS_USABLE:
-                    continue
-                if not record.path_reaction_labels:
-                    # Refused EXPLICITLY, with its own log line, rather than left to fall through
-                    # the structural-match loop below (whose `candidate_labels and ...` guard would
-                    # also never match an empty tuple, but whose "matches none of this run's own
-                    # candidates" message would misdescribe the problem: the record carries no
-                    # structural evidence at all, so matching was never even attempted).
-                    _logger.info(
-                        f"PES loop: refusing prior QM for {record.network_ts_label!r} at "
-                        f"{manifest_path!r} -- it records no path_reaction_labels, so it cannot be "
-                        f"structurally matched to any of this run's own candidates.")
                     continue
                 if record.network_id != network_id:
                     # Never a gate -- see this function's own docstring: Arkane's network_id is
@@ -678,19 +715,23 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                     _logger.debug(
                         f"PES loop: matching prior QM at {manifest_path!r} for a different "
                         f"network_id ({record.network_id!r} vs this run's {network_id!r}) on "
-                        f"structural path_reaction_labels alone -- network_id is a log-only field, "
+                        f"the structural channel key alone -- network_id is a log-only field, "
                         f"never a gate (see this function's docstring).")
-                local_label = None
-                for candidate_label, candidate_labels in path_reaction_labels_by_ts_label.items():
-                    if candidate_labels and set(candidate_labels) == set(record.path_reaction_labels):
-                        local_label = candidate_label
-                        break
+                record_key = capture_keys_by_network_id.get(record.network_id, dict()).get(
+                    record.network_ts_label)
+                if record_key is None:
+                    _logger.info(
+                        f"PES loop: refusing prior QM for {record.network_ts_label!r} at "
+                        f"{manifest_path!r} -- its transition state has no unambiguous structural "
+                        f"channel identity in the capture's own vendored network copy, so it "
+                        f"cannot be matched to any of this run's own transition states.")
+                    continue
+                local_label = local_label_by_key.get(record_key)
                 if local_label is None:
                     _logger.info(
                         f"PES loop: refusing prior QM for {record.network_ts_label!r} at "
-                        f"{manifest_path!r} -- its path_reaction_labels "
-                        f"{record.path_reaction_labels!r} match none of this run's own "
-                        f"network-local candidates.")
+                        f"{manifest_path!r} -- its structural channel key {record_key!r} matches "
+                        f"none of this run's own transition states.")
                     continue
                 if local_label in conflicted:
                     _logger.info(

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -37,14 +37,13 @@ import os
 from arc.common import save_yaml_file
 from arc.main import ARC
 
-from t3.pdep.capture import capture_ts_artifacts
+from t3.pdep.capture import CAPTURE_MANIFEST_FILE_NAME, capture_ts_artifacts, verify_capture
 from t3.pdep.discovery import ARTIFACT_STATUS_USABLE
 from t3.pdep.hashing import hash_file
 from t3.pdep.hybrid import QMEnergySettings, write_hybrid_network_input_file
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label
 from t3.pdep.parser import parse_pdep_network_file
-from t3.pdep.pes_loop import hybrid_network_path
-from t3.pdep.pes_rounds import RoundPaths
+from t3.pdep.pes_rounds import RoundPaths, hybrid_network_path
 from t3.schema import PESLoopConfig
 
 _logger = logging.getLogger(__name__)
@@ -318,3 +317,65 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
     for warning in result.warnings:
         _logger.warning(warning)
     return converged_labels, queued_ts_labels
+
+
+def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str) -> dict[str, str]:
+    """
+    Reuse transition states a previous T3 (or standalone PES loop) run already computed.
+
+    Walks each configured project directory looking for capture manifests
+    (``t3.pdep.capture.CAPTURE_MANIFEST_FILE_NAME``) written anywhere under it -- a capture
+    directory is nested under a run's own iteration subdirectory (e.g. ``t3.main.T3``'s
+    ``self.paths['PDep capture']``) whose exact name and depth this function cannot assume, so it
+    is discovered by walking rather than by a fixed relative path.
+
+    Each manifest found is re-validated with ``verify_capture`` before anything in it is trusted
+    (the same re-hashing, tamper/torn-capture detection a live consumer gets -- see
+    ``t3.main``'s own use of it). An entry is adopted only when BOTH:
+
+    - ``record.network_id == network_id``: labels are namespace-local (a network-local ``TS1``
+      collides across networks), so matching on label alone would silently cross-wire two
+      networks' transition states.
+    - the capture's recorded ``energy_settings['model_chemistry']`` equals ``level_of_theory``:
+      mixing levels of theory inside one barrier's rate makes it inconsistent, so a prior result
+      computed at a different level is refused even though it exists and converged (never adopted
+      "close enough").
+
+    A project directory that does not exist, or whose manifest fails ``verify_capture`` (corrupt,
+    torn, tampered, or simply absent), is skipped with a logged warning rather than raised -- a
+    stale path left in a config must not kill a run that would otherwise work.
+
+    Args:
+        from_t3_projects (list): T3 (or standalone PES loop) project directories to search for
+                                 reusable prior QM, e.g. ``config.reuse.from_t3_projects``.
+        network_id (str): The network id this run's adopted transition states must belong to.
+        level_of_theory (str): The level of theory ``model_chemistry`` must match to be adopted
+                               (e.g. ``config.qm.sp_level``), undashed.
+
+    Returns:
+        dict[str, str]: Network-local TS label -> the adopted artifact path (already resolved,
+        by ``verify_capture``, to an absolute path inside its capture directory).
+    """
+    adopted = dict()
+    for project_directory in from_t3_projects:
+        if not os.path.isdir(project_directory):
+            _logger.warning(f"PES loop: reuse project directory {project_directory!r} does not "
+                            f"exist; skipping it rather than failing this run.")
+            continue
+        for root, _, files in os.walk(project_directory):
+            if CAPTURE_MANIFEST_FILE_NAME not in files:
+                continue
+            try:
+                verified = verify_capture(root)
+            except ValueError as e:
+                _logger.warning(f"PES loop: skipping capture at {root!r} while looking for prior "
+                                f"QM to reuse -- it failed verification: {e}")
+                continue
+            energy_settings = verified.energy_settings or {}
+            if energy_settings.get('model_chemistry') != level_of_theory:
+                continue
+            for record in verified.ts_records:
+                if record.network_id != network_id or record.status != ARTIFACT_STATUS_USABLE:
+                    continue
+                adopted[record.network_ts_label] = record.artifact_path
+    return adopted

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -48,7 +48,8 @@ from t3.pdep.hybrid import (QMEnergySettings, _read_qm_artifact, _vendor_qm_arti
                             write_hybrid_network_input_file)
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label
 from t3.pdep.parser import parse_pdep_network_file
-from t3.pdep.pes_rounds import RoundPaths, channel_keys_by_ts_label, hybrid_network_path
+from t3.pdep.pes_rounds import (RoundPaths, adoption_channel_keys_by_ts_label,
+                                hybrid_network_path)
 from t3.schema import PESLoopConfig
 
 _logger = logging.getLogger(__name__)
@@ -752,11 +753,18 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                                     ``level_of_theory`` -- without it every prior capture made
                                     under a composite SP/frequency pair is refused on a mismatch
                                     that does not exist (see ``_normalized_model_chemistry``).
-        channel_key_by_ts_label (dict): THIS run's own network-local TS label -> structural
-                                        channel key, from
-                                        ``t3.pdep.pes_rounds.channel_keys_by_ts_label`` over the
-                                        run's own (seed) network. The identity adoption is
-                                        matched against.
+        channel_key_by_ts_label (dict): THIS run's own network-local TS label -> ADOPTION channel
+                                        key, from
+                                        ``t3.pdep.pes_rounds.adoption_channel_keys_by_ts_label``
+                                        over the run's own (seed) network -- the structural
+                                        channel key qualified by the path reaction's RMG family.
+                                        The endpoints-only key is deliberately NOT what adoption
+                                        matches on: the two networks compared here are unrelated,
+                                        so a different pathway between the same endpoints would
+                                        key identically and this function would attach a prior
+                                        artifact to a saddle point it was never computed for. A
+                                        channel that names no family is refused rather than
+                                        matched on endpoints alone (see that function).
 
     Returns:
         dict[str, str]: Network-local TS label -> the adopted artifact path (already resolved,
@@ -830,8 +838,9 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                     continue
                 vendored_network_path = os.path.join(root, captured_path)
                 try:
-                    capture_keys_by_network_id[capture_network_id] = channel_keys_by_ts_label(
-                        parse_pdep_network_file(path=vendored_network_path))
+                    capture_keys_by_network_id[capture_network_id] = \
+                        adoption_channel_keys_by_ts_label(
+                            parse_pdep_network_file(path=vendored_network_path))
                 except (OSError, ValueError) as e:
                     _logger.warning(
                         f"PES loop: could not parse the vendored network copy "

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -33,9 +33,12 @@ This module never imports ``rmgpy`` or ``arkane``. It imports ``arc`` directly, 
 
 import logging
 import os
+import shutil
 
 from arc.common import save_yaml_file
+from arc.level import Level, assign_frequency_scale_factor
 from arc.main import ARC
+from arc.statmech.arkane import get_arkane_model_chemistry
 
 from t3.pdep.capture import CAPTURE_MANIFEST_FILE_NAME, capture_ts_artifacts, verify_capture
 from t3.pdep.discovery import ARTIFACT_STATUS_USABLE
@@ -172,8 +175,50 @@ def _explored_network_path(paths: RoundPaths, network_id: str) -> str:
     return os.path.join(paths.explorer_output, 'pdep', 'final', f'{network_id}.py')
 
 
+def _vendor_adopted_artifacts(adopted: dict, capture_dir: str) -> dict[str, str]:
+    """
+    Copy adopted prior-QM artifacts into this round's own capture directory.
+
+    ``write_hybrid_network_input_file``'s ``qm_artifacts_root`` guard only trusts artifact paths
+    that live under the capture directory it is given -- a deliberate fail-closed security guard
+    (see ``t3.pdep.hybrid``'s own docstring), which this function does not widen. An adopted
+    artifact lives under a DIFFERENT run's capture directory, so it is vendored (copied) into an
+    ``adopted/`` subdirectory of THIS round's own capture directory before being folded into
+    ``qm_transition_states`` -- the existing guard then covers it for free, since ``adopted/``
+    lives under the same ``capture_dir`` passed as ``qm_artifacts_root``.
+
+    Args:
+        adopted (dict): Network-local TS label -> source artifact path, as returned by
+                        ``adopt_prior_qm``.
+        capture_dir (str): This round's own capture directory (``paths.capture``).
+
+    Returns:
+        dict[str, str]: Network-local TS label -> the vendored (copied) artifact path, now inside
+        ``capture_dir``.
+
+    Raises:
+        FileNotFoundError: An adopted artifact's source path no longer exists -- fail closed
+                           rather than silently dropping it from the hybrid network.
+    """
+    if not adopted:
+        return dict()
+    adopted_dir = os.path.join(capture_dir, 'adopted')
+    os.makedirs(adopted_dir, exist_ok=True)
+    vendored = dict()
+    for ts_label, source_path in adopted.items():
+        if not os.path.isfile(source_path):
+            raise FileNotFoundError(
+                f"PES loop: adopted artifact for {ts_label!r} no longer exists at "
+                f"{source_path!r}; refusing to fold a missing artifact into this round's hybrid "
+                f"network.")
+        dest_path = os.path.join(adopted_dir, f'{ts_label}{os.path.splitext(source_path)[1]}')
+        shutil.copy2(source_path, dest_path)
+        vendored[ts_label] = dest_path
+    return vendored
+
+
 def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
-                  network_id: str) -> tuple[frozenset[str], frozenset[str]]:
+                  network_id: str, adopted: dict | None = None) -> tuple[frozenset[str], frozenset[str]]:
     """
     Run ARC on one round's QM candidates and fold whatever converges into a hybrid network file.
 
@@ -206,6 +251,11 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         paths (RoundPaths): This round's artifact layout.
         config (PESLoopConfig): The loop's configuration.
         network_id (str): The network file stem this round explored.
+        adopted (dict, optional): Network-local TS label -> artifact path adopted from a prior
+                                  run (``t3.pdep.pes_qm.adopt_prior_qm``), if any. Vendored into
+                                  this round's own capture directory and folded into
+                                  ``qm_transition_states`` alongside whatever ARC converged this
+                                  round.
 
     Returns:
         tuple: ``(converged_ts_labels, queued_ts_labels)``, both ``frozenset``. ``converged_ts_labels``
@@ -282,7 +332,12 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         record.network_ts_label for record in capture_result.records
         if record.status == ARTIFACT_STATUS_USABLE
     )
-    if not converged_labels:
+    # C2: vendor adopted artifacts into THIS round's own capture directory before deciding
+    # whether there is anything to write -- a round that adopted a prior result but converged
+    # nothing new still has a hybrid network worth writing (an adopted TS must not silently
+    # revert to an RMG/ILT rate estimate; see this module's caller, t3.pdep.pes_loop).
+    vendored_adopted = _vendor_adopted_artifacts(adopted or dict(), capture_result.capture_dir)
+    if not converged_labels and not vendored_adopted:
         _logger.info(f'ARC converged no transition states for network {network_id!r} this round.')
         return frozenset(), queued_ts_labels
 
@@ -291,6 +346,7 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         for record in capture_result.records
         if record.status == ARTIFACT_STATUS_USABLE
     }
+    qm_transition_states.update(vendored_adopted)
     energy_settings = QMEnergySettings.from_frozen(capture_result.energy_settings)
     # I1: the hybrid network is built from the CAPTURE's own vendored network copy and recorded
     # method (CaptureResult.networks is the authoritative source -- see t3.pdep.capture's own
@@ -319,7 +375,32 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
     return converged_labels, queued_ts_labels
 
 
-def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str) -> dict[str, str]:
+def _normalized_model_chemistry(sp_level: str) -> str | None:
+    """
+    Normalize a T3 ``sp_level`` string into ARC's own ``model_chemistry`` text.
+
+    A capture manifest's ``model_chemistry`` is ARC's byte-for-byte ``LevelOfTheory(...)`` repr,
+    written via ``arc.statmech.arkane.get_arkane_model_chemistry`` -- including year-suffix
+    resolution (e.g. ``'wb97xd'`` -> ``'wb97xd2023'``) no T3-side string normalizer could
+    reproduce. Comparing a manifest's ``model_chemistry`` against a raw ``config.qm.sp_level``
+    string is therefore never true on real ARC data; this function runs the same ARC
+    normalization chain ARC itself used to write the manifest, so the comparison is apples to
+    apples.
+
+    Args:
+        sp_level (str): A T3 level-of-theory string, e.g. ``config.qm.sp_level``, undashed.
+
+    Returns:
+        str | None: The normalized ``model_chemistry`` text, or ``None`` if ARC could not
+        resolve one.
+    """
+    level = Level(repr=sp_level)
+    scale = assign_frequency_scale_factor(level)
+    return get_arkane_model_chemistry(level, freq_scale_factor=scale)
+
+
+def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str,
+                   path_reaction_labels_by_ts_label: dict) -> dict[str, str]:
     """
     Reuse transition states a previous T3 (or standalone PES loop) run already computed.
 
@@ -327,19 +408,34 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
     (``t3.pdep.capture.CAPTURE_MANIFEST_FILE_NAME``) written anywhere under it -- a capture
     directory is nested under a run's own iteration subdirectory (e.g. ``t3.main.T3``'s
     ``self.paths['PDep capture']``) whose exact name and depth this function cannot assume, so it
-    is discovered by walking rather than by a fixed relative path.
+    is discovered by walking rather than by a fixed relative path. A directory that yields a
+    manifest is not descended into further -- a capture directory is never itself nested inside
+    another capture.
 
     Each manifest found is re-validated with ``verify_capture`` before anything in it is trusted
     (the same re-hashing, tamper/torn-capture detection a live consumer gets -- see
-    ``t3.main``'s own use of it). An entry is adopted only when BOTH:
+    ``t3.main``'s own use of it). An entry is adopted only when ALL of the following hold:
 
-    - ``record.network_id == network_id``: labels are namespace-local (a network-local ``TS1``
-      collides across networks), so matching on label alone would silently cross-wire two
-      networks' transition states.
-    - the capture's recorded ``energy_settings['model_chemistry']`` equals ``level_of_theory``:
-      mixing levels of theory inside one barrier's rate makes it inconsistent, so a prior result
-      computed at a different level is refused even though it exists and converged (never adopted
-      "close enough").
+    - the capture's recorded ``energy_settings['model_chemistry']``, once normalized through
+      ``_normalized_model_chemistry``, matches the requested ``level_of_theory``: mixing levels
+      of theory inside one barrier's rate makes it inconsistent, so a prior result computed at a
+      different level is refused even though it exists and converged (never adopted "close
+      enough"). A refusal is logged with the manifest path, its raw ``model_chemistry``, and the
+      requested level, so a silent "nothing was reused" is always explainable.
+    - ``record.network_id == network_id`` is used only as a cheap pre-filter, never the sole
+      guard: Arkane names TS artifacts positionally (``'TS{i+1}'``, see ``arkane/pdep.py``), so a
+      pruned or reordered exploration can re-issue the same label for a different transition
+      state, and ``network_id`` itself never matches across independent PES-loop runs (Arkane
+      names its own output by index, e.g. ``network0_full.py``, disjoint from T3's
+      ``network<digits>_<digits>`` convention). The real match is structural: the record's
+      ``path_reaction_labels`` (the path reaction label(s) its transition state actually joined)
+      against THIS run's own network-local candidates, supplied via
+      ``path_reaction_labels_by_ts_label``. A record with no recorded ``path_reaction_labels``,
+      or one that matches no local candidate, is refused.
+
+    If two prior captures offer conflicting artifacts for what structurally matches the same
+    local TS label, adoption for that label is refused (not a last-write-wins guess) and a
+    warning is logged.
 
     A project directory that does not exist, or whose manifest fails ``verify_capture`` (corrupt,
     torn, tampered, or simply absent), is skipped with a logged warning rather than raised -- a
@@ -348,23 +444,31 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
     Args:
         from_t3_projects (list): T3 (or standalone PES loop) project directories to search for
                                  reusable prior QM, e.g. ``config.reuse.from_t3_projects``.
-        network_id (str): The network id this run's adopted transition states must belong to.
+        network_id (str): This run's network id, used only as a cheap pre-filter (see above).
         level_of_theory (str): The level of theory ``model_chemistry`` must match to be adopted
                                (e.g. ``config.qm.sp_level``), undashed.
+        path_reaction_labels_by_ts_label (dict): THIS run's own network-local TS label -> tuple
+                                                 of path reaction labels it joins, e.g. derived
+                                                 from ``PDepNetwork.path_reactions_by_ts()``. The
+                                                 structural key adoption is matched against.
 
     Returns:
         dict[str, str]: Network-local TS label -> the adopted artifact path (already resolved,
         by ``verify_capture``, to an absolute path inside its capture directory).
     """
+    normalized_requested = _normalized_model_chemistry(level_of_theory)
     adopted = dict()
+    conflicted = set()
     for project_directory in from_t3_projects:
         if not os.path.isdir(project_directory):
             _logger.warning(f"PES loop: reuse project directory {project_directory!r} does not "
                             f"exist; skipping it rather than failing this run.")
             continue
-        for root, _, files in os.walk(project_directory):
+        for root, dirs, files in os.walk(project_directory):
             if CAPTURE_MANIFEST_FILE_NAME not in files:
                 continue
+            dirs[:] = []  # a capture directory is never nested inside another capture
+            manifest_path = os.path.join(root, CAPTURE_MANIFEST_FILE_NAME)
             try:
                 verified = verify_capture(root)
             except ValueError as e:
@@ -372,10 +476,33 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                                 f"QM to reuse -- it failed verification: {e}")
                 continue
             energy_settings = verified.energy_settings or {}
-            if energy_settings.get('model_chemistry') != level_of_theory:
+            manifest_model_chemistry = energy_settings.get('model_chemistry')
+            if manifest_model_chemistry != normalized_requested:
+                _logger.info(
+                    f"PES loop: refusing prior QM at {manifest_path!r} -- its model_chemistry "
+                    f"{manifest_model_chemistry!r} does not match the requested level of theory "
+                    f"{level_of_theory!r} (normalized: {normalized_requested!r}).")
                 continue
             for record in verified.ts_records:
                 if record.network_id != network_id or record.status != ARTIFACT_STATUS_USABLE:
                     continue
-                adopted[record.network_ts_label] = record.artifact_path
+                if not record.path_reaction_labels:
+                    continue
+                local_label = None
+                for candidate_label, candidate_labels in path_reaction_labels_by_ts_label.items():
+                    if candidate_labels and set(candidate_labels) == set(record.path_reaction_labels):
+                        local_label = candidate_label
+                        break
+                if local_label is None or local_label in conflicted:
+                    continue
+                if local_label in adopted and adopted[local_label] != record.artifact_path:
+                    _logger.warning(
+                        f"PES loop: refusing to adopt prior QM for {local_label!r} -- multiple "
+                        f"prior captures offer conflicting artifacts ({adopted[local_label]!r} "
+                        f"vs {record.artifact_path!r}); reuse for this transition state is "
+                        f"refused.")
+                    del adopted[local_label]
+                    conflicted.add(local_label)
+                    continue
+                adopted[local_label] = record.artifact_path
     return adopted

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -467,6 +467,16 @@ def _normalized_model_chemistry(sp_level: str) -> str | None:
     normalization chain ARC itself used to write the manifest, so the comparison is apples to
     apples.
 
+    ``None`` -- never an exception -- is the answer whenever ARC cannot resolve one. In
+    particular, ``get_arkane_model_chemistry`` itself RAISES (``ValueError: freq_level required
+    when freq_scale_factor isn't provided``) for a non-composite level with no tabulated
+    frequency scale factor -- e.g. ``'wb97xd2023/def2tzvp'``, ARC's own normalized form, exactly
+    what a user copying a level out of a prior capture manifest would write. This function only
+    ever has the single ``sp_level`` string, no frequency level to hand ARC in that case, so the
+    raise is converted to the documented "could not resolve" answer: the caller
+    (``adopt_prior_qm``) then warns that nothing will match, rather than the whole run dying
+    before round 0.
+
     Args:
         sp_level (str): A T3 level-of-theory string, e.g. ``config.qm.sp_level``, undashed.
 
@@ -476,7 +486,12 @@ def _normalized_model_chemistry(sp_level: str) -> str | None:
     """
     level = Level(repr=sp_level)
     scale = assign_frequency_scale_factor(level)
-    return get_arkane_model_chemistry(level, freq_scale_factor=scale)
+    try:
+        return get_arkane_model_chemistry(level, freq_scale_factor=scale)
+    except ValueError as e:
+        _logger.warning(f'PES loop: ARC could not normalize the level of theory {sp_level!r} '
+                        f'into a model_chemistry ({e}); treating it as unresolvable.')
+        return None
 
 
 def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str,
@@ -573,6 +588,15 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                 if record.status != ARTIFACT_STATUS_USABLE:
                     continue
                 if not record.path_reaction_labels:
+                    # Refused EXPLICITLY, with its own log line, rather than left to fall through
+                    # the structural-match loop below (whose `candidate_labels and ...` guard would
+                    # also never match an empty tuple, but whose "matches none of this run's own
+                    # candidates" message would misdescribe the problem: the record carries no
+                    # structural evidence at all, so matching was never even attempted).
+                    _logger.info(
+                        f"PES loop: refusing prior QM for {record.network_ts_label!r} at "
+                        f"{manifest_path!r} -- it records no path_reaction_labels, so it cannot be "
+                        f"structurally matched to any of this run's own candidates.")
                     continue
                 if record.network_id != network_id:
                     # Never a gate -- see this function's own docstring: Arkane's network_id is

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -1,0 +1,211 @@
+"""
+t3 pdep pes_qm module
+
+The real ARC-backed ``qm_runner`` that ``t3.pdep.pes_loop.run_pes_loop`` injects and calls as
+``qm_runner(candidates, paths, config, network_id) -> frozenset[str]``. Everything else in
+``t3.pdep`` is exercised without ever touching ARC (see ``pes_loop.py``'s own module docstring for
+why); this module is the one piece the loop cannot run without an ARC cluster behind it.
+
+``build_arc_input`` is kept a pure function -- no I/O, no ARC import at call time beyond the plain
+dict it returns -- specifically so the levels of theory, job types and TS label namespacing it
+decides are unit-testable without running anything. ``arc_qm_runner`` is the thin, impure shell
+around it: it writes that input, runs ARC via the exact mechanism ``t3.main.T3.run_arc`` already
+uses, captures whatever transition-state QM artifacts converged, folds them into a hybrid Arkane
+network input file, and reports back which network-local transition states are now usable.
+
+Every ``QMCandidate`` this module receives has already been screened by
+``t3.pdep.pes_rounds.split_qm_candidates``: barrierless channels, channels that already have QM,
+and channels with no declared transition state are filtered out before candidates ever reach
+``build_arc_input``. This module does not re-check any of that -- it trusts the split it was
+handed, the same way ``t3.main`` trusts ``add_reaction`` upstream of ``queue_pdep_transition_states``.
+
+TS labels are never handed to ARC in the network's own namespace: ``t3.pdep.join.arc_ts_label``
+namespaces every label by ``network_id`` before it reaches ``build_arc_input``'s ``reactions``
+list, because a network-local ``TS1`` is almost never ARC's ``TS1`` and guessing from list order
+has no basis (see ``t3/pdep/join.py``'s module docstring).
+
+This module never imports ``rmgpy`` or ``arkane``. It imports ``arc`` directly, the same as
+``t3.main`` does -- ARC is an allowed dependency; only RMG-Py and Arkane are not.
+"""
+
+import logging
+import os
+
+from arc.common import save_yaml_file
+from arc.main import ARC
+
+from t3.pdep.capture import capture_ts_artifacts
+from t3.pdep.discovery import ARTIFACT_STATUS_USABLE
+from t3.pdep.hashing import hash_file
+from t3.pdep.hybrid import QMEnergySettings, write_hybrid_network_input_file
+from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label
+from t3.pdep.pes_loop import hybrid_network_path
+from t3.pdep.pes_rounds import RoundPaths
+from t3.schema import PESLoopConfig
+
+_logger = logging.getLogger(__name__)
+
+# The name ARC's own input YAML is written under, inside the round's ARC project directory --
+# mirrors t3.main.T3.run_arc's 'ARC input' path, kept local here since this loop's ARC project
+# directory is per-round rather than per-T3-project.
+ARC_INPUT_FILE_NAME = 'arc_input.yml'
+
+
+def build_arc_input(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, network_id: str) -> dict:
+    """
+    Build the ARC input dict for one round's quantum chemistry, with no I/O.
+
+    Kept pure so the levels of theory, job types, and TS label namespacing this function decides
+    are unit-testable without running ARC, without writing a file, and without an ARC project
+    directory existing on disk.
+
+    Args:
+        candidates (tuple): The ``t3.pdep.pes_rounds.QMCandidate`` entries to queue, already
+                            screened by ``split_qm_candidates`` (no barrierless channels, none
+                            that already have QM, none with no declared transition state).
+        paths (RoundPaths): This round's artifact layout (``t3.pdep.pes_rounds.round_paths``).
+        config (PESLoopConfig): The loop's configuration; ``config.qm`` supplies the levels of
+                                theory, job types and TS adapters, ``config.pes`` the ME method.
+        network_id (str): The network file stem this round explored, e.g. ``'network1_1'``. Used
+                          to namespace every candidate's TS label via ``arc_ts_label`` so it can
+                          never collide with another network's transition state of the same
+                          network-local name.
+
+    Returns:
+        dict: The ARC input, suitable for ``arc.main.ARC(**arc_input)``.
+    """
+    qm = config.qm
+    reactions = []
+    for candidate in candidates:
+        reactions.append({
+            'ts_label': arc_ts_label(network_id, candidate.ts_label),
+            'network_ts_label': candidate.ts_label,
+            'family': candidate.family,
+        })
+    return {
+        'project_directory': paths.arc_project,
+        'opt_level': qm.opt_level,
+        'freq_level': qm.freq_level,
+        'sp_level': qm.sp_level,
+        'scan_level': qm.scan_level,
+        'irc_level': qm.irc_level,
+        'ts_adapters': qm.ts_adapters,
+        'job_types': {
+            'rotors': qm.rotors,
+            'irc': qm.irc,
+        },
+        'reactions': reactions,
+    }
+
+
+def _explored_network_path(paths: RoundPaths, network_id: str) -> str:
+    """
+    Reconstruct this round's explored network file path from its ``network_id`` alone.
+
+    Arkane's own explorer (``t3.pdep.explorer.arkane``) always writes the network it explored to
+    ``paths.explorer_output/pdep/final/<name>.py``, and ``network_id`` is, by construction
+    (``t3.pdep.parser.parse_pdep_network_file``), exactly that file's stem -- so the path is
+    deterministic from ``paths`` and ``network_id`` alone, with no need to thread the network
+    object itself through ``qm_runner``'s signature.
+
+    Args:
+        paths (RoundPaths): This round's artifact layout.
+        network_id (str): The network file stem this round explored.
+
+    Returns:
+        str: The path to this round's explored network file.
+    """
+    return os.path.join(paths.explorer_output, 'pdep', 'final', f'{network_id}.py')
+
+
+def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, network_id: str) -> frozenset:
+    """
+    Run ARC on one round's QM candidates and fold whatever converges into a hybrid network file.
+
+    This is the real ``qm_runner`` ``t3.pdep.pes_loop.run_pes_loop`` injects. It: builds the ARC
+    input (``build_arc_input``), runs ARC via the same construction ``t3.main.T3.run_arc`` uses
+    (``ARC(**arc_kwargs)`` then ``arc.execute()``), captures whatever transition-state QM
+    artifacts converged (``t3.pdep.capture.capture_ts_artifacts``) against this round's own
+    capture directory, and writes this round's hybrid Arkane network input file
+    (``t3.pdep.hybrid.write_hybrid_network_input_file``) to exactly
+    ``t3.pdep.pes_loop.hybrid_network_path(paths, network_id)`` -- the loop checks for that exact
+    file at the top of every round after the first and fails the round if it is absent.
+
+    Args:
+        candidates (tuple): The ``t3.pdep.pes_rounds.QMCandidate`` entries to queue, already
+                            screened by ``split_qm_candidates``.
+        paths (RoundPaths): This round's artifact layout.
+        config (PESLoopConfig): The loop's configuration.
+        network_id (str): The network file stem this round explored.
+
+    Returns:
+        frozenset: The network-local TS labels ARC converged this round (``status ==
+                   t3.pdep.discovery.ARTIFACT_STATUS_USABLE`` only -- an ``UNVERIFIED`` artifact's
+                   convergence is, by design, unknown, and is never treated as usable).
+    """
+    arc_input = dict(build_arc_input(candidates, paths, config, network_id))
+    if not os.path.isdir(paths.arc_project):
+        os.makedirs(paths.arc_project)
+    arc_input.setdefault('project', network_id)
+    reactions = arc_input.pop('reactions')
+
+    arc_kwargs = {key: value for key, value in arc_input.items()}
+    arc_input_path = os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME)
+    if not os.path.isfile(arc_input_path):
+        save_yaml_file(path=arc_input_path, content={**arc_kwargs, 'reactions': reactions})
+
+    arc = ARC(**arc_kwargs)
+    try:
+        arc.execute()
+    except Exception as e:
+        _logger.error(f'ARC crashed with {e.__class__}. Got the following error message:\n{e}')
+        raise
+
+    source_path = _explored_network_path(paths, network_id)
+    networks = {
+        network_id: {
+            'source_path': source_path,
+            'source_sha256': hash_file(source_path),
+            'method': config.pes.method,
+        },
+    }
+    join_records = [
+        TSJoinRecord(
+            network_id=network_id,
+            network_ts_label=candidate.ts_label,
+            status=JOIN_STATUS_QUEUED,
+            arc_ts_label=arc_ts_label(network_id, candidate.ts_label),
+            path_reaction_labels=(candidate.path_reaction.label,) if candidate.path_reaction is not None else (),
+        )
+        for candidate in candidates
+    ]
+
+    capture_result = capture_ts_artifacts(
+        join_records=join_records,
+        arc_project_directory=paths.arc_project,
+        capture_dir=paths.capture,
+        networks=networks,
+    )
+
+    converged_labels = frozenset(
+        record.network_ts_label for record in capture_result.records
+        if record.status == ARTIFACT_STATUS_USABLE
+    )
+    if not converged_labels:
+        _logger.info(f'ARC converged no transition states for network {network_id!r} this round.')
+        return frozenset()
+
+    qm_transition_states = {
+        record.network_ts_label: record.artifact_path
+        for record in capture_result.records
+        if record.status == ARTIFACT_STATUS_USABLE
+    }
+    energy_settings = QMEnergySettings.from_frozen(capture_result.energy_settings)
+    write_hybrid_network_input_file(
+        source_path=source_path,
+        dest_path=hybrid_network_path(paths, network_id),
+        method=config.pes.method,
+        qm_transition_states=qm_transition_states,
+        energy_settings=energy_settings,
+    )
+    return converged_labels

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -173,7 +173,8 @@ def _explored_network_path(paths: RoundPaths, network_id: str) -> str:
     return os.path.join(paths.explorer_output, 'pdep', 'final', f'{network_id}.py')
 
 
-def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, network_id: str) -> frozenset:
+def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
+                  network_id: str) -> tuple[frozenset, frozenset]:
     """
     Run ARC on one round's QM candidates and fold whatever converges into a hybrid network file.
 

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -2,16 +2,19 @@
 t3 pdep pes_qm module
 
 The real ARC-backed ``qm_runner`` that ``t3.pdep.pes_loop.run_pes_loop`` injects and calls as
-``qm_runner(candidates, paths, config, network_id) -> frozenset[str]``. Everything else in
-``t3.pdep`` is exercised without ever touching ARC (see ``pes_loop.py``'s own module docstring for
-why); this module is the one piece the loop cannot run without an ARC cluster behind it.
+``qm_runner(candidates, paths, config, network_id) -> tuple[frozenset[str], frozenset[str]]`` --
+``(converged_ts_labels, queued_ts_labels)``. Everything else in ``t3.pdep`` is exercised without
+ever touching ARC (see ``pes_loop.py``'s own module docstring for why); this module is the one
+piece the loop cannot run without an ARC cluster behind it.
 
 ``build_arc_input`` is kept a pure function -- no I/O, no ARC import at call time beyond the plain
 dict it returns -- specifically so the levels of theory, job types and TS label namespacing it
 decides are unit-testable without running anything. ``arc_qm_runner`` is the thin, impure shell
 around it: it writes that input, runs ARC via the exact mechanism ``t3.main.T3.run_arc`` already
 uses, captures whatever transition-state QM artifacts converged, folds them into a hybrid Arkane
-network input file, and reports back which network-local transition states are now usable.
+network input file, and reports back which network-local transition states are now usable AND
+which were actually queued -- ``build_arc_input`` can silently drop a candidate for missing
+structure, so the two are not always the caller's own candidate list (N3).
 
 Every ``QMCandidate`` this module receives has already been screened by
 ``t3.pdep.pes_rounds.split_qm_candidates``: barrierless channels, channels that already have QM,
@@ -114,7 +117,14 @@ def build_arc_input(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         for label in labels:
             species_by_label.setdefault(label, species_structures[label])
         reactions.append({
-            'label': path_reaction.label,
+            # N1: no 'label' key here, deliberately. ARCReaction.from_dict only synthesizes
+            # self.label from reactants/products (arc/reaction/reaction.py's
+            # set_label_reactants_products) when self.label starts out falsy -- if 'reactants'
+            # and 'products' are already populated (as they always are here) AND 'label' carries
+            # the network's raw path-reaction label (e.g. 'reaction1', no '<=>'), that synthesis
+            # is skipped and check_atom_balance later crashes doing self.label.split('<=>')[well].
+            # t3.main.T3.build_pdep_path_reaction never sets a label either -- this matches that
+            # precedent.
             'ts_label': arc_ts_label(network_id, candidate.ts_label),
             'family': candidate.family,
             'reactants': list(path_reaction.reactants),
@@ -198,14 +208,33 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, n
         network_id (str): The network file stem this round explored.
 
     Returns:
-        frozenset: The network-local TS labels ARC converged this round (``status ==
-                   t3.pdep.discovery.ARTIFACT_STATUS_USABLE`` only -- an ``UNVERIFIED`` artifact's
-                   convergence is, by design, unknown, and is never treated as usable).
+        tuple: ``(converged_ts_labels, queued_ts_labels)``, both ``frozenset``. ``converged_ts_labels``
+               is the network-local TS labels ARC converged this round (``status ==
+               t3.pdep.discovery.ARTIFACT_STATUS_USABLE`` only -- an ``UNVERIFIED`` artifact's
+               convergence is, by design, unknown, and is never treated as usable).
+               ``queued_ts_labels`` is the network-local TS labels that actually reached ARC --
+               N3: ``build_arc_input`` silently drops a candidate whose reactant/product has no
+               entry in ``species_structures`` (logging a warning and continuing rather than
+               crashing), so the candidates this function was HANDED are not always the ones that
+               were actually queued. Reporting this back, rather than letting the caller assume
+               every offered candidate was queued, is what lets
+               ``t3.pdep.pes_loop.RoundRecord.queued_ts_labels`` stay honest.
     """
     source_path = _explored_network_path(paths, network_id)
     network = parse_pdep_network_file(path=source_path)
 
     arc_input = build_arc_input(candidates, paths, config, network_id, network.species_structures)
+    # N3: build_arc_input may have silently dropped some candidates (missing structure). Only the
+    # candidates whose namespaced TS label actually made it into arc_input['reactions'] were
+    # queued -- recompute the set from what build_arc_input actually returned rather than
+    # trusting that every candidate handed in survived.
+    queued_arc_ts_labels = frozenset(reaction['ts_label'] for reaction in arc_input['reactions'])
+    queued_candidates = tuple(
+        candidate for candidate in candidates
+        if arc_ts_label(network_id, candidate.ts_label) in queued_arc_ts_labels
+    )
+    queued_ts_labels = frozenset(candidate.ts_label for candidate in queued_candidates)
+
     if not os.path.isdir(paths.arc_project):
         os.makedirs(paths.arc_project)
     arc_kwargs = dict(arc_input)
@@ -236,7 +265,10 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, n
             arc_ts_label=arc_ts_label(network_id, candidate.ts_label),
             path_reaction_labels=(candidate.path_reaction.label,) if candidate.path_reaction is not None else (),
         )
-        for candidate in candidates
+        # N3: only candidates that actually reached ARC (queued_candidates), not every candidate
+        # this function was handed -- a candidate build_arc_input dropped for missing structure
+        # was never queued, so recording a JOIN_STATUS_QUEUED join record for it would be false.
+        for candidate in queued_candidates
     ]
 
     capture_result = capture_ts_artifacts(
@@ -252,7 +284,7 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, n
     )
     if not converged_labels:
         _logger.info(f'ARC converged no transition states for network {network_id!r} this round.')
-        return frozenset()
+        return frozenset(), queued_ts_labels
 
     qm_transition_states = {
         record.network_ts_label: record.artifact_path
@@ -265,7 +297,12 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, n
     # docstring), never from the live/original explored network -- capture_result.networks may
     # differ from `networks` above if a concurrent/prior capture already vendored this network
     # under a different method or path.
-    captured_network = capture_result.networks[network_id]
+    captured_network = capture_result.networks.get(network_id) if capture_result.networks else None
+    if captured_network is None:
+        raise KeyError(
+            f"capture_ts_artifacts did not vendor a copy of network {network_id!r} even though "
+            f"ARC converged {sorted(converged_labels)} for it -- CaptureResult.networks is "
+            f"missing an entry this call needs to write the round's hybrid network file.")
     captured_source_path = os.path.join(capture_result.capture_dir, captured_network['captured_path'])
     result = write_hybrid_network_input_file(
         source_path=captured_source_path,
@@ -279,4 +316,4 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, n
                 f"QM/RRKM for {list(result.qm_ts_labels)}, RMG/ILT for {list(result.ilt_ts_labels)}.")
     for warning in result.warnings:
         _logger.warning(warning)
-    return converged_labels
+    return converged_labels, queued_ts_labels

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -323,11 +323,16 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         paths (RoundPaths): This round's artifact layout.
         config (PESLoopConfig): The loop's configuration.
         network_id (str): The network file stem this round explored.
-        adopted (dict, optional): Network-local TS label -> artifact path adopted from a prior
-                                  run (``t3.pdep.pes_qm.adopt_prior_qm``), if any. Vendored into
-                                  this round's own capture directory and folded into
-                                  ``qm_transition_states`` alongside whatever ARC converged this
-                                  round.
+        adopted (dict, optional): Network-local TS label -> artifact path for every QM artifact
+                                  already in hand before this round ran -- reused from a prior
+                                  project (``t3.pdep.pes_qm.adopt_prior_qm``) or converged by an
+                                  earlier round of this loop (``t3.pdep.pes_loop`` passes its
+                                  cumulative map every round). Vendored into this round's own
+                                  capture directory and folded into ``qm_transition_states``
+                                  alongside whatever ARC converged this round, so every round's
+                                  hybrid carries the CUMULATIVE QM. With no candidates to queue at
+                                  all, ARC and capture are skipped entirely and this round's whole
+                                  job is vendoring these and writing the hybrid.
 
     Returns:
         tuple: ``(converged_ts_labels, queued_ts_labels)``, both ``frozenset``. ``converged_ts_labels``
@@ -385,28 +390,6 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
             f'sensitivity analysis (t3.pdep.pes_sa.run_round_me_sensitivity, stamped by '
             f't3.pdep.pes_rounds.attach_sensitivity_evidence); it is never defaulted or invented.')
 
-    if not os.path.isdir(paths.arc_project):
-        os.makedirs(paths.arc_project)
-    arc_kwargs = dict(arc_input)
-    arc_kwargs.setdefault('project', network_id)
-
-    arc = ARC(**arc_kwargs)
-    arc_input_path = os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME)
-    if not os.path.isfile(arc_input_path):
-        save_yaml_file(path=arc_input_path, content=arc.as_dict())
-    try:
-        arc.execute()
-    except Exception as e:
-        _logger.error(f'ARC crashed with {e.__class__}. Got the following error message:\n{e}')
-        raise
-
-    networks = {
-        network_id: {
-            'source_path': source_path,
-            'source_sha256': hash_file(source_path),
-            'method': config.pes.method,
-        },
-    }
     join_records = [
         TSJoinRecord(
             network_id=network_id,
@@ -426,28 +409,70 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         for candidate in queued_candidates
     ]
 
-    capture_result = capture_ts_artifacts(
-        join_records=join_records,
-        arc_project_directory=paths.arc_project,
-        capture_dir=paths.capture,
-        networks=networks,
-        # Derived off the join records' own frozen evidence, mirroring
-        # t3.main.T3._capture_pdep_ts_artifacts byte for byte -- the argument whose omission was
-        # defect 1: without it every captured artifact carries coefficient=None/delta_ln_k=None
-        # and capture's own verify_capture self-check (rightly) refuses the staged capture.
-        sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)
-                           for record in join_records},
-    )
+    if join_records:
+        if not os.path.isdir(paths.arc_project):
+            os.makedirs(paths.arc_project)
+        arc_kwargs = dict(arc_input)
+        arc_kwargs.setdefault('project', network_id)
+
+        arc = ARC(**arc_kwargs)
+        arc_input_path = os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME)
+        if not os.path.isfile(arc_input_path):
+            save_yaml_file(path=arc_input_path, content=arc.as_dict())
+        try:
+            arc.execute()
+        except Exception as e:
+            _logger.error(f'ARC crashed with {e.__class__}. Got the following error message:\n{e}')
+            raise
+
+        networks = {
+            network_id: {
+                'source_path': source_path,
+                'source_sha256': hash_file(source_path),
+                'method': config.pes.method,
+            },
+        }
+        capture_result = capture_ts_artifacts(
+            join_records=join_records,
+            arc_project_directory=paths.arc_project,
+            capture_dir=paths.capture,
+            networks=networks,
+            # Derived off the join records' own frozen evidence, mirroring
+            # t3.main.T3._capture_pdep_ts_artifacts byte for byte -- the argument whose omission
+            # was defect 1: without it every captured artifact carries
+            # coefficient=None/delta_ln_k=None and capture's own verify_capture self-check
+            # (rightly) refuses the staged capture.
+            sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)
+                               for record in join_records},
+        )
+    else:
+        # Defect-2 fix: a round with nothing to queue (every candidate satisfied by adoption, or
+        # every candidate dropped by build_arc_input) must not run ARC on an empty reaction list,
+        # and MUST NOT call capture_ts_artifacts at all -- capture refuses an empty join_records
+        # outright ("an iteration that queued no P-dep transition states must not call
+        # capture_ts_artifacts at all"), and that refusal is correct: there is nothing to capture.
+        # With adopted artifacts in hand, this round's whole job is vendoring them and writing the
+        # hybrid; with none, there is nothing to do at all.
+        capture_result = None
+        if not adopted:
+            _logger.info(f'Nothing was queued and nothing was adopted for network {network_id!r} '
+                         f'this round; no hybrid network to write.')
+            return frozenset(), queued_ts_labels
 
     converged_labels = frozenset(
         record.network_ts_label for record in capture_result.records
         if record.status == ARTIFACT_STATUS_USABLE
-    )
+    ) if capture_result is not None else frozenset()
     # C2: vendor adopted artifacts into THIS round's own capture directory before deciding
     # whether there is anything to write -- a round that adopted a prior result but converged
     # nothing new still has a hybrid network worth writing (an adopted TS must not silently
-    # revert to an RMG/ILT rate estimate; see this module's caller, t3.pdep.pes_loop).
-    vendored_adopted = _vendor_adopted_artifacts(adopted or dict(), capture_result.capture_dir)
+    # revert to an RMG/ILT rate estimate; see this module's caller, t3.pdep.pes_loop). When this
+    # round captured nothing at all (capture_result is None), the round's capture directory is
+    # still the vendoring root -- created here, holding only the adopted/ subtree.
+    vendor_root = capture_result.capture_dir if capture_result is not None else paths.capture
+    if capture_result is None and not os.path.isdir(vendor_root):
+        os.makedirs(vendor_root)
+    vendored_adopted = _vendor_adopted_artifacts(adopted or dict(), vendor_root)
     if not converged_labels and not vendored_adopted:
         _logger.info(f'ARC converged no transition states for network {network_id!r} this round.')
         return frozenset(), queued_ts_labels
@@ -456,36 +481,44 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         record.network_ts_label: record.artifact_path
         for record in capture_result.records
         if record.status == ARTIFACT_STATUS_USABLE
-    }
+    } if capture_result is not None else dict()
     qm_transition_states.update(vendored_adopted)
     # C3: capture_ts_artifacts only reads energy_settings when THIS round captured at least one
     # new artifact (records_with_artifact) -- a round that adopted a prior result but converged
-    # nothing new gets capture_result.energy_settings=None, which would otherwise crash
-    # QMEnergySettings.from_frozen. The adopted artifacts were computed under settings recorded in
-    # their OWN prior manifest -- and those, not a guess, are the correct provenance for them.
-    energy_settings_frozen = capture_result.energy_settings
+    # nothing new gets capture_result.energy_settings=None (or no capture_result at all), which
+    # would otherwise crash QMEnergySettings.from_frozen. The adopted artifacts were computed
+    # under settings recorded in their OWN prior manifest -- and those, not a guess, are the
+    # correct provenance for them.
+    energy_settings_frozen = capture_result.energy_settings if capture_result is not None else None
     if energy_settings_frozen is None:
         energy_settings_frozen = _adopted_energy_settings(adopted or dict())
     energy_settings = QMEnergySettings.from_frozen(energy_settings_frozen)
-    # I1: the hybrid network is built from the CAPTURE's own vendored network copy and recorded
-    # method (CaptureResult.networks is the authoritative source -- see t3.pdep.capture's own
-    # docstring), never from the live/original explored network -- capture_result.networks may
-    # differ from `networks` above if a concurrent/prior capture already vendored this network
-    # under a different method or path.
-    captured_network = capture_result.networks.get(network_id) if capture_result.networks else None
-    if captured_network is None:
-        raise KeyError(
-            f"capture_ts_artifacts did not vendor a copy of network {network_id!r} even though "
-            f"ARC converged {sorted(converged_labels)} for it -- CaptureResult.networks is "
-            f"missing an entry this call needs to write the round's hybrid network file.")
-    captured_source_path = os.path.join(capture_result.capture_dir, captured_network['captured_path'])
+    if capture_result is not None:
+        # I1: the hybrid network is built from the CAPTURE's own vendored network copy and
+        # recorded method (CaptureResult.networks is the authoritative source -- see
+        # t3.pdep.capture's own docstring), never from the live/original explored network --
+        # capture_result.networks may differ from `networks` above if a concurrent/prior capture
+        # already vendored this network under a different method or path.
+        captured_network = capture_result.networks.get(network_id) if capture_result.networks else None
+        if captured_network is None:
+            raise KeyError(
+                f"capture_ts_artifacts did not vendor a copy of network {network_id!r} even though "
+                f"ARC converged {sorted(converged_labels)} for it -- CaptureResult.networks is "
+                f"missing an entry this call needs to write the round's hybrid network file.")
+        hybrid_source_path = os.path.join(capture_result.capture_dir, captured_network['captured_path'])
+        hybrid_method = captured_network['method']
+    else:
+        # No capture happened, so no vendored network copy exists; the round's own explored
+        # network (the file this function parsed above) is the only -- and the truthful -- source.
+        hybrid_source_path = source_path
+        hybrid_method = config.pes.method
     result = write_hybrid_network_input_file(
-        source_path=captured_source_path,
+        source_path=hybrid_source_path,
         dest_path=hybrid_network_path(paths, network_id),
-        method=captured_network['method'],
+        method=hybrid_method,
         qm_transition_states=qm_transition_states,
         energy_settings=energy_settings,
-        qm_artifacts_root=capture_result.capture_dir,
+        qm_artifacts_root=vendor_root,
     )
     _logger.info(f"Wrote a hybrid P-dep network input for {network_id!r} to {result.dest_path}: "
                 f"QM/RRKM for {list(result.qm_ts_labels)}, RMG/ILT for {list(result.ilt_ts_labels)}.")

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -581,9 +581,9 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
     return converged_labels, queued_ts_labels
 
 
-def _normalized_model_chemistry(sp_level: str) -> str | None:
+def _normalized_model_chemistry(sp_level: str, freq_level: str | None = None) -> str | None:
     """
-    Normalize a T3 ``sp_level`` string into ARC's own ``model_chemistry`` text.
+    Normalize a T3 ``sp_level``/``freq_level`` pair into ARC's own ``model_chemistry`` text.
 
     A capture manifest's ``model_chemistry`` is ARC's byte-for-byte ``LevelOfTheory(...)`` repr,
     written via ``arc.statmech.arkane.get_arkane_model_chemistry`` -- including year-suffix
@@ -593,35 +593,104 @@ def _normalized_model_chemistry(sp_level: str) -> str | None:
     normalization chain ARC itself used to write the manifest, so the comparison is apples to
     apples.
 
-    ``None`` -- never an exception -- is the answer whenever ARC cannot resolve one. In
-    particular, ``get_arkane_model_chemistry`` itself RAISES (``ValueError: freq_level required
-    when freq_scale_factor isn't provided``) for a non-composite level with no tabulated
-    frequency scale factor -- e.g. ``'wb97xd2023/def2tzvp'``, ARC's own normalized form, exactly
-    what a user copying a level out of a prior capture manifest would write. This function only
-    ever has the single ``sp_level`` string, no frequency level to hand ARC in that case, so the
-    raise is converted to the documented "could not resolve" answer: the caller
-    (``adopt_prior_qm``) then warns that nothing will match, rather than the whole run dying
-    before round 0.
+    The frequency level is what makes that chain reproducible, and it is why this takes two
+    arguments rather than one. ARC settles its own frequency scale factor BEFORE the Arkane
+    adapter runs, in ``ARC.check_freq_scaling_factor`` (``arc/main.py``), and it settles it from
+    the FREQUENCY level -- ``assign_frequency_scale_factor(freq_level)``, falling back to ``1``
+    when the database has no entry. That factor is therefore never ``None`` for any input T3 can
+    build (``build_arc_input`` always sets ``freq_level``), so ``get_arkane_model_chemistry``
+    always takes its ``freq_scale_factor is not None`` branch and writes the plain
+    ``LevelOfTheory`` repr of the SP level.
+
+    Deriving the factor from the SP level instead -- as this function used to -- silently breaks
+    the whole of ``config.reuse`` for every configuration where ``sp_level != freq_level``: an SP
+    level with no tabulated scale factor of its OWN (e.g. ``'dlpno-ccsd(t)-f12/cc-pvtz-f12'``,
+    which the schema explicitly permits) yields ``None``, ARC then RAISES ``ValueError:
+    freq_level required when freq_scale_factor isn't provided``, this function reports
+    "unresolvable", and every prior capture is refused on a ``model_chemistry`` mismatch that
+    never existed. Reuse looked implemented and was dead.
+
+    Only whether the factor is ``None`` reaches ARC's branch decision, never its value, so a
+    fallback of ``1`` reproduces ARC's own string exactly even when ARC reached its value by
+    Truhlar's method rather than by the database.
+
+    ``None`` -- never an exception -- remains the answer whenever ARC genuinely cannot resolve
+    one: the caller (``adopt_prior_qm``) then warns that nothing will match, rather than the whole
+    run dying before round 0.
 
     Args:
-        sp_level (str): A T3 level-of-theory string, e.g. ``config.qm.sp_level``, undashed.
+        sp_level (str): A T3 single-point level-of-theory string, e.g. ``config.qm.sp_level``,
+                        undashed.
+        freq_level (str, optional): The frequency level the same run used, e.g.
+                                    ``config.qm.freq_level``. ``None`` falls back to ``sp_level``,
+                                    the only honest guess when a caller has no separate frequency
+                                    level to offer.
 
     Returns:
         str | None: The normalized ``model_chemistry`` text, or ``None`` if ARC could not
         resolve one.
     """
+    normalized = _normalized_model_chemistries(sp_level, freq_level)
+    return normalized[0] if normalized else None
+
+
+def _normalized_model_chemistries(sp_level: str, freq_level: str | None = None) -> tuple[str, ...]:
+    """
+    Every ``model_chemistry`` spelling a capture made at this ``sp_level``/``freq_level`` pair may
+    legitimately carry.
+
+    There are two, and both are real ARC output, because ARC's own answer depends on whether it
+    had settled a frequency scale factor by the time the Arkane adapter ran:
+
+    - the plain ``LevelOfTheory(...)`` repr of the SP level, which
+      ``get_arkane_model_chemistry`` returns once ``freq_scale_factor`` is not ``None`` -- what
+      ARC writes today, since ``ARC.check_freq_scaling_factor`` always settles one from the
+      frequency level (falling back to ``1``) before the adapter is built;
+    - the multi-line ``CompositeLevelOfTheory(freq=..., energy=...)`` form it returns when no
+      scale factor was settled. A capture carrying exactly this is vendored in this repository:
+      ``tests/data/pdep_energy_settings/composite_level_project/calcs/statmech/thermo/input.py``,
+      which ``t3.pdep.energy_settings`` preserves verbatim into the manifest.
+
+    They describe the SAME pair of levels, so accepting either is not a loosened match -- it is
+    the match. Refusing one of them would refuse reuse from every capture written by an ARC on
+    the other side of that behaviour change, which is not a level-of-theory conflict at all.
+
+    Args:
+        sp_level (str): The single-point level-of-theory string, undashed.
+        freq_level (str, optional): The frequency level, defaulting to ``sp_level``.
+
+    Returns:
+        tuple[str, ...]: The accepted spellings, most-likely first; empty if ARC could not resolve
+        any.
+    """
     level = Level(repr=sp_level)
-    scale = assign_frequency_scale_factor(level)
-    try:
-        return get_arkane_model_chemistry(level, freq_scale_factor=scale)
-    except ValueError as e:
+    frequency_level = Level(repr=freq_level) if freq_level else level
+    # Mirrors ARC.check_freq_scaling_factor: the factor comes from the FREQUENCY level, and is
+    # never left as None once a frequency level exists.
+    scale = assign_frequency_scale_factor(frequency_level)
+    if scale is None:
+        scale = 1
+    spellings = []
+    for freq_scale_factor in (scale, None):
+        try:
+            resolved = get_arkane_model_chemistry(level, freq_level=frequency_level,
+                                                  freq_scale_factor=freq_scale_factor)
+        except ValueError as e:
+            _logger.debug(f'PES loop: ARC could not normalize the level of theory {sp_level!r} '
+                          f'(frequencies at {freq_level or sp_level!r}) with '
+                          f'freq_scale_factor={freq_scale_factor!r}: {e}')
+            continue
+        if resolved is not None and resolved not in spellings:
+            spellings.append(resolved)
+    if not spellings:
         _logger.warning(f'PES loop: ARC could not normalize the level of theory {sp_level!r} '
-                        f'into a model_chemistry ({e}); treating it as unresolvable.')
-        return None
+                        f'(frequencies at {freq_level or sp_level!r}) into a model_chemistry; '
+                        f'treating it as unresolvable.')
+    return tuple(spellings)
 
 
 def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str,
-                   channel_key_by_ts_label: dict) -> dict[str, str]:
+                   channel_key_by_ts_label: dict, freq_level: str | None = None) -> dict[str, str]:
     """
     Reuse transition states a previous T3 (or standalone PES loop) run already computed.
 
@@ -675,8 +744,14 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                                  reusable prior QM, e.g. ``config.reuse.from_t3_projects``.
         network_id (str): This run's network id. Logged for traceability only -- never a gate
                           (see above).
-        level_of_theory (str): The level of theory ``model_chemistry`` must match to be adopted
-                               (e.g. ``config.qm.sp_level``), undashed.
+        level_of_theory (str): The SINGLE-POINT level of theory ``model_chemistry`` must match to
+                               be adopted (e.g. ``config.qm.sp_level``), undashed.
+        freq_level (str, optional): The frequency level of the same run (e.g.
+                                    ``config.qm.freq_level``). Required to reproduce ARC's own
+                                    ``model_chemistry`` string whenever it differs from
+                                    ``level_of_theory`` -- without it every prior capture made
+                                    under a composite SP/frequency pair is refused on a mismatch
+                                    that does not exist (see ``_normalized_model_chemistry``).
         channel_key_by_ts_label (dict): THIS run's own network-local TS label -> structural
                                         channel key, from
                                         ``t3.pdep.pes_rounds.channel_keys_by_ts_label`` over the
@@ -687,8 +762,12 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
         dict[str, str]: Network-local TS label -> the adopted artifact path (already resolved,
         by ``verify_capture``, to an absolute path inside its capture directory).
     """
-    normalized_requested = _normalized_model_chemistry(level_of_theory)
-    if normalized_requested is None:
+    # Every spelling ARC may have written for this sp/freq pair -- see
+    # _normalized_model_chemistries: the plain SP LevelOfTheory repr and the
+    # CompositeLevelOfTheory(freq=..., energy=...) form are the same pair of levels, and captures
+    # carrying each exist.
+    normalized_requested = _normalized_model_chemistries(level_of_theory, freq_level)
+    if not normalized_requested:
         _logger.warning(
             f"PES loop: ARC could not resolve a model_chemistry for the requested level of "
             f"theory {level_of_theory!r}; every prior capture's model_chemistry will therefore "
@@ -727,11 +806,12 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                 continue
             energy_settings = verified.energy_settings or {}
             manifest_model_chemistry = energy_settings.get('model_chemistry')
-            if manifest_model_chemistry != normalized_requested:
+            if manifest_model_chemistry not in normalized_requested:
                 _logger.info(
                     f"PES loop: refusing prior QM at {manifest_path!r} -- its model_chemistry "
                     f"{manifest_model_chemistry!r} does not match the requested level of theory "
-                    f"{level_of_theory!r} (normalized: {normalized_requested!r}).")
+                    f"{level_of_theory!r} (accepted spellings: "
+                    f"{list(normalized_requested)}).")
                 continue
             # The capture's own VENDORED network copy is the authoritative structural record of
             # what each of its transition states connects (verified.networks -- see

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -39,7 +39,9 @@ from arc.level import Level, assign_frequency_scale_factor
 from arc.main import ARC
 from arc.statmech.arkane import get_arkane_model_chemistry
 
-from t3.pdep.capture import CAPTURE_MANIFEST_FILE_NAME, capture_ts_artifacts, verify_capture
+from t3.pdep.capture import (CAPTURE_MANIFEST_FILE_NAME,
+                             SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS,
+                             capture_ts_artifacts, verify_capture)
 from t3.pdep.discovery import ARTIFACT_STATUS_USABLE
 from t3.pdep.hashing import hash_file
 from t3.pdep.hybrid import (QMEnergySettings, _read_qm_artifact, _vendor_qm_artifacts,
@@ -444,6 +446,10 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
             # (rightly) refuses the staged capture.
             sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)
                                for record in join_records},
+            # This loop's evidence is an ungated max over ALL direction keys (t3.pdep.pes_sa),
+            # NOT T3's in-run observable-gated convention -- mark the manifest so the two can
+            # never be silently compared on the shared coefficient/delta_ln_k field names.
+            sensitivity_aggregation=SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS,
         )
     else:
         # Defect-2 fix: a round with nothing to queue (every candidate satisfied by adoption, or

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -33,7 +33,6 @@ This module never imports ``rmgpy`` or ``arkane``. It imports ``arc`` directly, 
 
 import logging
 import os
-import shutil
 
 from arc.common import save_yaml_file
 from arc.level import Level, assign_frequency_scale_factor
@@ -43,7 +42,8 @@ from arc.statmech.arkane import get_arkane_model_chemistry
 from t3.pdep.capture import CAPTURE_MANIFEST_FILE_NAME, capture_ts_artifacts, verify_capture
 from t3.pdep.discovery import ARTIFACT_STATUS_USABLE
 from t3.pdep.hashing import hash_file
-from t3.pdep.hybrid import QMEnergySettings, write_hybrid_network_input_file
+from t3.pdep.hybrid import (QMEnergySettings, _read_qm_artifact, _vendor_qm_artifacts,
+                            write_hybrid_network_input_file)
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label
 from t3.pdep.parser import parse_pdep_network_file
 from t3.pdep.pes_rounds import RoundPaths, hybrid_network_path
@@ -177,7 +177,8 @@ def _explored_network_path(paths: RoundPaths, network_id: str) -> str:
 
 def _vendor_adopted_artifacts(adopted: dict, capture_dir: str) -> dict[str, str]:
     """
-    Copy adopted prior-QM artifacts into this round's own capture directory.
+    Copy adopted prior-QM artifacts, AND every log file they reference, into this round's own
+    capture directory.
 
     ``write_hybrid_network_input_file``'s ``qm_artifacts_root`` guard only trusts artifact paths
     that live under the capture directory it is given -- a deliberate fail-closed security guard
@@ -187,10 +188,27 @@ def _vendor_adopted_artifacts(adopted: dict, capture_dir: str) -> dict[str, str]
     ``qm_transition_states`` -- the existing guard then covers it for free, since ``adopted/``
     lives under the same ``capture_dir`` passed as ``qm_artifacts_root``.
 
+    A captured artifact's own ``Log(...)`` arguments are relative to the artifact's OWN directory
+    (see ``t3.pdep.hybrid.write_hybrid_network_input_file``'s docstring), so copying only the
+    ``.py`` file -- without also copying the log tree it points at -- leaves those references
+    dangling: ``write_hybrid_network_input_file``'s own pre-flight, run later on the vendored copy,
+    would then raise a ``ValueError`` for a ``Log(...)`` file that "does not exist". This function
+    therefore reuses ``t3.pdep.hybrid``'s own artifact-reading and vendoring machinery
+    (``_read_qm_artifact``, ``_vendor_qm_artifacts``) -- the same functions ``t3.pdep.capture``
+    already imports for the same reason -- instead of hand-copying just the ``.py`` file.
+
+    Every adopted artifact was, by construction, itself produced by a PRIOR call to
+    ``t3.pdep.capture.capture_ts_artifacts``, which always vendors an artifact to exactly
+    ``<that capture's own capture_dir>/qm/<arc_ts_label>.py`` (see
+    ``t3.pdep.capture``'s ``_CAPTURE_QM_SUBDIR`` and ``verify_capture``). So the artifact's own
+    ``allowed_log_root`` for confinement -- the prior run's own capture directory -- is always
+    recoverable as two directories up from its ``artifact_path``, with no need for
+    ``adopt_prior_qm`` to separately track or pass it.
+
     Args:
         adopted (dict): Network-local TS label -> source artifact path, as returned by
                         ``adopt_prior_qm``.
-        capture_dir (str): This round's own capture directory (``paths.capture``).
+        capture_dir (str): This round's own capture directory (``capture_result.capture_dir``).
 
     Returns:
         dict[str, str]: Network-local TS label -> the vendored (copied) artifact path, now inside
@@ -199,22 +217,76 @@ def _vendor_adopted_artifacts(adopted: dict, capture_dir: str) -> dict[str, str]
     Raises:
         FileNotFoundError: An adopted artifact's source path no longer exists -- fail closed
                            rather than silently dropping it from the hybrid network.
+        ValueError: An adopted artifact references a ``Log(...)`` file that no longer exists, or
+                   that resolves outside its own prior capture directory -- see
+                   ``t3.pdep.hybrid._read_qm_artifact``.
     """
     if not adopted:
         return dict()
-    adopted_dir = os.path.join(capture_dir, 'adopted')
-    os.makedirs(adopted_dir, exist_ok=True)
-    vendored = dict()
     for ts_label, source_path in adopted.items():
         if not os.path.isfile(source_path):
             raise FileNotFoundError(
                 f"PES loop: adopted artifact for {ts_label!r} no longer exists at "
                 f"{source_path!r}; refusing to fold a missing artifact into this round's hybrid "
                 f"network.")
-        dest_path = os.path.join(adopted_dir, f'{ts_label}{os.path.splitext(source_path)[1]}')
-        shutil.copy2(source_path, dest_path)
-        vendored[ts_label] = dest_path
-    return vendored
+    artifact_infos = {
+        ts_label: _read_qm_artifact(
+            ts_label=ts_label,
+            artifact_path=source_path,
+            allowed_log_root=os.path.dirname(os.path.dirname(os.path.abspath(source_path))),
+        )
+        for ts_label, source_path in adopted.items()
+    }
+    adopted_dir = os.path.join(capture_dir, 'adopted')
+    _vendor_qm_artifacts(artifact_infos=artifact_infos, qm_dir=adopted_dir, dest_dir=capture_dir)
+    return {ts_label: os.path.join(adopted_dir, f'{ts_label}.py') for ts_label in adopted}
+
+
+def _adopted_energy_settings(adopted: dict) -> dict | None:
+    """
+    Recover the frozen energy-reference settings adopted artifacts were computed under, from their
+    OWN prior capture manifest(s).
+
+    ``t3.pdep.capture.capture_ts_artifacts`` only reads ``energy_settings`` from the live ARC
+    project when THIS round captured at least one new artifact (``records_with_artifact``) -- a
+    round that adopted a prior result but converged nothing new gets ``CaptureResult.energy_settings
+    = None`` from that call, even though the adopted artifacts plainly WERE computed under some
+    settings. Those settings are recorded in each adopted artifact's own (prior) capture manifest --
+    the same manifest ``adopt_prior_qm`` already re-validated with ``verify_capture`` before
+    adopting from it -- so this function re-derives the artifact's prior capture directory the same
+    way ``_vendor_adopted_artifacts`` does (two directories up from ``artifact_path``, since a
+    captured artifact always lives at ``<capture_dir>/qm/<label>.py``) and reads that manifest's
+    settings directly, rather than treating "nothing new this round" as "no settings available".
+
+    Args:
+        adopted (dict): Network-local TS label -> ORIGINAL (pre-vendoring) adopted artifact path,
+                        as returned by ``adopt_prior_qm``.
+
+    Returns:
+        dict, optional: The frozen ``energy_settings`` block, or ``None`` if ``adopted`` is empty.
+
+    Raises:
+        ValueError: Two adopted artifacts come from prior captures whose manifests disagree on
+                   ``energy_settings`` -- refuse to guess which one is authoritative for this
+                   round's hybrid network rather than silently picking one.
+    """
+    if not adopted:
+        return None
+    settings_by_capture_dir = dict()
+    for source_path in adopted.values():
+        capture_dir = os.path.dirname(os.path.dirname(os.path.abspath(source_path)))
+        if capture_dir in settings_by_capture_dir:
+            continue
+        settings_by_capture_dir[capture_dir] = verify_capture(capture_dir).energy_settings
+    settings_values = list(settings_by_capture_dir.values())
+    first = settings_values[0]
+    for capture_dir, other in list(settings_by_capture_dir.items())[1:]:
+        if other != first:
+            raise ValueError(
+                f"PES loop: adopted artifacts come from prior captures with conflicting "
+                f"energy_settings ({first!r} vs {other!r} at {capture_dir!r}); refusing to guess "
+                f"which one is authoritative for this round's hybrid network.")
+    return first
 
 
 def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
@@ -229,7 +301,7 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
     (``t3.pdep.capture.capture_ts_artifacts``) against this round's own capture directory, and
     writes this round's hybrid Arkane network input file
     (``t3.pdep.hybrid.write_hybrid_network_input_file``) to exactly
-    ``t3.pdep.pes_loop.hybrid_network_path(paths, network_id)`` -- the loop checks for that exact
+    ``t3.pdep.pes_rounds.hybrid_network_path(paths, network_id)`` -- the loop checks for that exact
     file at the top of every round after the first and fails the round if it is absent.
 
     No ``_refuse_if_queued_ts_lack_artifacts``-equivalent guard exists here, unlike
@@ -347,7 +419,15 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
         if record.status == ARTIFACT_STATUS_USABLE
     }
     qm_transition_states.update(vendored_adopted)
-    energy_settings = QMEnergySettings.from_frozen(capture_result.energy_settings)
+    # C3: capture_ts_artifacts only reads energy_settings when THIS round captured at least one
+    # new artifact (records_with_artifact) -- a round that adopted a prior result but converged
+    # nothing new gets capture_result.energy_settings=None, which would otherwise crash
+    # QMEnergySettings.from_frozen. The adopted artifacts were computed under settings recorded in
+    # their OWN prior manifest -- and those, not a guess, are the correct provenance for them.
+    energy_settings_frozen = capture_result.energy_settings
+    if energy_settings_frozen is None:
+        energy_settings_frozen = _adopted_energy_settings(adopted or dict())
+    energy_settings = QMEnergySettings.from_frozen(energy_settings_frozen)
     # I1: the hybrid network is built from the CAPTURE's own vendored network copy and recorded
     # method (CaptureResult.networks is the authoritative source -- see t3.pdep.capture's own
     # docstring), never from the live/original explored network -- capture_result.networks may
@@ -422,16 +502,16 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
       different level is refused even though it exists and converged (never adopted "close
       enough"). A refusal is logged with the manifest path, its raw ``model_chemistry``, and the
       requested level, so a silent "nothing was reused" is always explainable.
-    - ``record.network_id == network_id`` is used only as a cheap pre-filter, never the sole
-      guard: Arkane names TS artifacts positionally (``'TS{i+1}'``, see ``arkane/pdep.py``), so a
-      pruned or reordered exploration can re-issue the same label for a different transition
-      state, and ``network_id`` itself never matches across independent PES-loop runs (Arkane
-      names its own output by index, e.g. ``network0_full.py``, disjoint from T3's
-      ``network<digits>_<digits>`` convention). The real match is structural: the record's
-      ``path_reaction_labels`` (the path reaction label(s) its transition state actually joined)
-      against THIS run's own network-local candidates, supplied via
+    - ``record.network_id`` is NEVER a gate -- it is logged only. Arkane names TS artifacts
+      positionally (``'TS{i+1}'``, see ``arkane/pdep.py``), so a pruned or reordered exploration
+      can re-issue the same label for a different transition state, and ``network_id`` itself
+      never matches across independent PES-loop runs (Arkane names its own output by index, e.g.
+      ``network0_full.py``, disjoint from T3's ``network<digits>_<digits>`` convention) -- gating
+      on it would refuse the exact case this function exists to serve. The real match is
+      structural: the record's ``path_reaction_labels`` (the path reaction label(s) its transition
+      state actually joined) against THIS run's own network-local candidates, supplied via
       ``path_reaction_labels_by_ts_label``. A record with no recorded ``path_reaction_labels``,
-      or one that matches no local candidate, is refused.
+      or one that matches no local candidate, is refused (logged).
 
     If two prior captures offer conflicting artifacts for what structurally matches the same
     local TS label, adoption for that label is refused (not a last-write-wins guess) and a
@@ -444,7 +524,8 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
     Args:
         from_t3_projects (list): T3 (or standalone PES loop) project directories to search for
                                  reusable prior QM, e.g. ``config.reuse.from_t3_projects``.
-        network_id (str): This run's network id, used only as a cheap pre-filter (see above).
+        network_id (str): This run's network id. Logged for traceability only -- never a gate
+                          (see above).
         level_of_theory (str): The level of theory ``model_chemistry`` must match to be adopted
                                (e.g. ``config.qm.sp_level``), undashed.
         path_reaction_labels_by_ts_label (dict): THIS run's own network-local TS label -> tuple
@@ -457,6 +538,11 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
         by ``verify_capture``, to an absolute path inside its capture directory).
     """
     normalized_requested = _normalized_model_chemistry(level_of_theory)
+    if normalized_requested is None:
+        _logger.warning(
+            f"PES loop: ARC could not resolve a model_chemistry for the requested level of "
+            f"theory {level_of_theory!r}; every prior capture's model_chemistry will therefore "
+            f"fail to match and nothing will be adopted from {from_t3_projects!r}.")
     adopted = dict()
     conflicted = set()
     for project_directory in from_t3_projects:
@@ -484,16 +570,36 @@ def adopt_prior_qm(from_t3_projects: list, network_id: str, level_of_theory: str
                     f"{level_of_theory!r} (normalized: {normalized_requested!r}).")
                 continue
             for record in verified.ts_records:
-                if record.network_id != network_id or record.status != ARTIFACT_STATUS_USABLE:
+                if record.status != ARTIFACT_STATUS_USABLE:
                     continue
                 if not record.path_reaction_labels:
                     continue
+                if record.network_id != network_id:
+                    # Never a gate -- see this function's own docstring: Arkane's network_id is
+                    # per-run and never matches across independent PES-loop runs by construction.
+                    # Logged only, so a structural match is always explainable even when the
+                    # network ids visibly differ.
+                    _logger.debug(
+                        f"PES loop: matching prior QM at {manifest_path!r} for a different "
+                        f"network_id ({record.network_id!r} vs this run's {network_id!r}) on "
+                        f"structural path_reaction_labels alone -- network_id is a log-only field, "
+                        f"never a gate (see this function's docstring).")
                 local_label = None
                 for candidate_label, candidate_labels in path_reaction_labels_by_ts_label.items():
                     if candidate_labels and set(candidate_labels) == set(record.path_reaction_labels):
                         local_label = candidate_label
                         break
-                if local_label is None or local_label in conflicted:
+                if local_label is None:
+                    _logger.info(
+                        f"PES loop: refusing prior QM for {record.network_ts_label!r} at "
+                        f"{manifest_path!r} -- its path_reaction_labels "
+                        f"{record.path_reaction_labels!r} match none of this run's own "
+                        f"network-local candidates.")
+                    continue
+                if local_label in conflicted:
+                    _logger.info(
+                        f"PES loop: refusing prior QM for {local_label!r} at {manifest_path!r} -- "
+                        f"already refused earlier this call due to a conflicting prior capture.")
                     continue
                 if local_label in adopted and adopted[local_label] != record.artifact_path:
                     _logger.warning(

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -174,7 +174,7 @@ def _explored_network_path(paths: RoundPaths, network_id: str) -> str:
 
 
 def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
-                  network_id: str) -> tuple[frozenset, frozenset]:
+                  network_id: str) -> tuple[frozenset[str], frozenset[str]]:
     """
     Run ARC on one round's QM candidates and fold whatever converges into a hybrid network file.
 

--- a/t3/pdep/pes_qm.py
+++ b/t3/pdep/pes_qm.py
@@ -39,6 +39,7 @@ from t3.pdep.discovery import ARTIFACT_STATUS_USABLE
 from t3.pdep.hashing import hash_file
 from t3.pdep.hybrid import QMEnergySettings, write_hybrid_network_input_file
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label
+from t3.pdep.parser import parse_pdep_network_file
 from t3.pdep.pes_loop import hybrid_network_path
 from t3.pdep.pes_rounds import RoundPaths
 from t3.schema import PESLoopConfig
@@ -51,13 +52,35 @@ _logger = logging.getLogger(__name__)
 ARC_INPUT_FILE_NAME = 'arc_input.yml'
 
 
-def build_arc_input(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, network_id: str) -> dict:
+def build_arc_input(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, network_id: str,
+                    species_structures: dict) -> dict:
     """
-    Build the ARC input dict for one round's quantum chemistry, with no I/O.
+    Build the ARC input dict for one round's quantum chemistry, with no file or network I/O.
 
-    Kept pure so the levels of theory, job types, and TS label namespacing this function decides
-    are unit-testable without running ARC, without writing a file, and without an ARC project
-    directory existing on disk.
+    Kept pure (beyond logging a warning for a candidate that cannot be built) so the levels of
+    theory, job types, and TS label namespacing this function decides are unit-testable without
+    running ARC, without writing a file, and without an ARC project directory existing on disk.
+
+    Every reaction dict this function emits mirrors ``t3.main.T3.build_pdep_path_reaction`` --
+    ARC's own ``ARCReaction.from_dict`` (``arc/reaction/reaction.py``), when handed a top-level
+    ``species_list``, resolves a reaction's ``r_species``/``p_species`` entries by matching their
+    ``'label'`` against that list rather than building fresh ``ARCSpecies`` from the reaction
+    dict itself -- so a reaction dict alone, without a top-level ``'species'`` list, can never
+    construct a valid ``ARCReaction``. ``species_structures`` (``t3.pdep.parser.PDepNetwork``'s
+    field of the same name) is what supplies the adjacency list every ``'species'`` entry needs.
+
+    A candidate whose reactant or product labels have no entry in ``species_structures`` is
+    dropped from the returned ``reactions`` list (with a warning logged) rather than raising --
+    the same fail-open choice ``build_pdep_path_reaction`` makes, so one network species with an
+    unreadable structure loses only the reactions it participates in, not every candidate in the
+    round.
+
+    ``compute_thermo`` is explicitly set to ``False`` on every emitted species dict. ARC defaults
+    a bare species dict's ``compute_thermo`` to ``True``, which would queue a full thermodynamics
+    job for every reactant and product species reaching ARC through this path -- unbounded by
+    ``config.qm.max_transition_states_per_round`` and outside what this round's TS-only QM budget
+    is meant to cover. This loop only ever needs the transition state itself; reactant/product
+    thermo, if wanted, is a distinct, separately-budgeted concern.
 
     Args:
         candidates (tuple): The ``t3.pdep.pes_rounds.QMCandidate`` entries to queue, already
@@ -70,18 +93,39 @@ def build_arc_input(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
                           to namespace every candidate's TS label via ``arc_ts_label`` so it can
                           never collide with another network's transition state of the same
                           network-local name.
+        species_structures (dict): Network species label -> RMG adjacency-list text, i.e. the
+                                   explored network's own ``PDepNetwork.species_structures``.
 
     Returns:
         dict: The ARC input, suitable for ``arc.main.ARC(**arc_input)``.
     """
     qm = config.qm
+    species_by_label = dict()
     reactions = []
     for candidate in candidates:
+        path_reaction = candidate.path_reaction
+        labels = tuple(path_reaction.reactants) + tuple(path_reaction.products)
+        missing = [label for label in labels if not species_structures.get(label)]
+        if missing:
+            _logger.warning(f"Network {network_id!r} carries no adjacency list for species "
+                            f"{missing} of transition state '{candidate.ts_label}', so that "
+                            f"reaction cannot be sent to ARC.")
+            continue
+        for label in labels:
+            species_by_label.setdefault(label, species_structures[label])
         reactions.append({
+            'label': path_reaction.label,
             'ts_label': arc_ts_label(network_id, candidate.ts_label),
-            'network_ts_label': candidate.ts_label,
             'family': candidate.family,
+            'reactants': list(path_reaction.reactants),
+            'products': list(path_reaction.products),
+            'r_species': [{'label': label} for label in path_reaction.reactants],
+            'p_species': [{'label': label} for label in path_reaction.products],
         })
+    species = [
+        {'label': label, 'adjlist': adjlist, 'compute_thermo': False}
+        for label, adjlist in species_by_label.items()
+    ]
     return {
         'project_directory': paths.arc_project,
         'opt_level': qm.opt_level,
@@ -94,6 +138,7 @@ def build_arc_input(candidates: tuple, paths: RoundPaths, config: PESLoopConfig,
             'rotors': qm.rotors,
             'irc': qm.irc,
         },
+        'species': species,
         'reactions': reactions,
     }
 
@@ -122,14 +167,28 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, n
     """
     Run ARC on one round's QM candidates and fold whatever converges into a hybrid network file.
 
-    This is the real ``qm_runner`` ``t3.pdep.pes_loop.run_pes_loop`` injects. It: builds the ARC
-    input (``build_arc_input``), runs ARC via the same construction ``t3.main.T3.run_arc`` uses
-    (``ARC(**arc_kwargs)`` then ``arc.execute()``), captures whatever transition-state QM
-    artifacts converged (``t3.pdep.capture.capture_ts_artifacts``) against this round's own
-    capture directory, and writes this round's hybrid Arkane network input file
+    This is the real ``qm_runner`` ``t3.pdep.pes_loop.run_pes_loop`` injects. It: parses this
+    round's explored network to get species structures, builds the ARC input (``build_arc_input``),
+    runs ARC via the same construction ``t3.main.T3.run_arc`` uses (``ARC(**arc_kwargs)`` then
+    ``arc.execute()``), captures whatever transition-state QM artifacts converged
+    (``t3.pdep.capture.capture_ts_artifacts``) against this round's own capture directory, and
+    writes this round's hybrid Arkane network input file
     (``t3.pdep.hybrid.write_hybrid_network_input_file``) to exactly
     ``t3.pdep.pes_loop.hybrid_network_path(paths, network_id)`` -- the loop checks for that exact
     file at the top of every round after the first and fails the round if it is absent.
+
+    No ``_refuse_if_queued_ts_lack_artifacts``-equivalent guard exists here, unlike
+    ``t3.main.T3._capture_pdep_ts_artifacts``. That guard exists because ``t3.main`` can capture
+    the SAME ARC project directory twice across separate iterations (a fresh capture, or a
+    skip-re-capture replay over an existing manifest), and ARC deletes and recreates
+    ``calcs/statmech/kinetics/`` on its next rate pass -- so a second capture over a project ARC
+    has since wiped can silently see fewer artifacts than the first one did. This loop never
+    reuses a project directory: every round gets its own freshly created ``paths.arc_project``
+    (``t3.pdep.pes_rounds.round_paths`` namespaces it by round index), and capture happens exactly
+    once, synchronously, immediately after ``arc.execute()`` returns within this same call -- there
+    is no second call, no later iteration, and no window in which ARC could have cleaned up this
+    round's own artifacts before they are captured. The artifact-wipe race the guard defends
+    against is structurally excluded here, not merely unobserved.
 
     Args:
         candidates (tuple): The ``t3.pdep.pes_rounds.QMCandidate`` entries to queue, already
@@ -143,25 +202,25 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, n
                    t3.pdep.discovery.ARTIFACT_STATUS_USABLE`` only -- an ``UNVERIFIED`` artifact's
                    convergence is, by design, unknown, and is never treated as usable).
     """
-    arc_input = dict(build_arc_input(candidates, paths, config, network_id))
+    source_path = _explored_network_path(paths, network_id)
+    network = parse_pdep_network_file(path=source_path)
+
+    arc_input = build_arc_input(candidates, paths, config, network_id, network.species_structures)
     if not os.path.isdir(paths.arc_project):
         os.makedirs(paths.arc_project)
-    arc_input.setdefault('project', network_id)
-    reactions = arc_input.pop('reactions')
-
-    arc_kwargs = {key: value for key, value in arc_input.items()}
-    arc_input_path = os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME)
-    if not os.path.isfile(arc_input_path):
-        save_yaml_file(path=arc_input_path, content={**arc_kwargs, 'reactions': reactions})
+    arc_kwargs = dict(arc_input)
+    arc_kwargs.setdefault('project', network_id)
 
     arc = ARC(**arc_kwargs)
+    arc_input_path = os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME)
+    if not os.path.isfile(arc_input_path):
+        save_yaml_file(path=arc_input_path, content=arc.as_dict())
     try:
         arc.execute()
     except Exception as e:
         _logger.error(f'ARC crashed with {e.__class__}. Got the following error message:\n{e}')
         raise
 
-    source_path = _explored_network_path(paths, network_id)
     networks = {
         network_id: {
             'source_path': source_path,
@@ -201,11 +260,23 @@ def arc_qm_runner(candidates: tuple, paths: RoundPaths, config: PESLoopConfig, n
         if record.status == ARTIFACT_STATUS_USABLE
     }
     energy_settings = QMEnergySettings.from_frozen(capture_result.energy_settings)
-    write_hybrid_network_input_file(
-        source_path=source_path,
+    # I1: the hybrid network is built from the CAPTURE's own vendored network copy and recorded
+    # method (CaptureResult.networks is the authoritative source -- see t3.pdep.capture's own
+    # docstring), never from the live/original explored network -- capture_result.networks may
+    # differ from `networks` above if a concurrent/prior capture already vendored this network
+    # under a different method or path.
+    captured_network = capture_result.networks[network_id]
+    captured_source_path = os.path.join(capture_result.capture_dir, captured_network['captured_path'])
+    result = write_hybrid_network_input_file(
+        source_path=captured_source_path,
         dest_path=hybrid_network_path(paths, network_id),
-        method=config.pes.method,
+        method=captured_network['method'],
         qm_transition_states=qm_transition_states,
         energy_settings=energy_settings,
+        qm_artifacts_root=capture_result.capture_dir,
     )
+    _logger.info(f"Wrote a hybrid P-dep network input for {network_id!r} to {result.dest_path}: "
+                f"QM/RRKM for {list(result.qm_ts_labels)}, RMG/ILT for {list(result.ilt_ts_labels)}.")
+    for warning in result.warnings:
+        _logger.warning(warning)
     return converged_labels

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -22,11 +22,20 @@ this list, so a non-deterministic order would admit a different subset on each r
 runs of the same input incomparable.
 """
 
+import logging
 import os
 from dataclasses import dataclass, replace
 
+from arc.molecule.molecule import Molecule
+
 from t3.pdep.barrierless import classify_barrierless
-from t3.pdep.parser import PDepNetwork, PDepPathReaction
+from t3.pdep.parser import PDepNetwork, PDepPathReaction, canonical_channel_pair
+
+_logger = logging.getLogger(__name__)
+
+# adjacency-list text -> canonical SMILES (or None for unparseable text), memoized because one
+# loop converts the same handful of structures once per round per consumer.
+_CANONICAL_STRUCTURE_CACHE: dict = dict()
 
 
 @dataclass(frozen=True)
@@ -174,6 +183,129 @@ def attach_sensitivity_evidence(split: CandidateSplit,
             continue
         candidates.append(replace(candidate, coefficient=coefficient, delta_ln_k=delta_ln_k))
     return CandidateSplit(candidates=tuple(candidates), skipped=tuple(skipped))
+
+
+def _canonical_structure(adjlist: str) -> str | None:
+    """
+    Reduce one RMG adjacency list to a canonical, label- and atom-order-independent identity.
+
+    ARC's own ``Molecule`` (never ``rmgpy``) parses the adjacency list and renders a canonical
+    SMILES, so two projects that wrote the same molecule with different species labels or a
+    different atom order still produce the same identity string.
+
+    Args:
+        adjlist (str): The RMG adjacency-list text.
+
+    Returns:
+        str | None: The canonical SMILES, or ``None`` if the text could not be parsed into a
+        molecule -- the caller must then refuse to key the channel rather than guess.
+    """
+    if adjlist in _CANONICAL_STRUCTURE_CACHE:
+        return _CANONICAL_STRUCTURE_CACHE[adjlist]
+    try:
+        smiles = Molecule().from_adjacency_list(adjlist).to_smiles()
+    except Exception as e:
+        _logger.warning(f'Could not canonicalize an adjacency list into a molecule ({e}); the '
+                        f'channel using it cannot be structurally keyed.')
+        smiles = None
+    _CANONICAL_STRUCTURE_CACHE[adjlist] = smiles
+    return smiles
+
+
+def structural_channel_key(path_reaction: PDepPathReaction,
+                           species_structures: dict) -> tuple | None:
+    """
+    The direction-insensitive STRUCTURAL identity of the channel a path reaction connects.
+
+    Why labels are not enough: every TS label Arkane writes is purely positional --
+    ``rmgpy/rmg/pdep.py:854`` replaces every path reaction's transition state with a fresh,
+    label-less object before every network file write, so ``TS3`` means nothing more than
+    "whatever sat at ``path_reactions[2]`` when that file was written", and pruning or discovery
+    between explorations shifts indices. Reaction labels (``reaction<i>``) are positional too,
+    and can even collide within one file after a remove-then-append. Carrying anything across
+    network-file writes by either label can attach a computed barrier to the WRONG saddle point.
+    This key is what may be carried instead: the two channels the reaction connects, each species
+    reduced to its canonical structure (``_canonical_structure``), canonicalized
+    direction-insensitively through ``t3.pdep.parser.canonical_channel_pair`` -- the identity the
+    network's own topology assigns the reaction, immune to renumbering AND to per-project species
+    label indices.
+
+    Args:
+        path_reaction (PDepPathReaction): The path reaction to key.
+        species_structures (dict): Species label -> RMG adjacency-list text, i.e. the owning
+            network's ``PDepNetwork.species_structures``.
+
+    Returns:
+        tuple | None: The structural key, or ``None`` when any participating species has no
+        parseable structure in ``species_structures`` -- the channel then has no structural
+        identity and must not be carried (fail closed, never keyed by label instead).
+    """
+    sides = list()
+    for labels in (path_reaction.reactants, path_reaction.products):
+        side = list()
+        for label in labels:
+            adjlist = species_structures.get(label)
+            if not adjlist:
+                return None
+            smiles = _canonical_structure(adjlist)
+            if smiles is None:
+                return None
+            side.append(smiles)
+        sides.append(side)
+    return canonical_channel_pair(sides[0], sides[1])
+
+
+def channel_keys_by_ts_label(network: PDepNetwork) -> dict:
+    """
+    Map each of a network's transition state labels to its channel's structural key.
+
+    Fail-closed by construction, in three ways, because this map is what QM artifacts are carried
+    across network-file writes on (see ``structural_channel_key`` for why labels cannot be):
+
+    - a transition state shared by SEVERAL path reactions is omitted (which of its channels would
+      be "the" identity is ambiguous -- the same reason ``t3.main`` refuses to queue such a TS);
+    - a transition state whose channel cannot be structurally keyed (a species with no parseable
+      structure) is omitted;
+    - two transition states whose channels key IDENTICALLY are BOTH omitted -- a duplicate channel
+      pair means the structural key cannot distinguish them, and attaching an artifact to
+      "whichever matched first" is exactly the wrong-saddle-point failure this keying exists to
+      prevent.
+
+    An omitted transition state is simply re-decided (and, if selected, re-queued) each round
+    rather than carried -- duplicated QM spend, never a misattributed barrier.
+
+    Args:
+        network (PDepNetwork): The parsed network.
+
+    Returns:
+        dict: Network-local TS label -> structural key, for every transition state that has
+        exactly one, unambiguous structural identity.
+    """
+    keys = dict()
+    for ts_label, path_reactions in network.path_reactions_by_ts().items():
+        if len(path_reactions) != 1:
+            _logger.warning(f'Transition state {ts_label!r} of network {network.network_id!r} is '
+                            f'shared by {len(path_reactions)} path reactions; it has no single '
+                            f'structural channel identity and will not be carried across rounds.')
+            continue
+        key = structural_channel_key(path_reactions[0], network.species_structures)
+        if key is None:
+            _logger.warning(f'Transition state {ts_label!r} of network {network.network_id!r} '
+                            f'cannot be structurally keyed (a participating species has no '
+                            f'parseable structure); it will not be carried across rounds.')
+            continue
+        keys[ts_label] = key
+    by_key = dict()
+    for ts_label, key in keys.items():
+        by_key.setdefault(key, list()).append(ts_label)
+    for key, ts_labels in by_key.items():
+        if len(ts_labels) > 1:
+            _logger.warning(f'Transition states {sorted(ts_labels)} of network '
+                            f'{network.network_id!r} connect structurally identical channels; '
+                            f'none of them can be carried across rounds unambiguously.')
+            for ts_label in ts_labels:
+                del keys[ts_label]
+    return keys
 
 
 PES_LOOP_DIAGRAM_FILENAME = 'pes_diagram.png'

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -23,7 +23,7 @@ runs of the same input incomparable.
 """
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from t3.pdep.barrierless import classify_barrierless
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
@@ -38,10 +38,21 @@ class QMCandidate:
         path_reaction (PDepPathReaction): The parsed path reaction.
         ts_label (str): The network-local transition state label (e.g. ``'TS1'``).
         family (str | None): The RMG family, when the kinetics comment named one.
+        coefficient (float | None): The signed dln(k)/dE0 sensitivity coefficient (mol/J) this
+            round's master-equation SA measured for this transition state
+            (``t3.pdep.pes_sa.run_round_me_sensitivity``), stamped by
+            ``attach_sensitivity_evidence``. ``None`` only before stamping;
+            ``t3.pdep.pes_qm.arc_qm_runner`` refuses to queue a candidate left at ``None``,
+            because ``t3.pdep.capture`` would (rightly) refuse its artifact after the QM spend.
+        delta_ln_k (float | None): The corresponding dimensionless rate response,
+            ``abs(coefficient) * perturbation`` -- same convention as
+            ``t3.pdep.selector.SensitiveTransitionState``.
     """
     path_reaction: PDepPathReaction
     ts_label: str
     family: str | None
+    coefficient: float | None = None
+    delta_ln_k: float | None = None
 
 
 @dataclass(frozen=True)
@@ -106,6 +117,44 @@ def split_qm_candidates(network: PDepNetwork, computed_ts_labels: frozenset) -> 
     return CandidateSplit(candidates=tuple(candidates), skipped=tuple(skipped))
 
 
+def attach_sensitivity_evidence(split: CandidateSplit,
+                                evidence_by_ts_label: dict) -> CandidateSplit:
+    """
+    Stamp each candidate with the real sensitivity evidence this round's ME SA measured for it.
+
+    A candidate whose transition state has NO entry in ``evidence_by_ts_label`` is moved to
+    ``skipped`` with its reason recorded, never queued: ``t3.pdep.capture`` refuses (fail-closed,
+    by design) any captured artifact that carries no ``coefficient``/``delta_ln_k`` evidence, so
+    queueing such a candidate would spend real QM and then lose the result at capture time -- and
+    inventing a number instead would violate the standing constraint that no rate-determining
+    parameter may be fabricated.
+
+    Args:
+        split (CandidateSplit): The split to stamp, from ``split_qm_candidates``.
+        evidence_by_ts_label (dict): Network-local TS label -> ``(coefficient, delta_ln_k)``,
+            from ``t3.pdep.pes_sa.run_round_me_sensitivity``.
+
+    Returns:
+        CandidateSplit: The same candidates in the same order, each carrying its evidence, minus
+        the ones with no evidence (appended to ``skipped``, each with its reason).
+    """
+    candidates, skipped = [], list(split.skipped)
+    for candidate in split.candidates:
+        pair = evidence_by_ts_label.get(candidate.ts_label)
+        if pair is None:
+            skipped.append(SkippedChannel(
+                label=candidate.path_reaction.label,
+                reason=f"'{candidate.path_reaction.label}': transition state "
+                       f'{candidate.ts_label} has no finite sensitivity evidence in this '
+                       f"round's master-equation sensitivity analysis, and a captured artifact "
+                       f'must carry the evidence that justified selecting it '
+                       f'(t3.pdep.capture); not queueing it rather than inventing a number.'))
+            continue
+        coefficient, delta_ln_k = pair
+        candidates.append(replace(candidate, coefficient=coefficient, delta_ln_k=delta_ln_k))
+    return CandidateSplit(candidates=tuple(candidates), skipped=tuple(skipped))
+
+
 PES_LOOP_DIAGRAM_FILENAME = 'pes_diagram.png'
 
 
@@ -118,6 +167,8 @@ class RoundPaths:
         root (str): The round's own directory.
         arc_project (str): The ARC project directory for this round's QM.
         explorer_output (str): Where the Arkane explorer writes.
+        sa (str): Where this round's master-equation sensitivity analysis runs
+            (``t3.pdep.pes_sa.run_round_me_sensitivity``).
         capture (str): Where this round's QM artifacts are frozen.
         hybrid (str): Where this round's hybrid network input file is written.
         diagram (str): The PES diagram for this round.
@@ -125,6 +176,7 @@ class RoundPaths:
     root: str
     arc_project: str
     explorer_output: str
+    sa: str
     capture: str
     hybrid: str
     diagram: str
@@ -164,6 +216,7 @@ def round_paths(project_directory: str, round_index: int) -> RoundPaths:
     return RoundPaths(root=root,
                       arc_project=os.path.join(root, 'ARC'),
                       explorer_output=os.path.join(root, 'explorer'),
+                      sa=os.path.join(root, 'SA'),
                       capture=os.path.join(root, 'capture'),
                       hybrid=os.path.join(root, 'hybrid'),
                       diagram=os.path.join(root, PES_LOOP_DIAGRAM_FILENAME))

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -193,23 +193,33 @@ def _canonical_structure(adjlist: str) -> str | None:
     SMILES, so two projects that wrote the same molecule with different species labels or a
     different atom order still produce the same identity string.
 
+    What the identity is NOT independent of -- deliberately: the spin multiplicity is appended
+    explicitly (``...|m<multiplicity>``), because SMILES alone does not encode spin state and two
+    genuinely distinct RMG species collapse onto one string without it -- singlet and triplet CH2
+    are both ``'[CH2]'``. Adopting a singlet channel's barrier onto the triplet channel (or vice
+    versa) is exactly the wrong-saddle-point misattribution structural keying exists to prevent,
+    so the multiplicity is part of the identity. Charge and lone-pair differences already separate
+    through the SMILES itself (``[OH]`` vs ``[OH-]``; O(3P) ``[O]`` vs O(1D) ``O``).
+
     Args:
         adjlist (str): The RMG adjacency-list text.
 
     Returns:
-        str | None: The canonical SMILES, or ``None`` if the text could not be parsed into a
-        molecule -- the caller must then refuse to key the channel rather than guess.
+        str | None: The canonical identity (``<canonical SMILES>|m<multiplicity>``), or ``None``
+        if the text could not be parsed into a molecule -- the caller must then refuse to key the
+        channel rather than guess.
     """
     if adjlist in _CANONICAL_STRUCTURE_CACHE:
         return _CANONICAL_STRUCTURE_CACHE[adjlist]
     try:
-        smiles = Molecule().from_adjacency_list(adjlist).to_smiles()
+        molecule = Molecule().from_adjacency_list(adjlist)
+        identity = f'{molecule.to_smiles()}|m{molecule.multiplicity}'
     except Exception as e:
         _logger.warning(f'Could not canonicalize an adjacency list into a molecule ({e}); the '
                         f'channel using it cannot be structurally keyed.')
-        smiles = None
-    _CANONICAL_STRUCTURE_CACHE[adjlist] = smiles
-    return smiles
+        identity = None
+    _CANONICAL_STRUCTURE_CACHE[adjlist] = identity
+    return identity
 
 
 def structural_channel_key(path_reaction: PDepPathReaction,

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -321,7 +321,8 @@ def channel_keys_by_ts_label(network: PDepNetwork) -> dict:
 def adoption_channel_keys_by_ts_label(network: PDepNetwork) -> dict:
     """
     Map each transition state to the identity CROSS-CAPTURE adoption may be matched on: its
-    structural channel key PLUS the RMG family of the path reaction that produced it.
+    structural channel key PLUS a discriminator for the PATHWAY that produced it -- the RMG family
+    when the kinetics comment names one, the comment itself otherwise.
 
     Why the endpoints alone are not enough here. ``structural_channel_key`` identifies the
     reactants and products a channel connects -- not a saddle point. ``channel_keys_by_ts_label``
@@ -335,46 +336,58 @@ def adoption_channel_keys_by_ts_label(network: PDepNetwork) -> dict:
     What actually discriminates a pathway, established empirically against the vendored real
     networks rather than assumed:
 
-    - The RMG family, parsed out of the path reaction's kinetics comment
-      (``t3.pdep.barrierless.rmg_family``), is the ONE such field, and it is present only
-      sometimes: 1 of 3 path reactions in ``tests/data/pdep_real_networks/network799_1``, and 0 of
-      3 in ``network21_1``, whose kinetics come from a reaction library and name no family at all.
-    - No other field survives. The kinetics comment is the only carrier of pathway provenance, and
-      ``t3.pdep.hybrid`` DELIBERATELY drops the whole ``kinetics = ...`` entry of every QM'd path
-      reaction (its invariant 2, ``t3/pdep/hybrid.py:18``) -- so any comment-derived discriminator
-      is null on exactly the channels whose identity has to be carried. The transition state's
-      ``E0`` goes the same way, replaced by a statmech ``Log(...)`` reference.
+    - The RMG family (``t3.pdep.barrierless.rmg_family``) is the obvious candidate, and on its own
+      it is not enough: it is present in only 1 of 3 path reactions in
+      ``tests/data/pdep_real_networks/network799_1`` and 0 of 3 in ``network21_1``, whose kinetics
+      come from a reaction library and name no family at all.
+    - The kinetics comment the family is parsed OUT of is present in all six, and discriminates
+      just as well -- ``'Estimated from node Root_N-1R!H->C'`` and
+      ``"Reaction library: 'primaryNitrogenLibrary'"`` each name the specific rate rule or library
+      a pathway came from. It is the fallback here.
+    - Nothing else exists. The kinetics comment is the ONLY carrier of pathway provenance in a
+      network file, and ``t3.pdep.hybrid`` DELIBERATELY drops the whole ``kinetics = ...`` entry
+      of every QM'd path reaction (its invariant 2, ``t3/pdep/hybrid.py:18``), so a comment-derived
+      discriminator is null on exactly the channels a WITHIN-RUN carry would need it for. The
+      transition state's ``E0`` goes the same way, replaced by a statmech ``Log(...)`` reference.
 
     So the discriminator exists for cross-capture adoption -- where both sides are RMG-estimated
-    networks that still carry their kinetics comments -- and a channel that does not carry one is
+    networks that still carry their kinetics comments -- and a channel that carries neither is
     REFUSED (omitted from this map, logged) rather than matched on its endpoints. A refused match
     costs quantum chemistry that was already paid for once; a false match costs correctness of the
     barrier the whole loop exists to compute, presented as if it had been computed. That asymmetry
     decides it.
 
     This is NOT what the within-run, round-to-round carry uses -- see ``channel_keys_by_ts_label``,
-    which stays endpoints-only precisely because the family cannot survive the hybrid write this
+    which stays endpoints-only precisely because no discriminator survives the hybrid write this
     loop itself performs between one round and the next.
 
     Args:
         network (PDepNetwork): The parsed network.
 
     Returns:
-        dict: Network-local TS label -> ``(structural key, RMG family)``, for every transition
-        state that has both an unambiguous structural identity and a named family.
+        dict: Network-local TS label -> ``(structural key, pathway discriminator)``, for every
+        transition state that has both an unambiguous structural identity and a discriminator.
     """
     path_reactions_by_ts = network.path_reactions_by_ts()
     keys = dict()
     for ts_label, key in channel_keys_by_ts_label(network).items():
-        family = rmg_family(path_reactions_by_ts[ts_label][0])
-        if family is None:
+        path_reaction = path_reactions_by_ts[ts_label][0]
+        # Family first, comment second. The family is the coarser and more stable of the two: it
+        # survives rate-rule retraining and degeneracy changes that reword a comment, so preferring
+        # it keeps a family-bearing channel adoptable across RMG database versions. The comment is
+        # the fallback, not a second-class one -- 'Estimated from node Root_N-1R!H->C' and
+        # "Reaction library: 'primaryNitrogenLibrary'" each name the specific rate rule or library
+        # a pathway came from, which is exactly the pathway identity the endpoints cannot supply.
+        discriminator = rmg_family(path_reaction) or (path_reaction.kinetics_comment or '').strip()
+        if not discriminator:
             _logger.info(
-                f'Transition state {ts_label!r} of network {network.network_id!r} names no RMG '
-                f'family, so its channel is identified by its endpoints alone. A different '
-                f'pathway between the same endpoints would key identically across captures, so '
-                f'prior QM will not be adopted for it -- it will be recomputed instead.')
+                f'Transition state {ts_label!r} of network {network.network_id!r} names neither an '
+                f'RMG family nor any kinetics comment, so its channel is identified by its '
+                f'endpoints alone. A different pathway between the same endpoints would key '
+                f'identically across captures, so prior QM will not be adopted for it -- it will '
+                f'be recomputed instead.')
             continue
-        keys[ts_label] = (key, family)
+        keys[ts_label] = (key, discriminator)
     return keys
 
 

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -118,7 +118,8 @@ def split_qm_candidates(network: PDepNetwork, computed_ts_labels: frozenset) -> 
 
 
 def attach_sensitivity_evidence(split: CandidateSplit,
-                                evidence_by_ts_label: dict) -> CandidateSplit:
+                                evidence_by_ts_label: dict,
+                                min_delta_ln_k: float = 0.0) -> CandidateSplit:
     """
     Stamp each candidate with the real sensitivity evidence this round's ME SA measured for it.
 
@@ -129,14 +130,26 @@ def attach_sensitivity_evidence(split: CandidateSplit,
     inventing a number instead would violate the standing constraint that no rate-determining
     parameter may be fabricated.
 
+    A candidate whose measured ``delta_ln_k`` is BELOW ``min_delta_ln_k`` is also skipped (with
+    the measured value in its reason): a response below the floor -- including a measured exact
+    zero -- does not justify the QM spend, and folding its coefficient into a capture manifest as
+    "the sensitivity evidence that justified selecting this transition state" would make that
+    sentence false. This mirrors T3's in-run selection, where ``t3.pdep.selector``'s
+    ``_bounded_cutoff`` floors at ``min_delta_ln_k / perturbation > 0`` and such a record is
+    definitionally unreachable. The floor applies under BOTH ``qm.scope`` values -- 'sensitive'
+    ranks and 'all' does not, but neither may queue below it.
+
     Args:
         split (CandidateSplit): The split to stamp, from ``split_qm_candidates``.
         evidence_by_ts_label (dict): Network-local TS label -> ``(coefficient, delta_ln_k)``,
             from ``t3.pdep.pes_sa.run_round_me_sensitivity``.
+        min_delta_ln_k (float, optional): The smallest measured ln(k) response that justifies
+            queueing (``config.qm.min_delta_ln_k``). ``0.0`` disables the floor.
 
     Returns:
         CandidateSplit: The same candidates in the same order, each carrying its evidence, minus
-        the ones with no evidence (appended to ``skipped``, each with its reason).
+        the ones with no evidence or with a response below the floor (appended to ``skipped``,
+        each with its reason).
     """
     candidates, skipped = [], list(split.skipped)
     for candidate in split.candidates:
@@ -151,6 +164,14 @@ def attach_sensitivity_evidence(split: CandidateSplit,
                        f'(t3.pdep.capture); not queueing it rather than inventing a number.'))
             continue
         coefficient, delta_ln_k = pair
+        if delta_ln_k < min_delta_ln_k:
+            skipped.append(SkippedChannel(
+                label=candidate.path_reaction.label,
+                reason=f"'{candidate.path_reaction.label}': transition state "
+                       f'{candidate.ts_label} measured a ln(k) response of {delta_ln_k:.3e}, '
+                       f'below the min_delta_ln_k floor ({min_delta_ln_k:.3e}); its leverage on '
+                       f'the network is too small to justify the QM spend.'))
+            continue
         candidates.append(replace(candidate, coefficient=coefficient, delta_ln_k=delta_ln_k))
     return CandidateSplit(candidates=tuple(candidates), skipped=tuple(skipped))
 

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, replace
 
 from arc.molecule.molecule import Molecule
 
-from t3.pdep.barrierless import classify_barrierless
+from t3.pdep.barrierless import classify_barrierless, rmg_family
 from t3.pdep.parser import PDepNetwork, PDepPathReaction, canonical_channel_pair
 
 _logger = logging.getLogger(__name__)
@@ -315,6 +315,66 @@ def channel_keys_by_ts_label(network: PDepNetwork) -> dict:
                             f'none of them can be carried across rounds unambiguously.')
             for ts_label in ts_labels:
                 del keys[ts_label]
+    return keys
+
+
+def adoption_channel_keys_by_ts_label(network: PDepNetwork) -> dict:
+    """
+    Map each transition state to the identity CROSS-CAPTURE adoption may be matched on: its
+    structural channel key PLUS the RMG family of the path reaction that produced it.
+
+    Why the endpoints alone are not enough here. ``structural_channel_key`` identifies the
+    reactants and products a channel connects -- not a saddle point. ``channel_keys_by_ts_label``
+    covers the case where two pathways between the same endpoints sit in ONE file (both are
+    dropped as structurally duplicated), but that guard cannot reach across files: if a prior
+    capture's network holds one A<=>B pathway and this run's network holds a DIFFERENT A<=>B
+    pathway, each file holds a single, identical key, no duplicate is present, and the prior
+    artifact is attached to a saddle point it was never computed for -- silently, as a computed
+    barrier. That is the precise misattribution this whole keying exists to prevent.
+
+    What actually discriminates a pathway, established empirically against the vendored real
+    networks rather than assumed:
+
+    - The RMG family, parsed out of the path reaction's kinetics comment
+      (``t3.pdep.barrierless.rmg_family``), is the ONE such field, and it is present only
+      sometimes: 1 of 3 path reactions in ``tests/data/pdep_real_networks/network799_1``, and 0 of
+      3 in ``network21_1``, whose kinetics come from a reaction library and name no family at all.
+    - No other field survives. The kinetics comment is the only carrier of pathway provenance, and
+      ``t3.pdep.hybrid`` DELIBERATELY drops the whole ``kinetics = ...`` entry of every QM'd path
+      reaction (its invariant 2, ``t3/pdep/hybrid.py:18``) -- so any comment-derived discriminator
+      is null on exactly the channels whose identity has to be carried. The transition state's
+      ``E0`` goes the same way, replaced by a statmech ``Log(...)`` reference.
+
+    So the discriminator exists for cross-capture adoption -- where both sides are RMG-estimated
+    networks that still carry their kinetics comments -- and a channel that does not carry one is
+    REFUSED (omitted from this map, logged) rather than matched on its endpoints. A refused match
+    costs quantum chemistry that was already paid for once; a false match costs correctness of the
+    barrier the whole loop exists to compute, presented as if it had been computed. That asymmetry
+    decides it.
+
+    This is NOT what the within-run, round-to-round carry uses -- see ``channel_keys_by_ts_label``,
+    which stays endpoints-only precisely because the family cannot survive the hybrid write this
+    loop itself performs between one round and the next.
+
+    Args:
+        network (PDepNetwork): The parsed network.
+
+    Returns:
+        dict: Network-local TS label -> ``(structural key, RMG family)``, for every transition
+        state that has both an unambiguous structural identity and a named family.
+    """
+    path_reactions_by_ts = network.path_reactions_by_ts()
+    keys = dict()
+    for ts_label, key in channel_keys_by_ts_label(network).items():
+        family = rmg_family(path_reactions_by_ts[ts_label][0])
+        if family is None:
+            _logger.info(
+                f'Transition state {ts_label!r} of network {network.network_id!r} names no RMG '
+                f'family, so its channel is identified by its endpoints alone. A different '
+                f'pathway between the same endpoints would key identically across captures, so '
+                f'prior QM will not be adopted for it -- it will be recomputed instead.')
+            continue
+        keys[ts_label] = (key, family)
     return keys
 
 

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -22,6 +22,7 @@ this list, so a non-deterministic order would admit a different subset on each r
 runs of the same input incomparable.
 """
 
+import os
 from dataclasses import dataclass
 
 from t3.pdep.barrierless import classify_barrierless
@@ -103,3 +104,66 @@ def split_qm_candidates(network: PDepNetwork, computed_ts_labels: frozenset) -> 
         candidates.append(QMCandidate(path_reaction=path_reaction, ts_label=ts_label,
                                       family=verdict.family))
     return CandidateSplit(candidates=tuple(candidates), skipped=tuple(skipped))
+
+
+PES_LOOP_DIAGRAM_FILENAME = 'pes_diagram.png'
+
+
+@dataclass(frozen=True)
+class RoundPaths:
+    """
+    Where one round of the loop puts its artifacts.
+
+    Attributes:
+        root (str): The round's own directory.
+        arc_project (str): The ARC project directory for this round's QM.
+        explorer_output (str): Where the Arkane explorer writes.
+        capture (str): Where this round's QM artifacts are frozen.
+        hybrid (str): Where this round's hybrid network input file is written.
+        diagram (str): The PES diagram for this round.
+    """
+    root: str
+    arc_project: str
+    explorer_output: str
+    capture: str
+    hybrid: str
+    diagram: str
+
+
+def round_paths(project_directory: str, round_index: int) -> RoundPaths:
+    """
+    Resolve the artifact layout for one round.
+
+    Every round is self-contained, and in particular gets its OWN ARC project directory. That is
+    what lets the loop run ARC more than once without fighting ``t3.pdep.capture``'s single-shot
+    window: ARC recreates ``calcs/statmech/`` with ``delete_existing_subdir=True`` on every rate
+    pass, so a second ARC run sharing one project directory would destroy the first round's
+    un-captured artifacts. Separate projects make that structurally impossible rather than
+    merely discouraged.
+
+    The capture directory is deliberately a sibling of the ARC project, never nested inside it:
+    ``capture_ts_artifacts`` refuses a ``capture_dir`` that resolves inside the ARC project
+    directory, for the same reason.
+
+    Args:
+        project_directory (str): The loop's project directory. Must be absolute.
+        round_index (int): The zero-based round number.
+
+    Returns:
+        RoundPaths: The resolved layout.
+
+    Raises:
+        ValueError: If ``project_directory`` is not absolute, or ``round_index`` is negative.
+    """
+    if not os.path.isabs(project_directory):
+        raise ValueError(f"'project_directory' must be an absolute path, got "
+                         f"{project_directory!r}.")
+    if round_index < 0:
+        raise ValueError(f"'round_index' must be non-negative, got {round_index}.")
+    root = os.path.join(project_directory, f'round_{round_index}')
+    return RoundPaths(root=root,
+                      arc_project=os.path.join(root, 'ARC'),
+                      explorer_output=os.path.join(root, 'explorer'),
+                      capture=os.path.join(root, 'capture'),
+                      hybrid=os.path.join(root, 'hybrid'),
+                      diagram=os.path.join(root, PES_LOOP_DIAGRAM_FILENAME))

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -167,3 +167,30 @@ def round_paths(project_directory: str, round_index: int) -> RoundPaths:
                       capture=os.path.join(root, 'capture'),
                       hybrid=os.path.join(root, 'hybrid'),
                       diagram=os.path.join(root, PES_LOOP_DIAGRAM_FILENAME))
+
+
+def hybrid_network_path(paths: RoundPaths, network_id: str) -> str:
+    """
+    Where a round's ``qm_runner`` must write its hybrid network input file.
+
+    ``RoundPaths.hybrid`` is a directory, not a file, and the PES loop needs a file path to hand
+    the next round's explorer. It also needs that file's stem to carry ``network_id`` rather than
+    the literal ``'hybrid'``, because ``parse_pdep_network_file`` derives ``network_id =
+    Path(path).stem`` (``t3/pdep/parser.py:729``) -- every round writing to a ``hybrid.py`` stem
+    would collapse distinct networks onto one ``network_id``, and with it one ARC job-label
+    namespace (the exact failure ruling C4 exists to prevent).
+
+    This lives in ``t3.pdep.pes_rounds`` (not ``t3.pdep.pes_loop``, which re-exports it for
+    backward compatibility) so that both ``t3.pdep.pes_loop`` and ``t3.pdep.pes_qm`` can import it
+    without creating an import cycle between those two modules.
+
+    Args:
+        paths (RoundPaths): This round's paths.
+        network_id (str): The network id to preserve in the file's stem (normally the just-explored
+            network's own ``network_id``).
+
+    Returns:
+        str: The hybrid network file path this round's ``qm_runner`` must write to, and the path
+        the next round explores from.
+    """
+    return os.path.join(paths.hybrid, f'{network_id}.py')

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -1,0 +1,105 @@
+"""
+t3 pdep pes_rounds module
+
+The per-round bookkeeping of the PES exploration loop: which path reactions in an explored network
+still need quantum chemistry, and which must be left alone.
+
+Three separate reasons disqualify a path reaction from QM, and they are kept distinct because they
+mean different things to someone reading the round record:
+
+* it is **barrierless** -- there is no saddle point to find, so QM cannot succeed (see
+  ``t3.pdep.barrierless``);
+* it **already has QM** from an earlier round or an adopted prior project -- re-queueing it would
+  spend the budget twice for the same number;
+* it **declares no transition state** in the network file -- there is nothing to point a job at.
+
+Every disqualification is recorded with its reason rather than filtered out silently. A loop that
+quietly drops channels produces a PES that looks complete and is not, which is precisely the
+failure mode the whole exercise exists to remove.
+
+Candidate order is the network file's own order, deterministically. The budget admits a prefix of
+this list, so a non-deterministic order would admit a different subset on each run and make two
+runs of the same input incomparable.
+"""
+
+from dataclasses import dataclass
+
+from t3.pdep.barrierless import classify_barrierless
+from t3.pdep.parser import PDepNetwork, PDepPathReaction
+
+
+@dataclass(frozen=True)
+class QMCandidate:
+    """
+    A path reaction whose transition state should be sent to ARC.
+
+    Attributes:
+        path_reaction (PDepPathReaction): The parsed path reaction.
+        ts_label (str): The network-local transition state label (e.g. ``'TS1'``).
+        family (str | None): The RMG family, when the kinetics comment named one.
+    """
+    path_reaction: PDepPathReaction
+    ts_label: str
+    family: str | None
+
+
+@dataclass(frozen=True)
+class SkippedChannel:
+    """
+    A path reaction deliberately not sent to ARC, and why.
+
+    Attributes:
+        label (str): The path reaction's label.
+        reason (str): Why it was skipped, for the log and the round record.
+    """
+    label: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class CandidateSplit:
+    """
+    The outcome of splitting a network's path reactions into QM candidates and skips.
+
+    Attributes:
+        candidates (tuple): The ``QMCandidate`` objects, in network-file order.
+        skipped (tuple): The ``SkippedChannel`` objects, in network-file order.
+    """
+    candidates: tuple = ()
+    skipped: tuple = ()
+
+
+def split_qm_candidates(network: PDepNetwork, computed_ts_labels: frozenset) -> CandidateSplit:
+    """
+    Split a network's path reactions into those needing QM and those that must not get it.
+
+    Args:
+        network (PDepNetwork): The parsed network, freshly explored or freshly generated.
+        computed_ts_labels (frozenset): Network-local TS labels that already have QM, from this
+                                        loop's earlier rounds or from an adopted prior project.
+
+    Returns:
+        CandidateSplit: Candidates and skips, each in the network file's own order.
+    """
+    candidates, skipped = [], []
+    for path_reaction in network.path_reactions:
+        ts_label = path_reaction.transition_state
+        if ts_label is None:
+            skipped.append(SkippedChannel(
+                label=path_reaction.label,
+                reason=f"'{path_reaction.label}': declares no transition state in the network "
+                       f'file, so there is nothing to compute.'))
+            continue
+        if ts_label in computed_ts_labels:
+            skipped.append(SkippedChannel(
+                label=path_reaction.label,
+                reason=f"'{path_reaction.label}': transition state {ts_label} already has QM; not "
+                       f'queueing it again.'))
+            continue
+        verdict = classify_barrierless(path_reaction)
+        if verdict.is_barrierless:
+            skipped.append(SkippedChannel(label=path_reaction.label, reason=verdict.reason))
+            continue
+        candidates.append(QMCandidate(path_reaction=path_reaction, ts_label=ts_label,
+                                      family=verdict.family))
+    return CandidateSplit(candidates=tuple(candidates), skipped=tuple(skipped))

--- a/t3/pdep/pes_sa.py
+++ b/t3/pdep/pes_sa.py
@@ -1,0 +1,154 @@
+"""
+t3 pdep pes_sa module
+
+The standalone PES loop's own source of REAL per-transition-state sensitivity evidence: a
+master-equation (ME) sensitivity analysis run with Arkane on the round's freshly explored network.
+
+Why this exists: ``t3.pdep.capture.capture_ts_artifacts`` refuses (by deliberate, fail-closed
+design) to capture any transition-state QM artifact that does not carry the ``coefficient``/
+``delta_ln_k`` sensitivity evidence that justified selecting it -- see ``verify_capture``. Inside
+a T3 iteration that evidence comes from a dedicated Arkane ME SA run
+(``t3.utils.writer.write_pdep_network_file`` -> ``t3.runners.rmg_runner.run_arkane_job`` ->
+``sensitivity/sa_coefficients.yml`` -> ``t3.pdep.selector``), frozen onto each ``TSJoinRecord`` at
+queue time (``t3.main.T3.queue_pdep_transition_states``) and read back off the durable join
+records at capture time (``t3.main.T3._capture_pdep_ts_artifacts``). The standalone loop
+(``t3.pdep.pes_loop``) had NO such source, so every capture it attempted was -- correctly --
+refused. This module runs the same Arkane ME SA, through the same production seams
+(``write_arkane_network_input_file`` with ``sensitivity=True``, ``run_arkane_job``,
+``read_sa_yaml_file``), against the round's own explored network.
+
+What the evidence means here: the loop has no single caller-declared observable reaction the way a
+T3 iteration does (there, criterion (a) names the network reaction an observable is sensitive to,
+and the selector examines exactly that direction key). The standalone loop's k(T,P) of interest is
+the network itself, so each transition state's evidence is its strongest measured leverage --
+the maximum-|coefficient| dln(k)/dE0 row for that transition state across EVERY network reaction
+direction and every condition of the SA output. That is a real, measured Arkane derivative, never
+a default or a sentinel: a transition state for which the SA reports no finite row gets NO
+evidence here, and the loop refuses to queue it rather than inventing a number
+(``t3.pdep.pes_rounds.attach_sensitivity_evidence``).
+
+This module never imports ``rmgpy`` or ``arkane``; Arkane runs behind ``run_arkane_job`` (ARC's
+own entry point), exactly as T3's in-iteration ME SA does.
+"""
+
+import logging
+import os
+
+from t3.pdep.selector import E0_PERTURBATION_J_PER_MOL, STRUCTURES_KEY, TS_ENTRY_PREFIX, _is_finite
+from t3.pdep.yaml_safe import read_sa_yaml_file
+from t3.runners.rmg_runner import run_arkane_job
+from t3.utils.writer import write_arkane_network_input_file
+
+_logger = logging.getLogger(__name__)
+
+# Where Arkane writes the ME SA coefficients, relative to the SA run's output directory -- the
+# same artifact ``run_arkane_job`` itself requires (its ``required_artifact`` default).
+SA_COEFFICIENTS_RELPATH = os.path.join('sensitivity', 'sa_coefficients.yml')
+
+
+def ts_sensitivity_evidence(sa_dict: dict,
+                            perturbation: float = E0_PERTURBATION_J_PER_MOL,
+                            ) -> dict[str, tuple[float, float]]:
+    """
+    Extract per-transition-state sensitivity evidence from a loaded Arkane ME SA dictionary.
+
+    For each transition state, the evidence is the maximum-|coefficient| row across EVERY network
+    reaction direction key and every (T, P) condition -- the strongest measured leverage this
+    transition state's E0 has on any k(T,P) of the network (see the module docstring for why the
+    aggregation is over all directions rather than one caller-declared observable direction).
+
+    Malformed pieces (a non-dict direction entry, a non-dict condition entry, a non-finite
+    coefficient, the ``structures`` mapping) are skipped, never guessed at: a transition state
+    whose every row is unusable simply gets no evidence, which downstream refuses loudly.
+
+    Args:
+        sa_dict (dict): A loaded Arkane PDep sensitivity dictionary (see
+            ``t3.pdep.selector._select_from_sa_dict`` for the shape). Keys are network reaction
+            strings (plus a ``'structures'`` entry); values map a (T, 'K', P, 'bar') condition to
+            a mapping of entry label to sensitivity coefficient.
+        perturbation (float, optional): The E0 perturbation Arkane applied, in J/mol, used to
+            compute each ``delta_ln_k`` exactly as ``t3.pdep.selector._evidence_for_ts`` does.
+
+    Returns:
+        dict[str, tuple[float, float]]: Network-local transition state label ->
+        ``(coefficient, delta_ln_k)``.
+
+    Raises:
+        ValueError: If ``sa_dict`` is not a dict at all -- a malformed payload is a fact about the
+                   SA artifact, not "a network with no sensitive transition states", and must not
+                   be silently read as the latter.
+    """
+    if not isinstance(sa_dict, dict):
+        raise ValueError(f'The sensitivity payload is malformed: expected a dict, got '
+                         f'{type(sa_dict).__name__}.')
+    evidence = dict()
+    for direction_key, conditions in sa_dict.items():
+        if direction_key == STRUCTURES_KEY or not isinstance(conditions, dict):
+            continue
+        for _condition, entries in conditions.items():
+            if not isinstance(entries, dict):
+                continue
+            for entry, coefficient in entries.items():
+                if not isinstance(entry, str) or not entry.startswith(TS_ENTRY_PREFIX):
+                    continue
+                if not _is_finite(coefficient):
+                    continue
+                ts_label = entry[len(TS_ENTRY_PREFIX):]
+                coefficient = float(coefficient)
+                current = evidence.get(ts_label)
+                if current is None or abs(coefficient) > abs(current[0]):
+                    evidence[ts_label] = (coefficient, abs(coefficient) * perturbation)
+    return evidence
+
+
+def run_round_me_sensitivity(network_path: str,
+                             sa_dir: str,
+                             method: str,
+                             timeout: float | None = None,
+                             logger=None,
+                             ) -> dict[str, tuple[float, float]]:
+    """
+    Run one round's Arkane ME sensitivity analysis and return the per-TS evidence it measured.
+
+    Mirrors T3's in-iteration pipeline exactly, through the same production seams: render an
+    Arkane input for ``network_path`` with a ``sensitivity_conditions`` directive spanning the
+    network's own T/P extrema (``write_arkane_network_input_file(..., sensitivity=True)``), run
+    Arkane on it (``run_arkane_job``, which itself requires ``sensitivity/sa_coefficients.yml``
+    to have been (re)written for the job to count as succeeded), then load and reduce that output
+    (``read_sa_yaml_file`` -> ``ts_sensitivity_evidence``).
+
+    Args:
+        network_path (str): The network file to analyze -- the round's freshly explored network.
+        sa_dir (str): The SA run's own output directory (``t3.pdep.pes_rounds.RoundPaths.sa``).
+        method (str): The master-equation method, 'CSE', 'MSC' or 'RS' (``config.pes.method``).
+        timeout (float, optional): Wall-clock deadline for the Arkane process, in seconds, passed
+            through to ``run_arkane_job``. ``None`` means no deadline.
+        logger: A T3 ``Logger``, or ``None``. Passed through to ``run_arkane_job``.
+
+    Returns:
+        dict[str, tuple[float, float]]: Network-local transition state label ->
+        ``(coefficient, delta_ln_k)``. May name transition states the caller is not interested in
+        (Arkane reports every TS row); may also lack a transition state whose every row was
+        non-finite -- the caller decides what a missing entry means.
+
+    Raises:
+        ValueError: If the Arkane SA job failed, timed out, or produced a malformed payload --
+                   the round then has no real sensitivity evidence, and the caller must refuse to
+                   queue QM rather than invent any (see ``t3.pdep.pes_loop``).
+        OSError: If the SA input could not be written, or the SA output could not be read.
+    """
+    os.makedirs(sa_dir, exist_ok=True)
+    input_path = os.path.join(sa_dir, 'input.py')
+    write_arkane_network_input_file(source_path=network_path, dest_path=input_path,
+                                    method=method, sensitivity=True)
+    job_result = run_arkane_job(input_file=input_path, output_directory=sa_dir,
+                                logger=logger, timeout=timeout)
+    if not job_result:
+        raise ValueError(f'The master-equation sensitivity analysis for {network_path!r} failed: '
+                         f'{job_result.reason}')
+    sa_path = os.path.join(sa_dir, SA_COEFFICIENTS_RELPATH)
+    evidence = ts_sensitivity_evidence(read_sa_yaml_file(sa_path))
+    _logger.info(f'PES loop: the master-equation sensitivity analysis for {network_path!r} '
+                 f'measured evidence for {len(evidence)} transition state(s): '
+                 f'{sorted(evidence)}.')
+    return evidence

--- a/t3/pdep/pes_sa.py
+++ b/t3/pdep/pes_sa.py
@@ -32,9 +32,10 @@ own entry point), exactly as T3's in-iteration ME SA does.
 """
 
 import logging
+import math
 import os
 
-from t3.pdep.selector import E0_PERTURBATION_J_PER_MOL, STRUCTURES_KEY, TS_ENTRY_PREFIX, _is_finite
+from t3.pdep.selector import E0_PERTURBATION_J_PER_MOL, STRUCTURES_KEY, TS_ENTRY_PREFIX
 from t3.pdep.yaml_safe import read_sa_yaml_file
 from t3.runners.rmg_runner import run_arkane_job
 from t3.utils.writer import write_arkane_network_input_file
@@ -44,6 +45,24 @@ _logger = logging.getLogger(__name__)
 # Where Arkane writes the ME SA coefficients, relative to the SA run's output directory -- the
 # same artifact ``run_arkane_job`` itself requires (its ``required_artifact`` default).
 SA_COEFFICIENTS_RELPATH = os.path.join('sensitivity', 'sa_coefficients.yml')
+
+
+def _is_finite(coefficient) -> bool:
+    """
+    Whether ``coefficient`` is a usable finite real number.
+
+    Mirrors ``t3.pdep.selector._is_finite`` (kept private there) rather than importing it:
+    ``bool`` is deliberately excluded even though it is an ``int`` subtype, so a stray
+    ``True``/``False`` SA row is never silently read as ``1``/``0``.
+
+    Args:
+        coefficient: The value to check.
+
+    Returns:
+        bool: Whether the value is a finite, non-bool real number.
+    """
+    return isinstance(coefficient, (int, float)) and not isinstance(coefficient, bool) \
+        and math.isfinite(coefficient)
 
 
 def ts_sensitivity_evidence(sa_dict: dict,

--- a/t3/schema.py
+++ b/t3/schema.py
@@ -906,7 +906,12 @@ class PESSection(BaseModel):
     network: Annotated[str, Field(min_length=1)]
     source: list[str]
     method: str = 'MSC'
-    bath_gas: dict | None = None
+    # Required, and required to be non-empty. There is no bath gas that is right by default for an
+    # arbitrary network, and PDepExplorerConfig refuses a config without one -- but it refuses it
+    # from inside run_pes_loop, by which time the CLI has already created the project directory,
+    # the log file and round_0/. Refusing it here turns the likeliest first-run mistake on this
+    # input file into an immediate, actionable validation error.
+    bath_gas: dict
     explore_tol: Annotated[float, Field(gt=0)] | None = None
     energy_tol: Annotated[float, Field(gt=0)] | None = None
     flux_tol: Annotated[float, Field(gt=0)] | None = None
@@ -929,6 +934,21 @@ class PESSection(BaseModel):
                 f"The PES 'source' must name 1 or 2 species -- 1 for a unimolecular well, 2 for a "
                 f"bimolecular entry channel (A + B). Arkane's explorer accepts nothing else. "
                 f"Got {len(value)}: {value}.")
+        return value
+
+    @field_validator('bath_gas')
+    @classmethod
+    def check_bath_gas(cls, value):
+        """PESSection.bath_gas validator.
+
+        An empty mapping passes the ``dict`` type check but is exactly as useless as a missing one:
+        ``t3.pdep.explorer.config.PDepExplorerConfig`` raises on both, deep inside the loop.
+        """
+        if not value:
+            raise ValueError(
+                "The PES 'bath_gas' must be a non-empty mapping of species labels to mole "
+                "fractions (e.g. {'N2': 1.0}). An Arkane explorer input file cannot be written "
+                "without one, and there is no default that is right for an arbitrary network.")
         return value
 
     @field_validator('method')

--- a/t3/schema.py
+++ b/t3/schema.py
@@ -899,7 +899,24 @@ def _refuse_dashed_level(value: str, field_name: str) -> str:
     return value
 
 
-class PESSection(BaseModel):
+class PESStrictSection(BaseModel):
+    """
+    Base for every section of the standalone PES exploration loop's input file.
+
+    ``extra = "forbid"`` on ``PESLoopConfig`` alone only rejects an unknown TOP-LEVEL key: pydantic
+    does not propagate a model's config into the nested models its fields declare. Without this
+    base, a typo inside a section -- ``qm.max_transition_state_per_round`` for
+    ``max_transition_states_per_round`` -- is silently discarded, the run proceeds on the schema
+    default, and the user is never told their setting did nothing. Every section forbids extras
+    here rather than repeating the class-level config four times, so a section added later cannot
+    forget to.
+    """
+
+    class Config:
+        extra = "forbid"
+
+
+class PESSection(PESStrictSection):
     """
     A class for validating input.pes arguments of the standalone PES exploration loop.
     """
@@ -918,7 +935,14 @@ class PESSection(BaseModel):
     maximum_radical_electrons: Annotated[int, Field(gt=0, strict=True)] | None = None
     # Explorer runtime is unbounded, so this is load-bearing rather than decorative: without it a
     # single pathological network parks the loop forever.
-    timeout: Annotated[float, Field(gt=0)] = 7200.0
+    #
+    # strict=True for the same reason max_rounds uses it: bool is a subclass of int, so
+    # `timeout: true` in a YAML input otherwise validates as 1.0 -- a one-second explorer budget
+    # that fails every network, arrived at by a typo. allow_inf_nan=False because +inf passes
+    # `gt=0` and reinstates exactly the unbounded runtime this field exists to bound. Both are
+    # refused by PDepExplorerConfig too, but only from INSIDE run_pes_loop, after the CLI has
+    # created the project directory, the log file and round_0/.
+    timeout: Annotated[float, Field(gt=0, strict=True, allow_inf_nan=False)] = 7200.0
 
     @field_validator('source')
     @classmethod
@@ -960,7 +984,7 @@ class PESSection(BaseModel):
         return value
 
 
-class PESQMSection(BaseModel):
+class PESQMSection(PESStrictSection):
     """
     A class for validating input.qm arguments of the standalone PES exploration loop.
 
@@ -1013,7 +1037,7 @@ class PESQMSection(BaseModel):
         return self
 
 
-class PESTerminationSection(BaseModel):
+class PESTerminationSection(PESStrictSection):
     """
     A class for validating input.termination arguments of the standalone PES exploration loop.
     """
@@ -1023,14 +1047,14 @@ class PESTerminationSection(BaseModel):
     stop_when_no_new_ts: bool = True
 
 
-class PESReuseSection(BaseModel):
+class PESReuseSection(PESStrictSection):
     """
     A class for validating input.reuse arguments of the standalone PES exploration loop.
     """
     from_t3_projects: list[str] = Field(default_factory=list)
 
 
-class PESLoopConfig(BaseModel):
+class PESLoopConfig(PESStrictSection):
     """
     A class for validating the standalone PES exploration loop's input file.
     """
@@ -1038,9 +1062,6 @@ class PESLoopConfig(BaseModel):
     qm: PESQMSection = Field(default_factory=PESQMSection)
     termination: PESTerminationSection = Field(default_factory=PESTerminationSection)
     reuse: PESReuseSection = Field(default_factory=PESReuseSection)
-
-    class Config:
-        extra = "forbid"
 
 
 class InputBase(BaseModel):

--- a/t3/schema.py
+++ b/t3/schema.py
@@ -4,6 +4,7 @@ used for input validation
 """
 
 import os
+import re
 from enum import Enum
 from typing import Annotated, Literal
 
@@ -862,6 +863,158 @@ class QM(BaseModel):
         if value not in supported_qm_adapters:
             raise ValueError(f'Supported QM adapters are:\n{supported_qm_adapters}\nGot:{value}')
         return value
+
+
+# Only def2 basis sets and the wb97xd functional must be written hyphen-free: ARC's cached
+# frequency scale factors (data/freq_scale_factors.yml) are keyed without hyphens, so a dashed
+# form silently falls back to a Truhlar fit, logs "Could not determine software for job type",
+# and makes Gaussian reject the route line. Genuine Dunning names (cc-pvtz-f12) keep their dashes,
+# so this checks only the two families that are actually affected.
+# Source: Vault/Code/ARC/Canonical Levels of Theory.md
+_DASHED_LEVEL_PATTERNS = (re.compile(r'\bwb97x-d\b', re.IGNORECASE),
+                          re.compile(r'\bdef2-', re.IGNORECASE))
+
+
+def _refuse_dashed_level(value: str, field_name: str) -> str:
+    """
+    Refuse a level of theory written with hyphens where ARC requires none.
+
+    Args:
+        value (str): The level of theory.
+        field_name (str): The field being validated, named in the error.
+
+    Returns:
+        str: The unchanged value.
+
+    Raises:
+        ValueError: If the value contains a dashed def2 basis or a dashed wb97xd functional.
+    """
+    for pattern in _DASHED_LEVEL_PATTERNS:
+        if pattern.search(value):
+            raise ValueError(
+                f"The '{field_name}' level of theory must be written undashed for def2 basis sets "
+                f"and the wb97xd functional: got {value!r}. Write e.g. 'wb97xd/def2tzvp'. A dashed "
+                f"form makes ARC miss the cached frequency scale factor and makes Gaussian reject "
+                f"the route line. Genuine Dunning names such as 'cc-pvtz-f12' keep their dashes.")
+    return value
+
+
+class PESSection(BaseModel):
+    """
+    A class for validating input.pes arguments of the standalone PES exploration loop.
+    """
+    network: Annotated[str, Field(min_length=1)]
+    source: list[str]
+    method: str = 'MSC'
+    bath_gas: dict | None = None
+    explore_tol: Annotated[float, Field(gt=0)] | None = None
+    energy_tol: Annotated[float, Field(gt=0)] | None = None
+    flux_tol: Annotated[float, Field(gt=0)] | None = None
+    maximum_radical_electrons: Annotated[int, Field(gt=0, strict=True)] | None = None
+    # Explorer runtime is unbounded, so this is load-bearing rather than decorative: without it a
+    # single pathological network parks the loop forever.
+    timeout: Annotated[float, Field(gt=0)] = 7200.0
+
+    @field_validator('source')
+    @classmethod
+    def check_source(cls, value):
+        """PESSection.source validator.
+
+        Arkane's explorer resolves ``source`` from ``species_dict`` only and accepts a
+        unimolecular or bimolecular entry channel -- never three or more, and never a transition
+        state. Refusing here beats a failure deep inside an Arkane run.
+        """
+        if not 1 <= len(value) <= 2:
+            raise ValueError(
+                f"The PES 'source' must name 1 or 2 species -- 1 for a unimolecular well, 2 for a "
+                f"bimolecular entry channel (A + B). Arkane's explorer accepts nothing else. "
+                f"Got {len(value)}: {value}.")
+        return value
+
+    @field_validator('method')
+    @classmethod
+    def check_method(cls, value):
+        """PESSection.method validator."""
+        if value not in ('CSE', 'RS', 'MSC'):
+            raise ValueError(f"The PES method must be either 'CSE', 'RS', or 'MSC'.\nGot: {value}")
+        return value
+
+
+class PESQMSection(BaseModel):
+    """
+    A class for validating input.qm arguments of the standalone PES exploration loop.
+
+    Level defaults are the proven ones from Vault/Code/ARC/Canonical Levels of Theory.md, not
+    ARC's repo defaults.
+    """
+    opt_level: str = 'wb97xd/def2tzvp'
+    freq_level: str = 'wb97xd/def2tzvp'
+    sp_level: str = 'wb97xd/def2tzvp'
+    irc_level: str = 'wb97xd/def2tzvp'
+    scan_level: str = 'wb97xd/def2tzvp'
+    ts_adapters: list[str] = Field(default_factory=lambda: ['heuristics', 'linear', 'kinbot',
+                                                            'goflow', 'rits'])
+    rotors: bool = False
+    irc: bool = False
+    scope: Literal['all', 'sensitive'] = 'sensitive'
+    max_transition_states_per_round: Annotated[int, Field(gt=0, strict=True)] = 10
+
+    @field_validator('opt_level', 'freq_level', 'sp_level', 'irc_level', 'scan_level')
+    @classmethod
+    def check_undashed(cls, value, info):
+        """PESQMSection level validators."""
+        return _refuse_dashed_level(value, info.field_name)
+
+    @model_validator(mode='after')
+    def check_level_pairings(self):
+        """PESQMSection cross-field validator.
+
+        freq must be evaluated at the same level as opt (so frequencies belong to a real minimum
+        of that surface), scan at the same level as freq (so rotors project out correctly), and
+        irc at the same level as opt. Source: Canonical Levels of Theory.
+        """
+        if self.freq_level != self.opt_level:
+            raise ValueError(f"'freq_level' must equal 'opt_level' so frequencies are evaluated at "
+                             f"a real minimum of the same surface. Got freq_level="
+                             f"{self.freq_level!r}, opt_level={self.opt_level!r}.")
+        if self.scan_level != self.freq_level:
+            raise ValueError(f"'scan_level' must equal 'freq_level' so rotors project out "
+                             f"correctly. Got scan_level={self.scan_level!r}, freq_level="
+                             f"{self.freq_level!r}.")
+        if self.irc_level != self.opt_level:
+            raise ValueError(f"'irc_level' must equal 'opt_level'. Got irc_level="
+                             f"{self.irc_level!r}, opt_level={self.opt_level!r}.")
+        return self
+
+
+class PESTerminationSection(BaseModel):
+    """
+    A class for validating input.termination arguments of the standalone PES exploration loop.
+    """
+    # strict=True because bool is a subclass of int: without it, `max_rounds: true` in a YAML
+    # input validates happily as 1 and silently caps the loop at a single round.
+    max_rounds: Annotated[int, Field(gt=0, strict=True)] = 5
+    stop_when_no_new_ts: bool = True
+
+
+class PESReuseSection(BaseModel):
+    """
+    A class for validating input.reuse arguments of the standalone PES exploration loop.
+    """
+    from_t3_projects: list[str] = Field(default_factory=list)
+
+
+class PESLoopConfig(BaseModel):
+    """
+    A class for validating the standalone PES exploration loop's input file.
+    """
+    pes: PESSection
+    qm: PESQMSection = Field(default_factory=PESQMSection)
+    termination: PESTerminationSection = Field(default_factory=PESTerminationSection)
+    reuse: PESReuseSection = Field(default_factory=PESReuseSection)
+
+    class Config:
+        extra = "forbid"
 
 
 class InputBase(BaseModel):

--- a/t3/schema.py
+++ b/t3/schema.py
@@ -958,6 +958,12 @@ class PESQMSection(BaseModel):
     irc: bool = False
     scope: Literal['all', 'sensitive'] = 'sensitive'
     max_transition_states_per_round: Annotated[int, Field(gt=0, strict=True)] = 10
+    # The smallest measured ln(k) response that justifies spending QM on a transition state,
+    # mirroring T3's in-run ``t3.sensitivity.pdep_min_delta_ln_k`` (same default, same bounds).
+    # Applies under BOTH scopes: 'sensitive' ranks and 'all' does not, but neither may queue a
+    # transition state whose measured leverage is below this floor -- its capture manifest would
+    # then record a coefficient that never justified anything.
+    min_delta_ln_k: Annotated[float, Field(gt=0, lt=1)] = 1e-3
 
     @field_validator('opt_level', 'freq_level', 'sp_level', 'irc_level', 'scan_level')
     @classmethod

--- a/tests/test_pdep/test_barrierless.py
+++ b/tests/test_pdep/test_barrierless.py
@@ -32,6 +32,14 @@ class TestRMGFamily(object):
         comment = 'Matched reaction 0 H2 + CO2 <=> CH2O2 in 1,3_Insertion_CO2/training\nfamily: 1,3_Insertion_CO2'
         assert rmg_family(_rxn(comment)) == '1,3_Insertion_CO2'
 
+    def test_family_with_a_plus_sign_survives(self):
+        """A family name may contain '+': '1+2_Cycloaddition' (real family, network799_1
+        reaction1) must not silently come back as None (N4)."""
+        comment = ('Estimated using template [o_atom_singlet;multiplebond] for rate rule '
+                  '[o_atom_singlet;mb_carbonyl]\nEuclidian distance = 1.0\nMultiplied by '
+                  'reaction path degeneracy 2.0\nfamily: 1+2_Cycloaddition')
+        assert rmg_family(_rxn(comment)) == '1+2_Cycloaddition'
+
     def test_no_family_returns_none(self):
         """A comment with no family is not guessed at."""
         assert rmg_family(_rxn('From a library.')) is None

--- a/tests/test_pdep/test_barrierless.py
+++ b/tests/test_pdep/test_barrierless.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from t3.pdep.barrierless import (BARRIERLESS_FAMILIES, BarrierlessVerdict, classify_barrierless,
+from t3.pdep.barrierless import (BARRIERLESS_FAMILIES, classify_barrierless,
                                  rmg_family)
 from t3.pdep.parser import PDepPathReaction
 

--- a/tests/test_pdep/test_barrierless.py
+++ b/tests/test_pdep/test_barrierless.py
@@ -1,0 +1,84 @@
+"""Tests for t3.pdep.barrierless."""
+
+import pytest
+
+from t3.pdep.barrierless import (BARRIERLESS_FAMILIES, BarrierlessVerdict, classify_barrierless,
+                                 rmg_family)
+from t3.pdep.parser import PDepPathReaction
+
+
+def _rxn(comment: str, transition_state: str | None = 'TS1') -> PDepPathReaction:
+    """Build a path reaction carrying only the fields the classifier reads."""
+    return PDepPathReaction(label='rxn', reactants=('A',), products=('B',),
+                            transition_state=transition_state, kinetics_type='Arrhenius',
+                            kinetics_comment=comment)
+
+
+class TestRMGFamily(object):
+    """Family extraction from the two forms RMG actually writes."""
+
+    def test_node_estimated_form(self):
+        """'... in family R_Recombination.' -- the node-estimated form."""
+        comment = 'Estimated from node Root_N-1R->H_N-1CNOS->N in family R_Recombination.'
+        assert rmg_family(_rxn(comment)) == 'R_Recombination'
+
+    def test_rate_rule_form(self):
+        """'family: 1,2_Insertion_CO' on its own line -- the rate-rule/training form."""
+        comment = 'Estimated using an average for rate rule [CO;RO_H]\nEuclidian distance: 0\nfamily: 1,2_Insertion_CO'
+        assert rmg_family(_rxn(comment)) == '1,2_Insertion_CO'
+
+    def test_family_with_commas_and_digits_survives(self):
+        """A family name is not [A-Za-z_]+: '1,3_Insertion_CO2' must come back whole."""
+        comment = 'Matched reaction 0 H2 + CO2 <=> CH2O2 in 1,3_Insertion_CO2/training\nfamily: 1,3_Insertion_CO2'
+        assert rmg_family(_rxn(comment)) == '1,3_Insertion_CO2'
+
+    def test_no_family_returns_none(self):
+        """A comment with no family is not guessed at."""
+        assert rmg_family(_rxn('From a library.')) is None
+
+    def test_empty_comment_returns_none(self):
+        assert rmg_family(_rxn('')) is None
+
+
+class TestClassifyBarrierless(object):
+    """The verdict the loop gates QM on."""
+
+    def test_r_recombination_is_barrierless(self):
+        """The case that motivated this module: the live campaign spent its whole TS-search
+        budget on HO + CHO <=> CH2O2, an R_Recombination, which has no saddle point at all."""
+        comment = 'Estimated from node Root_1R->H in family R_Recombination.'
+        verdict = classify_barrierless(_rxn(comment))
+        assert verdict.is_barrierless is True
+        assert verdict.family == 'R_Recombination'
+        assert 'R_Recombination' in verdict.reason
+
+    def test_insertion_family_is_not_barrierless(self):
+        """1,2_Insertion_CO has a real saddle point -- this campaign converged one at -632.77 cm^-1."""
+        verdict = classify_barrierless(_rxn('family: 1,2_Insertion_CO'))
+        assert verdict.is_barrierless is False
+        assert verdict.family == '1,2_Insertion_CO'
+
+    def test_unknown_family_is_not_barrierless(self):
+        """Fail OPEN, not closed. An unrecognized family gets its TS search: wrongly skipping a
+        real barrier silently loses physics, while wrongly attempting a barrierless one merely
+        wastes a job and is visible in the log."""
+        verdict = classify_barrierless(_rxn('family: Some_New_Family'))
+        assert verdict.is_barrierless is False
+        assert 'not a known barrierless family' in verdict.reason
+
+    def test_no_family_is_not_barrierless(self):
+        verdict = classify_barrierless(_rxn('From a library.'))
+        assert verdict.is_barrierless is False
+        assert verdict.family is None
+
+    def test_every_listed_family_classifies_as_barrierless(self):
+        """The constant and the classifier must not drift apart."""
+        for family in BARRIERLESS_FAMILIES:
+            verdict = classify_barrierless(_rxn(f'family: {family}'))
+            assert verdict.is_barrierless is True, f'{family} is listed but did not classify'
+
+    def test_verdict_is_frozen(self):
+        """A verdict is evidence; a caller must not edit it after the fact."""
+        verdict = classify_barrierless(_rxn('family: R_Recombination'))
+        with pytest.raises(Exception):
+            verdict.is_barrierless = False

--- a/tests/test_pdep/test_capture.py
+++ b/tests/test_pdep/test_capture.py
@@ -2098,3 +2098,20 @@ class TestSensitivityAggregationMarker:
         manifest = read_yaml_file(result.manifest_path)
         assert manifest['sensitivity_aggregation'] == 'all_directions_max_abs'
         assert verify_capture(result.capture_dir).sensitivity_aggregation == 'all_directions_max_abs'
+
+    def test_an_unrecognized_marker_is_refused_on_write(self, tmp_path):
+        record = _usable_record(tmp_path)
+        with pytest.raises(ValueError, match="Unrecognized 'sensitivity_aggregation'"):
+            _capture([record], str(tmp_path), f'{tmp_path}_capture',
+                     sensitivity_aggregation='made_up_convention')
+
+    def test_a_hand_edited_marker_is_refused_by_verify(self, tmp_path):
+        record = _usable_record(tmp_path)
+        result = _capture([record], str(tmp_path), f'{tmp_path}_capture',
+                          sensitivity_aggregation=capture_module.SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS)
+        manifest = read_yaml_file(result.manifest_path)
+        manifest['sensitivity_aggregation'] = 'tampered'
+        with open(result.manifest_path, 'w') as f:
+            yaml.safe_dump(manifest, f)
+        with pytest.raises(ValueError, match="unrecognized 'sensitivity_aggregation'"):
+            verify_capture(result.capture_dir)

--- a/tests/test_pdep/test_capture.py
+++ b/tests/test_pdep/test_capture.py
@@ -2076,3 +2076,25 @@ def test_a_capture_alone_can_drive_a_hybrid_network_write(tmp_path):
     with open(result.dest_path, 'r') as f:
         written = f.read()
     assert 'useAtomCorrections = True' in written
+
+
+class TestSensitivityAggregationMarker:
+    """The 'sensitivity_aggregation' manifest marker: T3's in-run captures record nothing (their
+    evidence is observable-selected and threshold-gated), the standalone PES loop marks its
+    manifests 'all_directions_max_abs' -- the two conventions' admissible coefficient ranges are
+    incompatible, and the marker is what prevents a silent comparison on the shared field names."""
+
+    def test_default_writes_no_marker_and_verify_surfaces_none(self, tmp_path):
+        record = _usable_record(tmp_path)
+        result = _capture([record], str(tmp_path), f'{tmp_path}_capture')
+        manifest = read_yaml_file(result.manifest_path)
+        assert 'sensitivity_aggregation' not in manifest
+        assert verify_capture(result.capture_dir).sensitivity_aggregation is None
+
+    def test_marker_is_written_verbatim_and_surfaced_by_verify(self, tmp_path):
+        record = _usable_record(tmp_path)
+        result = _capture([record], str(tmp_path), f'{tmp_path}_capture',
+                          sensitivity_aggregation=capture_module.SENSITIVITY_AGGREGATION_ALL_DIRECTIONS_MAX_ABS)
+        manifest = read_yaml_file(result.manifest_path)
+        assert manifest['sensitivity_aggregation'] == 'all_directions_max_abs'
+        assert verify_capture(result.capture_dir).sensitivity_aggregation == 'all_directions_max_abs'

--- a/tests/test_pdep/test_parser.py
+++ b/tests/test_pdep/test_parser.py
@@ -61,6 +61,23 @@ def test_network_id_equals_file_stem(stem, _num_species, _num_ts, _num_reactions
     assert network.path == path
 
 
+def test_species_structures_real_fixture_network799_1():
+    """
+    Test that ``PDepNetwork.species_structures`` captures each species' adjacency-list text,
+    keyed by the same label used in ``species_labels`` -- the field ``t3.pdep.pes_qm`` needs to
+    build real ARC ``ARCSpecies``/``ARCReaction`` dicts (ruling C2), rather than the bare
+    ``{'ts_label', 'family'}`` reaction dicts that cannot construct a valid ``ARCReaction``.
+    """
+    path = os.path.join(TEST_DATA_BASE_PATH, 'pdep_real_networks', 'network799_1', 'network799_1.py')
+    network = parse_pdep_network_file(path=path)
+    assert set(network.species_structures.keys()) == set(network.species_labels)
+    co3 = network.species_structures['O=C1OO1(21648)']
+    assert '1 O u0 p2 c0 {2,S} {4,S}' in co3
+    assert '4 C u0 p0 c0 {1,S} {2,S} {3,D}' in co3
+    o_atom = network.species_structures['O-2(13598)']
+    assert o_atom.strip() == '1 O u0 p3 c0'
+
+
 def test_network4_2_reaction1():
     """Test a specific known reaction (reaction1) from network4_2.py."""
     path = os.path.join(PDEP_NETWORK_DIR, 'network4_2.py')

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -2,7 +2,6 @@
 
 import dataclasses
 import os
-import tempfile
 
 import pytest
 
@@ -31,7 +30,7 @@ def config():
                          termination={'max_rounds': 3})
 
 
-def _stub_explorer(monkeypatch, families, fail=False):
+def _stub_explorer(monkeypatch, tmp_path, families, fail=False):
     """
     Patch ``explore_pdep_network``, ``parse_pdep_network_file``, and ``draw_pes_diagram`` at the
     names bound in ``t3.pdep.pes_loop``, so ``run_pes_loop`` can be tested without Arkane.
@@ -52,6 +51,8 @@ def _stub_explorer(monkeypatch, families, fail=False):
 
     Args:
         monkeypatch: pytest's monkeypatch fixture.
+        tmp_path: pytest's per-test scratch directory fixture, used instead of tempfile.mkdtemp
+            so this helper leaves nothing behind for pytest to clean up itself.
         families (list): One path reaction is fabricated per entry, carrying that family in its
             kinetics comment (recognized by ``t3.pdep.barrierless.classify_barrierless``).
         fail (bool): If True, every call to the stubbed explorer reports a failed exploration
@@ -76,7 +77,8 @@ def _stub_explorer(monkeypatch, families, fail=False):
 
     calls = []
     drawn = []
-    explore_dir = tempfile.mkdtemp()
+    explore_dir = os.path.join(str(tmp_path), 'explored')
+    os.makedirs(explore_dir, exist_ok=True)
 
     def _fake_explore(*, network_path, config, logger=None):
         calls.append(network_path)
@@ -128,7 +130,7 @@ class TestRunPESLoop(object):
     def test_no_candidates_terminates_immediately(self, tmp_path, monkeypatch, config):
         """A network whose every channel is barrierless has nothing to compute: one explore, one
         diagram, done -- not three empty rounds."""
-        _stub_explorer(monkeypatch, families=['R_Recombination', 'R_Recombination'])
+        _stub_explorer(monkeypatch, tmp_path, families=['R_Recombination', 'R_Recombination'])
         result = run_pes_loop(config, project_directory=str(tmp_path))
         assert result.status == PES_LOOP_NO_CANDIDATES
         assert len(result.rounds) == 1
@@ -140,11 +142,11 @@ class TestRunPESLoop(object):
         config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
                                     'bath_gas': {'He': 1.0}},
                                termination={'max_rounds': 3, 'stop_when_no_new_ts': False})
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
         def _runner(candidates, paths, cfg, network_id):
             _touch_hybrid_file(paths, network_id)
-            return frozenset()
+            return frozenset(), frozenset(c.ts_label for c in candidates)
 
         result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert result.status == PES_LOOP_MAX_ROUNDS
@@ -154,19 +156,20 @@ class TestRunPESLoop(object):
         """With the default stop_when_no_new_ts=True, a runner that converges nothing must stop
         after round 1 rather than spend the rest of the round budget -- this is what distinguishes
         'stalled' from 'max_rounds' (ruling C3)."""
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
         result = run_pes_loop(config, project_directory=str(tmp_path),
-                              qm_runner=lambda candidates, paths, cfg, network_id: frozenset())
+                              qm_runner=lambda candidates, paths, cfg, network_id:
+                              (frozenset(), frozenset(c.ts_label for c in candidates)))
         assert result.status == PES_LOOP_STALLED
         assert len(result.rounds) == 1
 
     def test_converges_when_every_candidate_is_computed(self, tmp_path, monkeypatch, config):
         """Once QM exists for every barriered channel, the loop stops on its own."""
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
         def _runner(candidates, paths, cfg, network_id):
             _touch_hybrid_file(paths, network_id)
-            return frozenset(c.ts_label for c in candidates)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert result.status == PES_LOOP_CONVERGED
@@ -177,11 +180,11 @@ class TestRunPESLoop(object):
         network -- not the pre-explore input, and not another round's output. Drawing from the
         input instead of the explored network is exactly the bug this feature exists to remove
         (byte-identical diagrams across runs even when a saddle point converged)."""
-        calls, drawn = _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        calls, drawn = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
         def _runner(candidates, paths, cfg, network_id):
             _touch_hybrid_file(paths, network_id)
-            return frozenset(c.ts_label for c in candidates)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert len(result.rounds) == 2
@@ -195,12 +198,12 @@ class TestRunPESLoop(object):
     def test_barrierless_channels_are_never_queued(self, tmp_path, monkeypatch, config):
         """The F21 gate, asserted end to end rather than only at the unit level."""
         queued = []
-        _stub_explorer(monkeypatch, families=['R_Recombination', '1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path, families=['R_Recombination', '1,2_Insertion_CO'])
 
         def _runner(candidates, paths, cfg, network_id):
             queued.extend(c.family for c in candidates)
             _touch_hybrid_file(paths, network_id)
-            return frozenset(c.ts_label for c in candidates)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert 'R_Recombination' not in queued
@@ -209,7 +212,7 @@ class TestRunPESLoop(object):
     def test_no_qm_runner_explores_and_draws_only(self, tmp_path, monkeypatch, config):
         """The honest behaviour without a configured runner: one round, a diagram, no crash -- and
         a status distinct from an operational stall, per the ruling on concern 4."""
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
         result = run_pes_loop(config, project_directory=str(tmp_path))
         assert result.status == PES_LOOP_DIAGRAM_ONLY
         assert len(result.rounds) == 1
@@ -217,7 +220,7 @@ class TestRunPESLoop(object):
 
     def test_a_failed_explore_stops_the_loop_and_says_why(self, tmp_path, monkeypatch, config):
         """A round that cannot explore must not be papered over as convergence."""
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'], fail=True)
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'], fail=True)
         result = run_pes_loop(config, project_directory=str(tmp_path))
         assert result.status == 'failed'
         assert result.reason
@@ -227,11 +230,11 @@ class TestRunPESLoop(object):
         """Round 1 must explore the QM-informed hybrid network qm_runner wrote, not re-explore
         round 0's original input -- otherwise this is N re-explorations of one file, never a loop
         (Critical 1)."""
-        calls, _ = _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        calls, _ = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
         def _runner(candidates, paths, cfg, network_id):
             _touch_hybrid_file(paths, network_id)
-            return frozenset(c.ts_label for c in candidates)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert calls[0] == '/abs/network1_1.py'
@@ -244,13 +247,13 @@ class TestRunPESLoop(object):
         """qm_runner must be handed the id of the network THIS round explored, not the loop's
         static input path's id -- ruling C4 exists precisely so a wrong id cannot misnamespace ARC
         jobs (Critical 1)."""
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
         received = []
 
         def _runner(candidates, paths, cfg, network_id):
             received.append(network_id)
             _touch_hybrid_file(paths, network_id)
-            return frozenset(c.ts_label for c in candidates)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert received[0] == 'explored_round0'
@@ -261,13 +264,13 @@ class TestRunPESLoop(object):
         """C1: TS labels adopted from an earlier T3 project must be treated as already computed
         before round 0 ever runs, not just before some later round -- there was previously zero
         coverage of this ruling at all."""
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
         queued = []
 
         def _runner(candidates, paths, cfg, network_id):
             queued.extend(c.ts_label for c in candidates)
             _touch_hybrid_file(paths, network_id)
-            return frozenset(c.ts_label for c in candidates)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner,
                     adopted_ts_labels=frozenset({'TS0'}))
@@ -279,11 +282,11 @@ class TestRunPESLoop(object):
         """qm_runner's contract is to write the round's hybrid network file; if it doesn't, that
         must surface as a PES_LOOP_FAILED round with a stated reason, not a FileNotFoundError
         escaping from round N after round N-1 already spent real ARC time (Important 3)."""
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
         def _runner(candidates, paths, cfg, network_id):
             # Deliberately does NOT write the hybrid file, breaking its contract.
-            return frozenset(c.ts_label for c in candidates)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert result.status == PES_LOOP_FAILED
@@ -337,7 +340,7 @@ class TestRunPESLoop(object):
         def _runner(candidates, paths, cfg, network_id):
             # Deliberately does NOT write the hybrid file -- this is the correct, contractual
             # behaviour when nothing converged, not a bug being simulated.
-            return frozenset()
+            return frozenset(), frozenset(c.ts_label for c in candidates)
 
         result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert result.status == PES_LOOP_MAX_ROUNDS

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -310,6 +310,51 @@ class TestRunPESLoop(object):
         assert 'TS0' not in queued
         assert 'TS1' in queued
 
+    def test_reuse_config_calls_adopt_prior_qm_and_seeds_round_0(self, tmp_path, monkeypatch,
+                                                                  config):
+        """Ruling 1: ``config.reuse.from_t3_projects`` being non-empty must actually call
+        ``adopt_prior_qm`` and remove what it returns from round 0's candidates -- a config knob
+        that has no reachable call site is exactly the "ships dead" failure this test exists to
+        catch."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+        adopt_calls = []
+
+        def _fake_adopt(from_t3_projects, network_id, level_of_theory):
+            adopt_calls.append((tuple(from_t3_projects), network_id, level_of_theory))
+            return {'TS0': '/fake/prior/TS0.py'}
+
+        monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm', _fake_adopt)
+        reuse_config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                          'bath_gas': {'He': 1.0}},
+                                     termination={'max_rounds': 3},
+                                     reuse={'from_t3_projects': ['/prior/project']})
+        queued = []
+
+        def _runner(candidates, paths, cfg, network_id):
+            queued.extend(c.ts_label for c in candidates)
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(reuse_config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert adopt_calls == [(('/prior/project',), 'network1_1', reuse_config.qm.sp_level)]
+        assert 'TS0' not in queued
+        assert 'TS1' in queued
+
+    def test_empty_reuse_config_does_not_call_adopt_prior_qm(self, tmp_path, monkeypatch, config):
+        """The default (empty) ``reuse.from_t3_projects`` must not pay for a filesystem walk that
+        can never find anything to adopt."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+        adopt_calls = []
+        monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm',
+                            lambda *a, **kw: adopt_calls.append((a, kw)) or {})
+
+        def _runner(candidates, paths, cfg, network_id):
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert adopt_calls == []
+
     def test_a_missing_hybrid_file_fails_loudly_instead_of_a_bare_traceback(self, tmp_path,
                                                                              monkeypatch, config):
         """qm_runner's contract is to write the round's hybrid network file; if it doesn't, that

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -382,7 +382,7 @@ class TestRunPESLoop(object):
         # The 4th argument is the seed network's STRUCTURAL channel-key map (canonical species
         # structures, direction-insensitive), never a positional-label map -- reaction and TS
         # labels are both positional in Arkane-written files and cannot identify a channel.
-        assert call_labels == {'TS0': (('C',), ('CC',)), 'TS1': (('CCC',), ('CCCC',))}
+        assert call_labels == {'TS0': (('CC|m1',), ('C|m1',)), 'TS1': (('CCCC|m1',), ('CCC|m1',))}
         assert 'TS0' not in queued
         assert 'TS1' in queued
 

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -5,6 +5,8 @@ import os
 
 import pytest
 
+from arc.molecule.molecule import Molecule
+
 from t3.pdep.capture import captured_qm_artifact_path
 from t3.pdep.explorer.result import (EXPLORATION_STATUS_FAILED, EXPLORATION_STATUS_SUCCEEDED,
                                      PDepExplorationResult)
@@ -46,6 +48,13 @@ def config():
                          termination={'max_rounds': 3})
 
 
+def _alkane_adjlist(n_carbons: int) -> str:
+    """A real RMG adjacency list for the linear alkane with ``n_carbons`` carbons, rendered by
+    ARC's own Molecule so the stub networks below carry genuinely parseable, mutually distinct
+    structures."""
+    return Molecule().from_smiles('C' * n_carbons).to_adjacency_list()
+
+
 def _stub_explorer(monkeypatch, tmp_path, families, fail=False):
     """
     Patch ``explore_pdep_network``, ``parse_pdep_network_file``, and ``draw_pes_diagram`` at the
@@ -80,16 +89,25 @@ def _stub_explorer(monkeypatch, tmp_path, families, fail=False):
         order.
     """
     path_reactions = tuple(
-        PDepPathReaction(label=f'reaction{i}', reactants=('A',), products=('B',),
+        PDepPathReaction(label=f'reaction{i}', reactants=(f'A{i}',), products=(f'B{i}',),
                          transition_state=f'TS{i}', kinetics_type='Arrhenius',
                          kinetics_comment=f'family: {family}')
         for i, family in enumerate(families))
+    # Every channel gets its own pair of REAL, distinct molecules (linear alkanes of increasing
+    # length): the loop carries QM across rounds by STRUCTURAL channel identity
+    # (t3.pdep.pes_rounds.channel_keys_by_ts_label), so a stub whose species had no parseable
+    # structures -- or whose every reaction connected the same pair -- would silently disable the
+    # cross-round memory these tests exist to exercise.
+    species_structures = {}
+    for i in range(len(families)):
+        species_structures[f'A{i}'] = _alkane_adjlist(2 * i + 1)
+        species_structures[f'B{i}'] = _alkane_adjlist(2 * i + 2)
     base_network = PDepNetwork(network_id='network1_1', path='/abs/network1_1.py', label=None,
-                               species_labels=('A', 'B'),
+                               species_labels=tuple(species_structures),
                                transition_state_labels=tuple(f'TS{i}' for i in
                                                               range(len(families))),
                                path_reactions=path_reactions, isomers=(), reactant_channels=(),
-                               product_channels=())
+                               product_channels=(), species_structures=species_structures)
 
     calls = []
     drawn = []
@@ -361,7 +379,10 @@ class TestRunPESLoop(object):
         assert call_projects == ('/prior/project',)
         assert call_network_id == 'network1_1'
         assert call_level == reuse_config.qm.sp_level == 'ccsd(t)-f12/cc-pvtz-f12'
-        assert call_labels == {'TS0': ('reaction0',), 'TS1': ('reaction1',)}
+        # The 4th argument is the seed network's STRUCTURAL channel-key map (canonical species
+        # structures, direction-insensitive), never a positional-label map -- reaction and TS
+        # labels are both positional in Arkane-written files and cannot identify a channel.
+        assert call_labels == {'TS0': (('C',), ('CC',)), 'TS1': (('CCC',), ('CCCC',))}
         assert 'TS0' not in queued
         assert 'TS1' in queued
 
@@ -760,3 +781,88 @@ class TestSensitivityFloor(object):
         assert result.status == PES_LOOP_CONVERGED
         assert [record.status for record in result.rounds] == ['continuing', PES_LOOP_CONVERGED]
         assert sorted(result.rounds[0].queued_ts_labels) == ['TS0']
+
+
+class TestRenumberedNetworksKeepQMOnTheRightChannel(object):
+    """THE wrong-saddle-point pin: every TS label Arkane writes is positional
+    (rmgpy/rmg/pdep.py:854), so a re-exploration can relabel channels between rounds. A
+    label-keyed carry would then skip the WRONG channel as 'already has QM' and fold round 0's
+    barrier onto a different reaction; the structural carry must keep the barrier on its own
+    channel regardless of what the labels do."""
+
+    def test_round_1_relabeling_does_not_misattribute_round_0s_artifact(self, tmp_path,
+                                                                        monkeypatch, config):
+        adj = {name: _alkane_adjlist(n)
+               for name, n in (('A0', 1), ('B0', 2), ('A1', 3), ('B1', 4))}
+
+        def _reaction(label, ts, reactants, products):
+            return PDepPathReaction(label=label, reactants=reactants, products=products,
+                                    transition_state=ts, kinetics_type='Arrhenius',
+                                    kinetics_comment='family: 1,2_Insertion_CO')
+
+        # Round 0's file: TS0 is the (A0, B0) channel. Round 1's re-exploration writes the SAME
+        # two channels with the positions -- and therefore the labels -- swapped: 'TS0' now names
+        # the (A1, B1) channel and 'TS1' names (A0, B0).
+        round0_network = PDepNetwork(
+            network_id='explored_round0', path='/x0.py', label=None,
+            species_labels=tuple(adj), transition_state_labels=('TS0', 'TS1'),
+            path_reactions=(_reaction('reaction0', 'TS0', ('A0',), ('B0',)),
+                            _reaction('reaction1', 'TS1', ('A1',), ('B1',))),
+            isomers=(), reactant_channels=(), product_channels=(), species_structures=adj)
+        round1_network = dataclasses.replace(
+            round0_network, network_id='explored_round1',
+            path_reactions=(_reaction('reaction0', 'TS0', ('A1',), ('B1',)),
+                            _reaction('reaction1', 'TS1', ('A0',), ('B0',))))
+        networks = [round0_network, round1_network, round1_network]
+
+        calls = []
+
+        def _fake_explore(*, network_path, config, logger=None):
+            calls.append(network_path)
+            output_path = os.path.join(str(tmp_path), f'explored_round{len(calls) - 1}.py')
+            open(output_path, 'w').close()
+            return PDepExplorationResult(network_id='network1_1',
+                                         status=EXPLORATION_STATUS_SUCCEEDED,
+                                         network_paths=(output_path,))
+
+        def _fake_parse(path):
+            # The loop parses each round's freshly explored network right after exploring it, so
+            # the round currently being parsed is simply the latest explore call.
+            network = networks[min(len(calls) - 1, 2)] if calls else networks[0]
+            return dataclasses.replace(network, path=path)
+
+        def _fake_draw(network_path, output_path):
+            open(output_path, 'w').close()
+
+        monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
+        monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file', _fake_parse)
+        monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram', _fake_draw)
+
+        offered_channels_per_round = []
+        adopted_per_round = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            offered_channels_per_round.append(
+                tuple((c.ts_label, c.path_reaction.reactants) for c in candidates))
+            adopted_per_round.append(dict(adopted))
+            _touch_hybrid_file(paths, network_id)
+            # Round 0 converges only its first offered channel; round 1 converges the rest.
+            converged = frozenset({candidates[0].ts_label}) if candidates else frozenset()
+            return converged, frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+
+        assert result.status == PES_LOOP_CONVERGED
+        # Round 0: both channels offered; (A0, B0) converged under its round-0 label 'TS0'.
+        assert offered_channels_per_round[0] == (('TS0', ('A0',)), ('TS1', ('A1',)))
+        # Round 1 (relabeled): the computed (A0, B0) channel now carries label 'TS1' and must be
+        # SKIPPED under that new label; the still-uncomputed (A1, B1) channel -- now labeled
+        # 'TS0', which a label-keyed carry would have wrongly skipped as computed -- must be the
+        # one offered.
+        assert offered_channels_per_round[1] == (('TS0', ('A1',)),)
+        # And round 0's artifact reaches round 1 as an adopted artifact under the channel's NEW
+        # label 'TS1', still pointing at the ORIGINATING (round 0) capture, where it was vendored
+        # under round 0's arc label for 'TS0' -- the right barrier, on the right channel.
+        round0_artifact = captured_qm_artifact_path(
+            round_paths(str(tmp_path), 0).capture, arc_ts_label('explored_round0', 'TS0'))
+        assert adopted_per_round[1] == {'TS1': round0_artifact}

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -440,3 +440,69 @@ class TestRunPESLoop(object):
                                                     'explored_round0')
         assert calls[1] != never_written_hybrid
         assert not os.path.isfile(never_written_hybrid)
+
+    def test_round_0_full_adoption_does_not_early_return_no_candidates(self, tmp_path, monkeypatch,
+                                                                        config):
+        """C2 (fix round 2): when EVERY round-0 candidate was satisfied by reuse,
+        split.candidates is empty -- but that must not be read as "nothing to do" and short-circuit
+        to PES_LOOP_NO_CANDIDATES carrying the raw, all-ILT explored network. The headline reuse
+        scenario (reuse everything -> get nothing back) was silently reported as a benign status
+        before this fix; qm_runner must still be called (with an empty candidates tuple) so it can
+        fold the adopted artifact into a hybrid network."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+
+        def _fake_adopt(from_t3_projects, network_id, level_of_theory, path_reaction_labels_by_ts_label):
+            return {'TS0': '/fake/prior/TS0.py'}
+
+        monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm', _fake_adopt)
+        reuse_config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                          'bath_gas': {'He': 1.0}},
+                                     termination={'max_rounds': 3},
+                                     reuse={'from_t3_projects': ['/prior/project']})
+        runner_calls = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            runner_calls.append((tuple(candidates), adopted))
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(), frozenset()
+
+        result = run_pes_loop(reuse_config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert len(runner_calls) == 1
+        called_candidates, called_adopted = runner_calls[0]
+        assert called_candidates == ()
+        assert called_adopted == {'TS0': '/fake/prior/TS0.py'}
+        assert result.status != PES_LOOP_NO_CANDIDATES
+
+    def test_round_0_full_adoption_advances_to_the_hybrid_file_it_wrote(self, tmp_path, monkeypatch,
+                                                                        config):
+        """Important (fix round 2): a round-0-only-adoption round's hybrid file, once written, must
+        actually be what the NEXT round explores -- qm_runner's returned newly_computed excludes
+        adopted labels by contract, so advancing current_network_path on newly_computed alone would
+        ignore the hybrid this round demonstrably wrote."""
+        calls, _drawn = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+
+        def _fake_adopt(from_t3_projects, network_id, level_of_theory, path_reaction_labels_by_ts_label):
+            return {'TS0': '/fake/prior/TS0.py'}
+
+        monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm', _fake_adopt)
+        reuse_config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                          'bath_gas': {'He': 1.0}},
+                                     termination={'max_rounds': 2, 'stop_when_no_new_ts': False},
+                                     reuse={'from_t3_projects': ['/prior/project']})
+        written_hybrid_paths = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            written_hybrid_paths.append(_touch_hybrid_file(paths, network_id))
+            return frozenset(), frozenset()
+
+        result = run_pes_loop(reuse_config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert len(written_hybrid_paths) == 1
+        # TS0 was folded into computed_ts_labels by adoption before round 0 even ran, so round 1
+        # (having nothing left to queue) correctly converges rather than exhausting max_rounds --
+        # that convergence, not a particular status, is the honest outcome here. What this test
+        # pins is that round 1 reached that conclusion by exploring the hybrid round 0 actually
+        # wrote, not the raw pre-adoption network (the fix-round-2 regression).
+        assert result.status == PES_LOOP_CONVERGED
+        assert len(result.rounds) == 2
+        assert result.rounds[0].status != PES_LOOP_FAILED
+        assert calls[1] == written_hybrid_paths[0]

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -1,5 +1,6 @@
 """Tests for t3.pdep.pes_loop."""
 
+import dataclasses
 import os
 
 import pytest
@@ -7,8 +8,10 @@ import pytest
 from t3.pdep.explorer.result import (EXPLORATION_STATUS_FAILED, EXPLORATION_STATUS_SUCCEEDED,
                                      PDepExplorationResult)
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
-from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES,
-                              PES_LOOP_STALLED, PESLoopResult, RoundRecord, run_pes_loop)
+from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_DIAGRAM_ONLY, PES_LOOP_FAILED,
+                              PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES, PES_LOOP_STALLED,
+                              PESLoopResult, RoundRecord, hybrid_network_path, run_pes_loop)
+from t3.pdep.pes_rounds import round_paths
 from t3.schema import PESLoopConfig
 
 
@@ -17,9 +20,10 @@ def config():
     """A minimal config pointing at a network fixture.
 
     ``bath_gas`` is required by ``PDepExplorerConfig`` (a config without one is a guaranteed
-    write-time failure -- see t3/pdep/explorer/config.py, issue #183), so it must be non-empty
-    here even though every test below stubs ``explore_pdep_network`` and never actually reaches
-    that construction's use.
+    ``__post_init__`` failure -- see t3/pdep/explorer/config.py, issue #183), so it must be
+    non-empty here. Every test below stubs ``explore_pdep_network`` itself, but ``run_pes_loop``
+    still builds a real ``PDepExplorerConfig`` from this fixture before handing it to the stub, so
+    that construction IS reached and validated -- only the actual exploration is faked out.
     """
     return PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
                               'bath_gas': {'He': 1.0}},
@@ -31,46 +35,82 @@ def _stub_explorer(monkeypatch, families, fail=False):
     Patch ``explore_pdep_network``, ``parse_pdep_network_file``, and ``draw_pes_diagram`` at the
     names bound in ``t3.pdep.pes_loop``, so ``run_pes_loop`` can be tested without Arkane.
 
+    Unlike a stub that discards its arguments, this one is faithful on two points that matter for
+    catching a real "loop that never actually loops" bug:
+
+    - The exploration stub records the ``network_path`` it was called with (in ``calls``, in call
+      order), so a test can pin that round 1 explores round 0's hybrid output rather than
+      re-exploring round 0's original input.
+    - Each call returns a DISTINCT output path (``/abs/explored_round{N}.py``), and the parse stub
+      derives ``network_id`` from that path's stem exactly as the real ``parse_pdep_network_file``
+      does (``Path(path).stem`` -- ``t3/pdep/parser.py:729``). This means a loop that ever passes
+      the wrong network id to ``qm_runner`` or draws from the wrong path is directly observable,
+      not masked by every round looking identical.
+
     Args:
         monkeypatch: pytest's monkeypatch fixture.
         families (list): One path reaction is fabricated per entry, carrying that family in its
             kinetics comment (recognized by ``t3.pdep.barrierless.classify_barrierless``).
-        fail (bool): If True, the stubbed explorer reports a failed exploration instead of a
-            succeeded one.
+        fail (bool): If True, every call to the stubbed explorer reports a failed exploration
+            instead of a succeeded one.
+
+    Returns:
+        tuple: ``(calls, drawn)`` -- the ``network_path`` each ``explore_pdep_network`` call
+        received, and the ``network_path`` each ``draw_pes_diagram`` call received, both in call
+        order.
     """
-    network_path = '/abs/network1_1.py'
-    network_id = 'network1_1'
-
-    if fail:
-        result = PDepExplorationResult(network_id=network_id, status=EXPLORATION_STATUS_FAILED,
-                                       reasons=('the explorer adapter crashed',))
-    else:
-        result = PDepExplorationResult(network_id=network_id, status=EXPLORATION_STATUS_SUCCEEDED,
-                                       network_paths=(network_path,))
-
     path_reactions = tuple(
         PDepPathReaction(label=f'reaction{i}', reactants=('A',), products=('B',),
                          transition_state=f'TS{i}', kinetics_type='Arrhenius',
                          kinetics_comment=f'family: {family}')
         for i, family in enumerate(families))
-    network = PDepNetwork(network_id=network_id, path=network_path, label=None,
-                          species_labels=('A', 'B'),
-                          transition_state_labels=tuple(f'TS{i}' for i in range(len(families))),
-                          path_reactions=path_reactions, isomers=(), reactant_channels=(),
-                          product_channels=())
+    base_network = PDepNetwork(network_id='network1_1', path='/abs/network1_1.py', label=None,
+                               species_labels=('A', 'B'),
+                               transition_state_labels=tuple(f'TS{i}' for i in
+                                                              range(len(families))),
+                               path_reactions=path_reactions, isomers=(), reactant_channels=(),
+                               product_channels=())
 
-    def _fake_explore(*args, **kwargs):
-        return result
+    calls = []
+    drawn = []
 
-    def _fake_parse(*args, **kwargs):
-        return network
+    def _fake_explore(*, network_path, config, logger=None):
+        calls.append(network_path)
+        if fail:
+            return PDepExplorationResult(network_id=base_network.network_id,
+                                         status=EXPLORATION_STATUS_FAILED,
+                                         reasons=('the explorer adapter crashed',))
+        output_path = f'/abs/explored_round{len(calls) - 1}.py'
+        return PDepExplorationResult(network_id=base_network.network_id,
+                                     status=EXPLORATION_STATUS_SUCCEEDED,
+                                     network_paths=(output_path,))
+
+    def _fake_parse(path):
+        network_id = os.path.splitext(os.path.basename(path))[0]
+        return dataclasses.replace(base_network, network_id=network_id, path=path)
 
     def _fake_draw(network_path, output_path):
+        drawn.append(network_path)
         open(output_path, 'w').close()
 
     monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
     monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file', _fake_parse)
     monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram', _fake_draw)
+
+    return calls, drawn
+
+
+def _touch_hybrid_file(paths, network_id):
+    """
+    Create the round's hybrid network file, standing in for what a real ``qm_runner`` (Task 6)
+    must write there. ``run_pes_loop`` checks for exactly this file at the top of every round after
+    the first, so any test whose loop is meant to continue past round 0 must call this from its
+    ``qm_runner`` stub.
+    """
+    path = hybrid_network_path(paths, network_id)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    open(path, 'w').close()
+    return path
 
 
 class TestRunPESLoop(object):
@@ -91,8 +131,12 @@ class TestRunPESLoop(object):
                                     'bath_gas': {'He': 1.0}},
                                termination={'max_rounds': 3, 'stop_when_no_new_ts': False})
         _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
-        result = run_pes_loop(config, project_directory=str(tmp_path),
-                              qm_runner=lambda candidates, paths, cfg, network_id: frozenset())
+
+        def _runner(candidates, paths, cfg, network_id):
+            _touch_hybrid_file(paths, network_id)
+            return frozenset()
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert result.status == PES_LOOP_MAX_ROUNDS
         assert len(result.rounds) == 3
 
@@ -109,21 +153,33 @@ class TestRunPESLoop(object):
     def test_converges_when_every_candidate_is_computed(self, tmp_path, monkeypatch, config):
         """Once QM exists for every barriered channel, the loop stops on its own."""
         _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
-        result = run_pes_loop(config, project_directory=str(tmp_path),
-                              qm_runner=lambda candidates, paths, cfg, network_id:
-                                  frozenset(c.ts_label for c in candidates))
+
+        def _runner(candidates, paths, cfg, network_id):
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert result.status == PES_LOOP_CONVERGED
         assert len(result.rounds) == 2
 
     def test_a_diagram_is_drawn_every_round(self, tmp_path, monkeypatch, config):
-        """The whole point: a picture per round, each from that round's own network."""
-        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
-        result = run_pes_loop(config, project_directory=str(tmp_path),
-                              qm_runner=lambda candidates, paths, cfg, network_id:
-                                  frozenset(c.ts_label for c in candidates))
+        """The whole point: a picture per round, each from that round's own FRESHLY EXPLORED
+        network -- not the pre-explore input, and not another round's output. Drawing from the
+        input instead of the explored network is exactly the bug this feature exists to remove
+        (byte-identical diagrams across runs even when a saddle point converged)."""
+        calls, drawn = _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+
+        def _runner(candidates, paths, cfg, network_id):
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert len(result.rounds) == 2
         for record in result.rounds:
             assert record.diagram_path is not None
             assert os.path.basename(record.diagram_path) == 'pes_diagram.png'
+        assert drawn == ['/abs/explored_round0.py', '/abs/explored_round1.py']
+        assert drawn != calls
 
     def test_barrierless_channels_are_never_queued(self, tmp_path, monkeypatch, config):
         """The F21 gate, asserted end to end rather than only at the unit level."""
@@ -132,15 +188,19 @@ class TestRunPESLoop(object):
 
         def _runner(candidates, paths, cfg, network_id):
             queued.extend(c.family for c in candidates)
+            _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates)
 
         run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert 'R_Recombination' not in queued
+        assert '1,2_Insertion_CO' in queued
 
     def test_no_qm_runner_explores_and_draws_only(self, tmp_path, monkeypatch, config):
-        """The honest behaviour without a configured runner: one round, a diagram, no crash."""
+        """The honest behaviour without a configured runner: one round, a diagram, no crash -- and
+        a status distinct from an operational stall, per the ruling on concern 4."""
         _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
         result = run_pes_loop(config, project_directory=str(tmp_path))
+        assert result.status == PES_LOOP_DIAGRAM_ONLY
         assert len(result.rounds) == 1
         assert result.rounds[0].diagram_path is not None
 
@@ -150,3 +210,72 @@ class TestRunPESLoop(object):
         result = run_pes_loop(config, project_directory=str(tmp_path))
         assert result.status == 'failed'
         assert result.reason
+
+    def test_round_1_explores_the_hybrid_path_not_the_original_network(self, tmp_path, monkeypatch,
+                                                                        config):
+        """Round 1 must explore the QM-informed hybrid network qm_runner wrote, not re-explore
+        round 0's original input -- otherwise this is N re-explorations of one file, never a loop
+        (Critical 1)."""
+        calls, _ = _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+
+        def _runner(candidates, paths, cfg, network_id):
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert calls[0] == '/abs/network1_1.py'
+        expected_round1_path = hybrid_network_path(round_paths(str(tmp_path), 0),
+                                                    'explored_round0')
+        assert calls[1] == expected_round1_path
+        assert calls[1] != calls[0]
+
+    def test_qm_runner_receives_the_explored_networks_id(self, tmp_path, monkeypatch, config):
+        """qm_runner must be handed the id of the network THIS round explored, not the loop's
+        static input path's id -- ruling C4 exists precisely so a wrong id cannot misnamespace ARC
+        jobs (Critical 1)."""
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        received = []
+
+        def _runner(candidates, paths, cfg, network_id):
+            received.append(network_id)
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert received[0] == 'explored_round0'
+        assert received[0] != 'network1_1'
+
+    def test_adopted_ts_labels_seed_removes_that_ts_from_round_0_candidates(self, tmp_path,
+                                                                             monkeypatch, config):
+        """C1: TS labels adopted from an earlier T3 project must be treated as already computed
+        before round 0 ever runs, not just before some later round -- there was previously zero
+        coverage of this ruling at all."""
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+        queued = []
+
+        def _runner(candidates, paths, cfg, network_id):
+            queued.extend(c.ts_label for c in candidates)
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner,
+                    adopted_ts_labels=frozenset({'TS0'}))
+        assert 'TS0' not in queued
+        assert 'TS1' in queued
+
+    def test_a_missing_hybrid_file_fails_loudly_instead_of_a_bare_traceback(self, tmp_path,
+                                                                             monkeypatch, config):
+        """qm_runner's contract is to write the round's hybrid network file; if it doesn't, that
+        must surface as a PES_LOOP_FAILED round with a stated reason, not a FileNotFoundError
+        escaping from round N after round N-1 already spent real ARC time (Important 3)."""
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+
+        def _runner(candidates, paths, cfg, network_id):
+            # Deliberately does NOT write the hybrid file, breaking its contract.
+            return frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert result.status == PES_LOOP_FAILED
+        assert len(result.rounds) == 2
+        assert result.rounds[-1].status == PES_LOOP_FAILED
+        assert 'hybrid' in result.reason.lower()

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import os
+import tempfile
 
 import pytest
 
@@ -41,9 +42,11 @@ def _stub_explorer(monkeypatch, families, fail=False):
     - The exploration stub records the ``network_path`` it was called with (in ``calls``, in call
       order), so a test can pin that round 1 explores round 0's hybrid output rather than
       re-exploring round 0's original input.
-    - Each call returns a DISTINCT output path (``/abs/explored_round{N}.py``), and the parse stub
-      derives ``network_id`` from that path's stem exactly as the real ``parse_pdep_network_file``
-      does (``Path(path).stem`` -- ``t3/pdep/parser.py:729``). This means a loop that ever passes
+    - Each call returns a DISTINCT, real (on-disk, in a scratch temp dir) output path named
+      ``explored_round{N}.py``, and the parse stub derives ``network_id`` from that path's stem
+      exactly as the real ``parse_pdep_network_file`` does (``Path(path).stem`` --
+      ``t3/pdep/parser.py:729``). The file must actually exist because ``run_pes_loop`` checks for
+      it at the top of every round after the first (Important 4). This means a loop that ever passes
       the wrong network id to ``qm_runner`` or draws from the wrong path is directly observable,
       not masked by every round looking identical.
 
@@ -73,6 +76,7 @@ def _stub_explorer(monkeypatch, families, fail=False):
 
     calls = []
     drawn = []
+    explore_dir = tempfile.mkdtemp()
 
     def _fake_explore(*, network_path, config, logger=None):
         calls.append(network_path)
@@ -80,7 +84,13 @@ def _stub_explorer(monkeypatch, families, fail=False):
             return PDepExplorationResult(network_id=base_network.network_id,
                                          status=EXPLORATION_STATUS_FAILED,
                                          reasons=('the explorer adapter crashed',))
-        output_path = f'/abs/explored_round{len(calls) - 1}.py'
+        # A real explore_pdep_network writes a real file to disk; the file-existence guard at the
+        # top of every round after the first (t3.pdep.pes_loop.run_pes_loop) depends on that, so
+        # this stub must too -- a bare fabricated path string is not enough once a round is
+        # allowed to re-explore its own prior output (Important 4) rather than always advancing to
+        # a hybrid file a separate helper (_touch_hybrid_file) creates.
+        output_path = os.path.join(explore_dir, f'explored_round{len(calls) - 1}.py')
+        open(output_path, 'w').close()
         return PDepExplorationResult(network_id=base_network.network_id,
                                      status=EXPLORATION_STATUS_SUCCEEDED,
                                      network_paths=(output_path,))
@@ -178,7 +188,8 @@ class TestRunPESLoop(object):
         for record in result.rounds:
             assert record.diagram_path is not None
             assert os.path.basename(record.diagram_path) == 'pes_diagram.png'
-        assert drawn == ['/abs/explored_round0.py', '/abs/explored_round1.py']
+        assert [os.path.basename(path) for path in drawn] == \
+            ['explored_round0.py', 'explored_round1.py']
         assert drawn != calls
 
     def test_barrierless_channels_are_never_queued(self, tmp_path, monkeypatch, config):
@@ -279,3 +290,63 @@ class TestRunPESLoop(object):
         assert len(result.rounds) == 2
         assert result.rounds[-1].status == PES_LOOP_FAILED
         assert 'hybrid' in result.reason.lower()
+
+    def test_a_round_that_converges_nothing_does_not_advance_to_a_hybrid_file_never_written(
+            self, tmp_path, monkeypatch, config):
+        """A round whose qm_runner converges nothing correctly writes no hybrid file (its
+        empty-convergence contract -- see t3.pdep.pes_qm.arc_qm_runner). The loop must re-explore
+        that round's own explored network next round rather than advance current_network_path to
+        a hybrid file that was never written -- otherwise the next round's file-existence guard
+        blames qm_runner for breaking a contract it never had, turning an honest stall into a
+        bogus PES_LOOP_FAILED (Important 4)."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               termination={'max_rounds': 2, 'stop_when_no_new_ts': False})
+
+        path_reactions = (PDepPathReaction(label='reaction0', reactants=('A',), products=('B',),
+                                           transition_state='TS0', kinetics_type='Arrhenius',
+                                           kinetics_comment='family: 1,2_Insertion_CO'),)
+        base_network = PDepNetwork(network_id='network1_1', path='/abs/network1_1.py', label=None,
+                                   species_labels=('A', 'B'), transition_state_labels=('TS0',),
+                                   path_reactions=path_reactions, isomers=(), reactant_channels=(),
+                                   product_channels=())
+
+        calls = []
+        explored_paths = []
+
+        def _fake_explore(*, network_path, config, logger=None):
+            calls.append(network_path)
+            output_path = os.path.join(str(tmp_path), f'explored_round{len(calls) - 1}.py')
+            open(output_path, 'w').close()
+            explored_paths.append(output_path)
+            return PDepExplorationResult(network_id=base_network.network_id,
+                                         status=EXPLORATION_STATUS_SUCCEEDED,
+                                         network_paths=(output_path,))
+
+        def _fake_parse(path):
+            network_id = os.path.splitext(os.path.basename(path))[0]
+            return dataclasses.replace(base_network, network_id=network_id, path=path)
+
+        def _fake_draw(network_path, output_path):
+            open(output_path, 'w').close()
+
+        monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
+        monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file', _fake_parse)
+        monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram', _fake_draw)
+
+        def _runner(candidates, paths, cfg, network_id):
+            # Deliberately does NOT write the hybrid file -- this is the correct, contractual
+            # behaviour when nothing converged, not a bug being simulated.
+            return frozenset()
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert result.status == PES_LOOP_MAX_ROUNDS
+        assert len(result.rounds) == 2
+        assert all(round_record.status != PES_LOOP_FAILED for round_record in result.rounds)
+        # Round 1 must re-explore round 0's own explored output, not a hybrid file round 0's
+        # qm_runner never wrote.
+        assert calls[1] == explored_paths[0]
+        never_written_hybrid = hybrid_network_path(round_paths(str(tmp_path), 0),
+                                                    'explored_round0')
+        assert calls[1] != never_written_hybrid
+        assert not os.path.isfile(never_written_hybrid)

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -15,6 +15,20 @@ from t3.pdep.pes_rounds import round_paths
 from t3.schema import PESLoopConfig
 
 
+@pytest.fixture(autouse=True)
+def stub_me_sensitivity(monkeypatch):
+    """Stand in for the round's Arkane ME sensitivity analysis (t3.pdep.pes_sa), which this
+    module's loop-sequencing tests cannot run (Arkane stays out of scope here, exactly as the
+    explorer does). Returns finite evidence for every TS label the stub networks below can
+    declare, with strictly decreasing |coefficient| in file order so the default scope='sensitive'
+    ranking preserves the file order these tests were written against. Tests about the SA step
+    itself re-monkeypatch over this."""
+    def _fake_sa(*, network_path, sa_dir, method, timeout=None, logger=None):
+        return {f'TS{i}': (0.05 - 0.001 * i, (0.05 - 0.001 * i) * 8368.0) for i in range(10)}
+
+    monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
+
+
 @pytest.fixture
 def config():
     """A minimal config pointing at a network fixture.
@@ -506,3 +520,127 @@ class TestRunPESLoop(object):
         assert len(result.rounds) == 2
         assert result.rounds[0].status != PES_LOOP_FAILED
         assert calls[1] == written_hybrid_paths[0]
+
+
+class TestRoundMeSensitivityWiring(object):
+    """Defect 1: the loop's own ME SA is the source of the real sensitivity evidence every queued
+    transition state must carry. These tests re-monkeypatch over this module's autouse SA stub."""
+
+    def test_candidates_reach_the_runner_stamped_with_the_sas_own_evidence(self, tmp_path,
+                                                                           monkeypatch, config):
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+        sa_calls = []
+
+        def _fake_sa(*, network_path, sa_dir, method, timeout=None, logger=None):
+            sa_calls.append({'network_path': network_path, 'sa_dir': sa_dir, 'method': method,
+                             'timeout': timeout})
+            return {'TS0': (-3.0e-5, 0.25)}
+
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
+        received = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            received.extend(candidates)
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert len(sa_calls) == 1
+        # The SA runs on THIS round's freshly explored network, into this round's own SA dir,
+        # with the configured ME method and the explorer's own timeout budget.
+        assert os.path.basename(sa_calls[0]['network_path']) == 'explored_round0.py'
+        assert sa_calls[0]['sa_dir'] == round_paths(str(tmp_path), 0).sa
+        assert sa_calls[0]['method'] == config.pes.method
+        assert sa_calls[0]['timeout'] == config.pes.timeout
+        assert received[0].coefficient == -3.0e-5
+        assert received[0].delta_ln_k == 0.25
+
+    def test_a_failed_sa_fails_the_round_rather_than_inventing_evidence(self, tmp_path,
+                                                                        monkeypatch, config):
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+
+        def _fake_sa(*, network_path, sa_dir, method, timeout=None, logger=None):
+            raise ValueError('the master-equation sensitivity analysis failed')
+
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
+        runner_calls = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            runner_calls.append(candidates)
+            return frozenset(), frozenset()
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert result.status == PES_LOOP_FAILED
+        assert 'sensitivity' in result.reason
+        assert runner_calls == []
+
+    def test_a_candidate_without_evidence_is_skipped_not_queued(self, tmp_path, monkeypatch, config):
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+
+        def _fake_sa(*, network_path, sa_dir, method, timeout=None, logger=None):
+            return {'TS1': (-3.0e-5, 0.25)}  # nothing for TS0
+
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
+        queued = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            queued.extend(c.ts_label for c in candidates)
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert 'TS0' not in queued
+        assert 'TS1' in queued
+        skipped_labels = {s.label: s.reason for record in result.rounds for s in record.skipped}
+        assert 'reaction0' in skipped_labels
+        assert 'no finite sensitivity evidence' in skipped_labels['reaction0']
+
+    def test_no_candidate_with_evidence_fails_the_round(self, tmp_path, monkeypatch, config):
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity',
+                            lambda **kwargs: dict())
+        result = run_pes_loop(config, project_directory=str(tmp_path),
+                              qm_runner=lambda candidates, paths, cfg, network_id, adopted=None:
+                              (frozenset(), frozenset()))
+        assert result.status == PES_LOOP_FAILED
+        assert 'no finite sensitivity evidence' in result.reason
+
+    def test_scope_sensitive_ranks_by_the_sas_own_evidence_not_file_order(self, tmp_path,
+                                                                          monkeypatch):
+        """Before this fix, scope='sensitive' degraded to file order with a warning because the
+        standalone loop had no SA to rank by. It has one now, so the budget must go to the most
+        sensitive transition state, not the first one in the file."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               qm={'scope': 'sensitive', 'max_transition_states_per_round': 1},
+                               termination={'max_rounds': 1, 'stop_when_no_new_ts': False})
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+
+        def _fake_sa(*, network_path, sa_dir, method, timeout=None, logger=None):
+            return {'TS0': (1.0e-6, 0.008), 'TS1': (-9.0e-5, 0.75)}
+
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
+        queued = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            queued.extend(c.ts_label for c in candidates)
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert queued == ['TS1']
+
+    def test_diagram_only_runs_no_sa_at_all(self, tmp_path, monkeypatch, config):
+        """qm_runner=None spends no QM and captures nothing, so there is no evidence to justify
+        and no Arkane SA to pay for."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+        sa_calls = []
+
+        def _fake_sa(**kwargs):
+            sa_calls.append(kwargs)
+            return {}
+
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
+        result = run_pes_loop(config, project_directory=str(tmp_path))
+        assert result.status == PES_LOOP_DIAGRAM_ONLY
+        assert sa_calls == []

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -357,9 +357,10 @@ class TestRunPESLoop(object):
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
         adopt_calls = []
 
-        def _fake_adopt(from_t3_projects, network_id, level_of_theory, path_reaction_labels_by_ts_label):
+        def _fake_adopt(from_t3_projects, network_id, level_of_theory,
+                        path_reaction_labels_by_ts_label, freq_level=None):
             adopt_calls.append((tuple(from_t3_projects), network_id, level_of_theory,
-                                path_reaction_labels_by_ts_label))
+                                path_reaction_labels_by_ts_label, freq_level))
             return {'TS0': '/fake/prior/TS0.py'}
 
         monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm', _fake_adopt)
@@ -379,7 +380,7 @@ class TestRunPESLoop(object):
 
         run_pes_loop(reuse_config, project_directory=str(tmp_path), qm_runner=_runner)
         assert len(adopt_calls) == 1
-        call_projects, call_network_id, call_level, call_labels = adopt_calls[0]
+        call_projects, call_network_id, call_level, call_labels, call_freq = adopt_calls[0]
         assert call_projects == ('/prior/project',)
         assert call_network_id == 'network1_1'
         assert call_level == reuse_config.qm.sp_level == 'ccsd(t)-f12/cc-pvtz-f12'
@@ -387,6 +388,10 @@ class TestRunPESLoop(object):
         # structures, direction-insensitive), never a positional-label map -- reaction and TS
         # labels are both positional in Arkane-written files and cannot identify a channel.
         assert call_labels == {'TS0': (('CC|m1',), ('C|m1',)), 'TS1': (('CCCC|m1',), ('CCC|m1',))}
+        # The frequency level must reach adoption too: ARC settles its model_chemistry string
+        # from the FREQUENCY level's scale factor, so without it every prior capture made under a
+        # composite sp/freq pair is refused on a mismatch that does not exist.
+        assert call_freq == reuse_config.qm.freq_level
         assert 'TS0' not in queued
         assert 'TS1' in queued
 
@@ -519,7 +524,8 @@ class TestRunPESLoop(object):
         fold the adopted artifact into a hybrid network."""
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
-        def _fake_adopt(from_t3_projects, network_id, level_of_theory, path_reaction_labels_by_ts_label):
+        def _fake_adopt(from_t3_projects, network_id, level_of_theory,
+                        path_reaction_labels_by_ts_label, freq_level=None):
             return {'TS0': '/fake/prior/TS0.py'}
 
         monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm', _fake_adopt)
@@ -549,7 +555,8 @@ class TestRunPESLoop(object):
         ignore the hybrid this round demonstrably wrote."""
         calls, _drawn = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
-        def _fake_adopt(from_t3_projects, network_id, level_of_theory, path_reaction_labels_by_ts_label):
+        def _fake_adopt(from_t3_projects, network_id, level_of_theory,
+                        path_reaction_labels_by_ts_label, freq_level=None):
             return {'TS0': '/fake/prior/TS0.py'}
 
         monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm', _fake_adopt)
@@ -735,7 +742,7 @@ class TestCumulativeAdoptedPlumbing(object):
         _stub_explorer(monkeypatch, tmp_path,
                        families=['1,2_Insertion_CO', '1,2_Insertion_CO', '1,2_Insertion_CO'])
         monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm',
-                            lambda *args: {'TS0': '/prior/capture/qm/TS0.py'})
+                            lambda *args, **kwargs: {'TS0': '/prior/capture/qm/TS0.py'})
         adopted_per_round = []
 
         def _runner(candidates, paths, cfg, network_id, adopted=None):

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -15,7 +15,7 @@ from t3.pdep.join import arc_ts_label
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
 from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_DIAGRAM_ONLY, PES_LOOP_FAILED,
                               PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES, PES_LOOP_STALLED,
-                              PESLoopResult, RoundRecord, _build_explorer_config,
+                              _build_explorer_config,
                               hybrid_network_path, run_pes_loop)
 from t3.pdep.pes_rounds import round_paths
 from t3.schema import PESLoopConfig

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -5,8 +5,10 @@ import os
 
 import pytest
 
+from t3.pdep.capture import captured_qm_artifact_path
 from t3.pdep.explorer.result import (EXPLORATION_STATUS_FAILED, EXPLORATION_STATUS_SUCCEEDED,
                                      PDepExplorationResult)
+from t3.pdep.join import arc_ts_label
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
 from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_DIAGRAM_ONLY, PES_LOOP_FAILED,
                               PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES, PES_LOOP_STALLED,
@@ -158,7 +160,7 @@ class TestRunPESLoop(object):
                                termination={'max_rounds': 3, 'stop_when_no_new_ts': False})
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             _touch_hybrid_file(paths, network_id)
             return frozenset(), frozenset(c.ts_label for c in candidates)
 
@@ -172,7 +174,7 @@ class TestRunPESLoop(object):
         'stalled' from 'max_rounds' (ruling C3)."""
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
         result = run_pes_loop(config, project_directory=str(tmp_path),
-                              qm_runner=lambda candidates, paths, cfg, network_id:
+                              qm_runner=lambda candidates, paths, cfg, network_id, adopted=None:
                               (frozenset(), frozenset(c.ts_label for c in candidates)))
         assert result.status == PES_LOOP_STALLED
         assert len(result.rounds) == 1
@@ -181,7 +183,7 @@ class TestRunPESLoop(object):
         """Once QM exists for every barriered channel, the loop stops on its own."""
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
@@ -196,7 +198,7 @@ class TestRunPESLoop(object):
         (byte-identical diagrams across runs even when a saddle point converged)."""
         calls, drawn = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
@@ -214,7 +216,7 @@ class TestRunPESLoop(object):
         queued = []
         _stub_explorer(monkeypatch, tmp_path, families=['R_Recombination', '1,2_Insertion_CO'])
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             queued.extend(c.family for c in candidates)
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
@@ -252,7 +254,7 @@ class TestRunPESLoop(object):
         must fail this test."""
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             offered = tuple(c.ts_label for c in candidates)
             assert offered == ('TS0', 'TS1')
             _touch_hybrid_file(paths, network_id)
@@ -279,7 +281,7 @@ class TestRunPESLoop(object):
         (Critical 1)."""
         calls, _ = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
@@ -297,7 +299,7 @@ class TestRunPESLoop(object):
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
         received = []
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             received.append(network_id)
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
@@ -314,7 +316,7 @@ class TestRunPESLoop(object):
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
         queued = []
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             queued.extend(c.ts_label for c in candidates)
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
@@ -371,7 +373,7 @@ class TestRunPESLoop(object):
         monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm',
                             lambda *a, **kw: adopt_calls.append((a, kw)) or {})
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
@@ -385,7 +387,7 @@ class TestRunPESLoop(object):
         escaping from round N after round N-1 already spent real ARC time (Important 3)."""
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             # Deliberately does NOT write the hybrid file, breaking its contract.
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
@@ -438,7 +440,7 @@ class TestRunPESLoop(object):
         monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file', _fake_parse)
         monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram', _fake_draw)
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             # Deliberately does NOT write the hybrid file -- this is the correct, contractual
             # behaviour when nothing converged, not a bug being simulated.
             return frozenset(), frozenset(c.ts_label for c in candidates)
@@ -644,3 +646,56 @@ class TestRoundMeSensitivityWiring(object):
         result = run_pes_loop(config, project_directory=str(tmp_path))
         assert result.status == PES_LOOP_DIAGRAM_ONLY
         assert sa_calls == []
+
+
+class TestQMSurvivesTheRoundBoundary(object):
+    """Defect 3: a TS converged in round N must reach round N+1's qm_runner as an adopted
+    artifact, so every round's hybrid carries the CUMULATIVE QM -- observed on this branch as
+    round 0 writing QM=[TS1,TS2]/ILT=[TS3] and round 1 writing QM=[TS3]/ILT=[TS1,TS2], with the
+    round-0 QM silently reverting to Arrhenius lines."""
+
+    def test_every_round_receives_the_cumulative_artifacts_as_adopted(self, tmp_path, monkeypatch):
+        """Three TSs: TS0 adopted from a prior project, TS1 converges in round 0, TS2 in round 1.
+        Round 0's runner must see the prior-project artifact; round 1's runner must ALSO see round
+        0's converged TS1, pointing at round 0's own capture (the originating capture, whose
+        verified manifest still exists), alongside the prior-project TS0."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               termination={'max_rounds': 3},
+                               reuse={'from_t3_projects': ['/prior/project']})
+        _stub_explorer(monkeypatch, tmp_path,
+                       families=['1,2_Insertion_CO', '1,2_Insertion_CO', '1,2_Insertion_CO'])
+        monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm',
+                            lambda *args: {'TS0': '/prior/capture/qm/TS0.py'})
+        adopted_per_round = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            adopted_per_round.append(dict(adopted))
+            _touch_hybrid_file(paths, network_id)
+            converged = frozenset({candidates[0].ts_label}) if candidates else frozenset()
+            return converged, frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert result.status == PES_LOOP_CONVERGED
+        assert len(adopted_per_round) == 2
+        assert adopted_per_round[0] == {'TS0': '/prior/capture/qm/TS0.py'}
+        round0_ts1_path = captured_qm_artifact_path(
+            round_paths(str(tmp_path), 0).capture, arc_ts_label('explored_round0', 'TS1'))
+        assert adopted_per_round[1] == {'TS0': '/prior/capture/qm/TS0.py',
+                                        'TS1': round0_ts1_path}
+
+    def test_a_runner_mutating_its_adopted_dict_cannot_corrupt_the_loops_own_record(
+            self, tmp_path, monkeypatch, config):
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+        adopted_per_round = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            adopted_per_round.append(dict(adopted))
+            adopted['INJECTED'] = '/nowhere.py'  # a hostile/buggy runner
+            _touch_hybrid_file(paths, network_id)
+            converged = frozenset({candidates[0].ts_label}) if candidates else frozenset()
+            return converged, frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert len(adopted_per_round) >= 2
+        assert 'INJECTED' not in adopted_per_round[1]

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -319,24 +319,33 @@ class TestRunPESLoop(object):
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
         adopt_calls = []
 
-        def _fake_adopt(from_t3_projects, network_id, level_of_theory):
-            adopt_calls.append((tuple(from_t3_projects), network_id, level_of_theory))
+        def _fake_adopt(from_t3_projects, network_id, level_of_theory, path_reaction_labels_by_ts_label):
+            adopt_calls.append((tuple(from_t3_projects), network_id, level_of_theory,
+                                path_reaction_labels_by_ts_label))
             return {'TS0': '/fake/prior/TS0.py'}
 
         monkeypatch.setattr('t3.pdep.pes_loop.adopt_prior_qm', _fake_adopt)
+        # Distinct sp_level from the default opt_level (mutation (e)): a fix that accidentally
+        # compared against opt_level rather than sp_level must fail this test.
         reuse_config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
                                           'bath_gas': {'He': 1.0}},
+                                     qm={'sp_level': 'ccsd(t)-f12/cc-pvtz-f12'},
                                      termination={'max_rounds': 3},
                                      reuse={'from_t3_projects': ['/prior/project']})
         queued = []
 
-        def _runner(candidates, paths, cfg, network_id):
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
             queued.extend(c.ts_label for c in candidates)
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         run_pes_loop(reuse_config, project_directory=str(tmp_path), qm_runner=_runner)
-        assert adopt_calls == [(('/prior/project',), 'network1_1', reuse_config.qm.sp_level)]
+        assert len(adopt_calls) == 1
+        call_projects, call_network_id, call_level, call_labels = adopt_calls[0]
+        assert call_projects == ('/prior/project',)
+        assert call_network_id == 'network1_1'
+        assert call_level == reuse_config.qm.sp_level == 'ccsd(t)-f12/cc-pvtz-f12'
+        assert call_labels == {'TS0': ('reaction0',), 'TS1': ('reaction1',)}
         assert 'TS0' not in queued
         assert 'TS1' in queued
 

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -1,6 +1,7 @@
 """Tests for t3.pdep.pes_loop."""
 
 import dataclasses
+import logging
 import os
 
 import pytest
@@ -436,7 +437,9 @@ class TestRunPESLoop(object):
         base_network = PDepNetwork(network_id='network1_1', path='/abs/network1_1.py', label=None,
                                    species_labels=('A', 'B'), transition_state_labels=('TS0',),
                                    path_reactions=path_reactions, isomers=(), reactant_channels=(),
-                                   product_channels=())
+                                   product_channels=(),
+                                   species_structures={'A': _alkane_adjlist(1),
+                                                       'B': _alkane_adjlist(2)})
 
         calls = []
         explored_paths = []
@@ -872,3 +875,100 @@ class TestRenumberedNetworksKeepQMOnTheRightChannel(object):
         round0_artifact = captured_qm_artifact_path(
             round_paths(str(tmp_path), 0).capture, arc_ts_label('explored_round0', 'TS0'))
         assert adopted_per_round[1] == {'TS1': round0_artifact}
+
+
+class TestUnkeyableNetworks(object):
+    """A network whose declared transition states cannot be structurally keyed AT ALL would
+    otherwise re-submit the same transition states to ARC every round until max_rounds -- up to a
+    full budget of duplicate QM spend -- with only a log line to explain it. That is a diagnosable
+    fault of the network, so the round fails with the unkeyable labels in its reason."""
+
+    def test_a_fully_unkeyable_network_fails_the_round_with_the_labels_in_the_reason(
+            self, tmp_path, monkeypatch, config):
+        path_reactions = (PDepPathReaction(label='reaction0', reactants=('A',), products=('B',),
+                                           transition_state='TS0', kinetics_type='Arrhenius',
+                                           kinetics_comment='family: 1,2_Insertion_CO'),)
+        # No species_structures at all: nothing can be keyed.
+        base_network = PDepNetwork(network_id='network1_1', path='/abs/network1_1.py', label=None,
+                                   species_labels=('A', 'B'), transition_state_labels=('TS0',),
+                                   path_reactions=path_reactions, isomers=(), reactant_channels=(),
+                                   product_channels=())
+
+        def _fake_explore(*, network_path, config, logger=None):
+            output_path = os.path.join(str(tmp_path), 'explored_round0.py')
+            open(output_path, 'w').close()
+            return PDepExplorationResult(network_id='network1_1',
+                                         status=EXPLORATION_STATUS_SUCCEEDED,
+                                         network_paths=(output_path,))
+
+        monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
+        monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file',
+                            lambda path: dataclasses.replace(base_network, path=path))
+        monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram',
+                            lambda network_path, output_path: open(output_path, 'w').close())
+        runner_calls = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            runner_calls.append(candidates)
+            return frozenset(), frozenset()
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert result.status == PES_LOOP_FAILED
+        assert len(result.rounds) == 1
+        assert "'TS0'" in result.reason
+        assert 'structural channel identity' in result.reason
+        assert 're-submit the same transition states' in result.reason
+        # Not a single ARC submission was bought with the doomed carry.
+        assert runner_calls == []
+
+    def test_a_partially_unkeyable_converged_ts_is_not_carried_and_says_so(self, tmp_path,
+                                                                           monkeypatch, config,
+                                                                           caplog):
+        """One keyable channel and one unkeyable one: the round proceeds (partial keying is not a
+        fault), but a CONVERGED unkeyable transition state is loudly not carried -- it will be
+        re-decided next round rather than risk a wrong-saddle-point attribution."""
+        adj = {'A0': _alkane_adjlist(1), 'B0': _alkane_adjlist(2)}
+        path_reactions = (
+            PDepPathReaction(label='reaction0', reactants=('A0',), products=('B0',),
+                             transition_state='TS0', kinetics_type='Arrhenius',
+                             kinetics_comment='family: 1,2_Insertion_CO'),
+            PDepPathReaction(label='reaction1', reactants=('A1',), products=('B1',),
+                             transition_state='TS1', kinetics_type='Arrhenius',
+                             kinetics_comment='family: 1,2_Insertion_CO'),
+        )
+        base_network = PDepNetwork(network_id='network1_1', path='/abs/network1_1.py', label=None,
+                                   species_labels=('A0', 'B0', 'A1', 'B1'),
+                                   transition_state_labels=('TS0', 'TS1'),
+                                   path_reactions=path_reactions, isomers=(), reactant_channels=(),
+                                   product_channels=(), species_structures=adj)
+
+        calls = []
+
+        def _fake_explore(*, network_path, config, logger=None):
+            calls.append(network_path)
+            output_path = os.path.join(str(tmp_path), f'explored_round{len(calls) - 1}.py')
+            open(output_path, 'w').close()
+            return PDepExplorationResult(network_id='network1_1',
+                                         status=EXPLORATION_STATUS_SUCCEEDED,
+                                         network_paths=(output_path,))
+
+        monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
+        monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file',
+                            lambda path: dataclasses.replace(base_network, path=path))
+        monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram',
+                            lambda network_path, output_path: open(output_path, 'w').close())
+        adopted_per_round = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            adopted_per_round.append(dict(adopted))
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_loop'):
+            run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        # TS1 (unkeyable) converged in round 0 but must not be carried: round 1's adopted holds
+        # only the keyable TS0's artifact, and the refusal was loud.
+        assert len(adopted_per_round) >= 2
+        assert set(adopted_per_round[1]) == {'TS0'}
+        assert "'TS1'" in caplog.text
+        assert 'cannot be carried across rounds' in caplog.text

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -56,7 +56,7 @@ def _alkane_adjlist(n_carbons: int) -> str:
     return Molecule().from_smiles('C' * n_carbons).to_adjacency_list()
 
 
-def _stub_explorer(monkeypatch, tmp_path, families, fail=False):
+def _stub_explorer(monkeypatch, tmp_path, families, fail=False, fail_from=None):
     """
     Patch ``explore_pdep_network``, ``parse_pdep_network_file``, and ``draw_pes_diagram`` at the
     names bound in ``t3.pdep.pes_loop``, so ``run_pes_loop`` can be tested without Arkane.
@@ -117,7 +117,9 @@ def _stub_explorer(monkeypatch, tmp_path, families, fail=False):
 
     def _fake_explore(*, network_path, config, logger=None):
         calls.append(network_path)
-        if fail:
+        # ``fail_from`` fails a LATER round rather than round 0, so a failure with good prior
+        # rounds behind it can be exercised at all.
+        if fail or (fail_from is not None and len(calls) - 1 >= fail_from):
             return PDepExplorationResult(network_id=base_network.network_id,
                                          status=EXPLORATION_STATUS_FAILED,
                                          reasons=('the explorer adapter crashed',))
@@ -418,6 +420,31 @@ class TestRunPESLoop(object):
         assert len(result.rounds) == 2
         assert result.rounds[-1].status == PES_LOOP_FAILED
         assert 'hybrid' in result.reason.lower()
+        # The failed round produced nothing, but round 0's explored network and drawn diagram are
+        # real and remain this run's best result: a failure must not throw them away.
+        assert result.final_network_path == result.rounds[0].network_path
+        assert result.final_diagram_path == result.rounds[0].diagram_path
+        assert result.final_diagram_path is not None
+
+    def test_a_failed_explore_at_round_1_keeps_round_0s_network_and_diagram(self, tmp_path,
+                                                                            monkeypatch, config):
+        """The exploration-failed branch must be as careful with prior rounds' artifacts as the
+        missing-hybrid branch above. Reporting ``None`` for both would make ``PES.py`` log
+        'Final network: None' for a run that in fact explored and drew a perfectly good round 0."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'], fail_from=1)
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert result.status == PES_LOOP_FAILED
+        assert len(result.rounds) == 2
+        assert result.rounds[1].status == PES_LOOP_FAILED
+        assert result.final_network_path == result.rounds[0].network_path
+        assert result.final_network_path is not None
+        assert result.final_diagram_path == result.rounds[0].diagram_path
+        assert result.final_diagram_path is not None
 
     def test_a_round_that_converges_nothing_does_not_advance_to_a_hybrid_file_never_written(
             self, tmp_path, monkeypatch, config):

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -1011,3 +1011,133 @@ class TestUnkeyableNetworks(object):
         assert set(adopted_per_round[1]) == {'TS0'}
         assert "'TS1'" in caplog.text
         assert 'cannot be carried across rounds' in caplog.text
+
+
+class TestTheFinalRoundsQMReachesTheOutput(object):
+    """The whole branch exists to make the emitted PES diagram carry barriers that were actually
+    computed. The last permitted round's hybrid network -- the one carrying that round's QM -- is
+    written AFTER that round's own diagram was drawn from its pre-QM explored network, so
+    returning the last RoundRecord's paths silently reverts the headline output to RMG estimates
+    whenever the final round is productive. With max_rounds: 1 -- the first thing a user runs --
+    that is EVERY run."""
+
+    def test_max_rounds_1_returns_the_qm_informed_network_not_the_pre_qm_one(self, tmp_path,
+                                                                            monkeypatch):
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               termination={'max_rounds': 1, 'stop_when_no_new_ts': False})
+        calls, drawn = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+        hybrid_paths = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            hybrid_paths.append(_touch_hybrid_file(paths, network_id))
+            return (frozenset(c.ts_label for c in candidates),
+                    frozenset(c.ts_label for c in candidates))
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+
+        assert result.status == PES_LOOP_MAX_ROUNDS
+        # One QM round only -- the final pass must not charge another.
+        assert len(result.rounds) == 1
+        assert len(hybrid_paths) == 1
+        # The final pass explored the hybrid the single round wrote...
+        assert calls == ['/abs/network1_1.py', hybrid_paths[0]]
+        # ...and the returned network/diagram are that re-exploration's, not the round's own.
+        assert result.final_network_path != result.rounds[0].network_path
+        assert result.final_diagram_path != result.rounds[0].diagram_path
+        assert drawn[-1] == result.final_network_path
+        assert os.path.isfile(result.final_diagram_path)
+
+    def test_the_final_draw_pass_launches_no_further_quantum_chemistry(self, tmp_path,
+                                                                       monkeypatch):
+        """The final exploration is a draw, not a round: no ME SA, no qm_runner call, and no ARC
+        project directory for the pass's own round index."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               termination={'max_rounds': 2, 'stop_when_no_new_ts': False})
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'] * 3)
+        sa_calls, runner_calls = [], []
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity',
+                            lambda **kwargs: sa_calls.append(kwargs['network_path'])
+                            or {f'TS{i}': (0.05 - 0.001 * i, 400.0) for i in range(10)})
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            # Converges one TS per round, so neither round exhausts the candidates and the loop
+            # really does stop on the budget rather than on convergence.
+            runner_calls.append(network_id)
+            _touch_hybrid_file(paths, network_id)
+            return (frozenset(c.ts_label for c in candidates[:1]),
+                    frozenset(c.ts_label for c in candidates))
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+
+        assert result.status == PES_LOOP_MAX_ROUNDS
+        assert len(runner_calls) == 2, 'the final draw pass must not call the QM runner'
+        assert len(sa_calls) == 2, 'the final draw pass must not run a master-equation SA'
+        assert not os.path.isdir(round_paths(str(tmp_path), 2).arc_project)
+
+    def test_a_final_round_that_converged_nothing_is_not_re_explored(self, tmp_path, monkeypatch):
+        """No hybrid was written, so there is nothing QM-informed to draw from and the extra
+        exploration would be pure waste (and would blame qm_runner for a file it correctly never
+        wrote)."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               termination={'max_rounds': 2, 'stop_when_no_new_ts': False})
+        calls, _ = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+        result = run_pes_loop(
+            config, project_directory=str(tmp_path),
+            qm_runner=lambda candidates, paths, cfg, network_id, adopted=None:
+            (frozenset(), frozenset(c.ts_label for c in candidates)))
+        assert result.status == PES_LOOP_MAX_ROUNDS
+        assert len(calls) == 2, 'no final draw pass without a hybrid network to draw from'
+        assert result.final_network_path == result.rounds[-1].network_path
+
+    def test_a_failed_final_re_exploration_keeps_the_last_rounds_own_result(self, tmp_path,
+                                                                           monkeypatch):
+        """Fail open, loudly: the bonus pass must never turn a run whose rounds all worked into a
+        run that reports nothing."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               termination={'max_rounds': 1, 'stop_when_no_new_ts': False})
+        # fail_from=1: round 0 explores fine, the final draw pass (the 2nd explore call) fails.
+        calls, _ = _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'],
+                                  fail_from=1)
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            _touch_hybrid_file(paths, network_id)
+            return (frozenset(c.ts_label for c in candidates),
+                    frozenset(c.ts_label for c in candidates))
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+
+        assert result.status == PES_LOOP_MAX_ROUNDS
+        assert len(calls) == 2
+        assert result.final_network_path == result.rounds[-1].network_path
+        assert result.final_diagram_path == result.rounds[-1].diagram_path
+        assert 'predate' in result.reason
+
+
+class TestDiagramFailuresAreNeverFatal(object):
+    """t3.pdep.explorer.arkane._draw_pes_diagram treats diagram generation as strictly
+    best-effort: the diagram describes the result, it is not part of it. The loop must hold the
+    same contract -- a matplotlib backend fault or a read-only output directory has nothing to do
+    with whether the exploration succeeded."""
+
+    @pytest.mark.parametrize('error', [RuntimeError('no matplotlib backend'),
+                                       OSError('read-only file system'),
+                                       ValueError('a species carries no E0')])
+    def test_a_non_valueerror_diagram_failure_does_not_abort_the_loop(self, tmp_path, monkeypatch,
+                                                                     config, error):
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+
+        def _explode(network_path, output_path):
+            raise error
+
+        monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram', _explode)
+        result = run_pes_loop(config, project_directory=str(tmp_path))
+
+        assert result.status == PES_LOOP_DIAGRAM_ONLY
+        assert result.rounds[0].diagram_path is None
+        assert result.final_diagram_path is None
+        assert result.final_network_path is not None, \
+            'the exploration succeeded; only the drawing failed'

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -699,3 +699,64 @@ class TestQMSurvivesTheRoundBoundary(object):
         run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
         assert len(adopted_per_round) >= 2
         assert 'INJECTED' not in adopted_per_round[1]
+
+
+class TestSensitivityFloor(object):
+    """qm.min_delta_ln_k mirrors T3's in-run pdep_min_delta_ln_k: a below-floor (e.g. measured
+    zero) response never buys QM, and 'every remaining channel below the floor' is a measured
+    terminal outcome, not a fault."""
+
+    def test_a_below_floor_candidate_is_never_queued(self, tmp_path, monkeypatch, config):
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+
+        def _fake_sa(*, network_path, sa_dir, method, timeout=None, logger=None):
+            return {'TS0': (0.0, 0.0), 'TS1': (-3.0e-5, 0.25)}
+
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
+        queued = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            queued.extend(c.ts_label for c in candidates)
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert 'TS0' not in queued
+        assert 'TS1' in queued
+        reasons = {s.label: s.reason for record in result.rounds for s in record.skipped}
+        assert 'below the min_delta_ln_k floor' in reasons['reaction0']
+
+    def test_all_below_floor_at_round_0_is_no_candidates_not_failed(self, tmp_path, monkeypatch,
+                                                                    config):
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity',
+                            lambda **kwargs: {'TS0': (0.0, 0.0)})
+        runner_calls = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            runner_calls.append(candidates)
+            return frozenset(), frozenset()
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert result.status == PES_LOOP_NO_CANDIDATES
+        assert runner_calls == []
+        assert 'below the min_delta_ln_k floor' in result.rounds[0].skipped[0].reason
+
+    def test_all_below_floor_after_progress_is_converged(self, tmp_path, monkeypatch, config):
+        """Round 0 converges the above-floor channel; round 1's only remaining channel measures
+        below the floor -- a measured 'done', reported as convergence with the skip recorded."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+
+        def _fake_sa(*, network_path, sa_dir, method, timeout=None, logger=None):
+            return {'TS0': (-3.0e-5, 0.25), 'TS1': (0.0, 0.0)}
+
+        monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert result.status == PES_LOOP_CONVERGED
+        assert [record.status for record in result.rounds] == ['continuing', PES_LOOP_CONVERGED]
+        assert sorted(result.rounds[0].queued_ts_labels) == ['TS0']

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -631,27 +631,32 @@ class TestRoundMeSensitivityWiring(object):
     def test_scope_sensitive_ranks_by_the_sas_own_evidence_not_file_order(self, tmp_path,
                                                                           monkeypatch):
         """Before this fix, scope='sensitive' degraded to file order with a warning because the
-        standalone loop had no SA to rank by. It has one now, so the budget must go to the most
-        sensitive transition state, not the first one in the file."""
+        standalone loop had no SA to rank by. It has one now: with four candidates and a budget
+        of two, the runner must receive the two largest-|coefficient| ones, ordered by descending
+        |coefficient| -- a full ranking, not a two-candidate argmax, and nothing like file order
+        (which would have offered TS0 then TS1)."""
         config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
                                     'bath_gas': {'He': 1.0}},
-                               qm={'scope': 'sensitive', 'max_transition_states_per_round': 1},
+                               qm={'scope': 'sensitive', 'max_transition_states_per_round': 2},
                                termination={'max_rounds': 1, 'stop_when_no_new_ts': False})
-        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+        _stub_explorer(monkeypatch, tmp_path,
+                       families=['1,2_Insertion_CO'] * 4)
 
         def _fake_sa(*, network_path, sa_dir, method, timeout=None, logger=None):
-            return {'TS0': (1.0e-6, 0.008), 'TS1': (-9.0e-5, 0.75)}
+            # Signs deliberately mixed: the ranking is by |coefficient|, not by signed value.
+            return {'TS0': (1.0e-6, 0.008), 'TS1': (-9.0e-5, 0.75),
+                    'TS2': (5.0e-5, 0.42), 'TS3': (-2.0e-6, 0.017)}
 
         monkeypatch.setattr('t3.pdep.pes_loop.run_round_me_sensitivity', _fake_sa)
-        queued = []
+        offered = []
 
         def _runner(candidates, paths, cfg, network_id, adopted=None):
-            queued.extend(c.ts_label for c in candidates)
+            offered.append(tuple(c.ts_label for c in candidates))
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
         run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
-        assert queued == ['TS1']
+        assert offered == [('TS1', 'TS2')]
 
     def test_diagram_only_runs_no_sa_at_all(self, tmp_path, monkeypatch, config):
         """qm_runner=None spends no QM and captures nothing, so there is no evidence to justify
@@ -669,11 +674,12 @@ class TestRoundMeSensitivityWiring(object):
         assert sa_calls == []
 
 
-class TestQMSurvivesTheRoundBoundary(object):
-    """Defect 3: a TS converged in round N must reach round N+1's qm_runner as an adopted
-    artifact, so every round's hybrid carries the CUMULATIVE QM -- observed on this branch as
-    round 0 writing QM=[TS1,TS2]/ILT=[TS3] and round 1 writing QM=[TS3]/ILT=[TS1,TS2], with the
-    round-0 QM silently reverting to Arrhenius lines."""
+class TestCumulativeAdoptedPlumbing(object):
+    """Defect 3's LOOP-SIDE plumbing, pinned against runner doubles: what run_pes_loop passes as
+    `adopted` each round, and that a runner cannot corrupt the loop's own record. Whether the
+    artifacts actually survive into a later round's hybrid is deliberately NOT claimed here --
+    that end-to-end fact is pinned against the real capture and hybrid writer in
+    test_pes_loop_integration.py."""
 
     def test_every_round_receives_the_cumulative_artifacts_as_adopted(self, tmp_path, monkeypatch):
         """Three TSs: TS0 adopted from a prior project, TS1 converges in round 0, TS2 in round 1.

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -384,10 +384,13 @@ class TestRunPESLoop(object):
         assert call_projects == ('/prior/project',)
         assert call_network_id == 'network1_1'
         assert call_level == reuse_config.qm.sp_level == 'ccsd(t)-f12/cc-pvtz-f12'
-        # The 4th argument is the seed network's STRUCTURAL channel-key map (canonical species
-        # structures, direction-insensitive), never a positional-label map -- reaction and TS
-        # labels are both positional in Arkane-written files and cannot identify a channel.
-        assert call_labels == {'TS0': (('CC|m1',), ('C|m1',)), 'TS1': (('CCCC|m1',), ('CCC|m1',))}
+        # The 4th argument is the seed network's ADOPTION channel-key map: the structural channel
+        # key (canonical species structures, direction-insensitive) QUALIFIED BY THE RMG FAMILY,
+        # never a positional-label map -- reaction and TS labels are both positional in
+        # Arkane-written files and cannot identify a channel, and the endpoints alone cannot
+        # identify a PATHWAY across two unrelated files.
+        assert call_labels == {'TS0': ((('CC|m1',), ('C|m1',)), '1,2_Insertion_CO'),
+                               'TS1': ((('CCCC|m1',), ('CCC|m1',)), '1,2_Insertion_CO')}
         # The frequency level must reach adoption too: ARC settles its model_chemistry string
         # from the FREQUENCY level's scale factor, so without it every prior capture made under a
         # composite sp/freq pair is refused on a mismatch that does not exist.

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -218,6 +218,39 @@ class TestRunPESLoop(object):
         assert len(result.rounds) == 1
         assert result.rounds[0].diagram_path is not None
 
+    def test_diagram_only_branch_reports_every_offered_candidate_as_queued(self, tmp_path,
+                                                                           monkeypatch, config):
+        """N3 (round 3): qm_runner=None never runs a runner at all, so nothing CAN be dropped --
+        the diagram-only branch's queued_ts_labels must report every candidate that was offered.
+        Mutation M6 (reverting this branch to queued_ts_labels=()) must fail this test."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+        result = run_pes_loop(config, project_directory=str(tmp_path))
+        assert result.rounds[0].queued_ts_labels == ('TS0', 'TS1')
+
+    def test_queued_ts_labels_reflects_what_the_runner_actually_queued_not_what_was_offered(
+            self, tmp_path, monkeypatch, config):
+        """N3 (round 3): every qm_runner double elsewhere in this file returns the offered set
+        verbatim as its queued half, which cannot distinguish RoundRecord.queued_ts_labels from
+        the offered set the loop built before the runner ran. This runner drops one offered
+        candidate from what it reports as queued (as build_arc_input legitimately can, for a
+        candidate missing structure) -- proving the loop records the runner's OWN report, not what
+        it offered. Mutation M5 (queued_ts_labels = tuple(offered_ts_labels) at pes_loop.py:348)
+        must fail this test."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+
+        def _runner(candidates, paths, cfg, network_id):
+            offered = tuple(c.ts_label for c in candidates)
+            assert offered == ('TS0', 'TS1')
+            _touch_hybrid_file(paths, network_id)
+            # Converge nothing, and report only TS0 as queued -- TS1 is dropped, as build_arc_input
+            # legitimately drops a candidate missing structure.
+            return frozenset(), frozenset({'TS0'})
+
+        result = run_pes_loop(config, project_directory=str(tmp_path),
+                              qm_runner=_runner)
+        assert result.rounds[0].queued_ts_labels == ('TS0',)
+        assert 'TS1' not in result.rounds[0].queued_ts_labels
+
     def test_a_failed_explore_stops_the_loop_and_says_why(self, tmp_path, monkeypatch, config):
         """A round that cannot explore must not be papered over as convergence."""
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'], fail=True)

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -334,7 +334,77 @@ class TestRunPESLoop(object):
                                                                              monkeypatch, config):
         """C1: TS labels adopted from an earlier T3 project must be treated as already computed
         before round 0 ever runs, not just before some later round -- there was previously zero
-        coverage of this ruling at all."""
+        coverage of this ruling at all. The artifact comes with the label: without one there is
+        nothing to fold into any hybrid, so the claim cannot be honoured (see below)."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+        artifact_path = str(tmp_path / 'prior' / 'capture' / 'qm' / 'TS0.py')
+        os.makedirs(os.path.dirname(artifact_path))
+        open(artifact_path, 'w').close()
+        queued, adopted_per_round = [], []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            queued.extend(c.ts_label for c in candidates)
+            adopted_per_round.append(dict(adopted))
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner,
+                    adopted_ts_labels={'TS0': artifact_path})
+        assert 'TS0' not in queued
+        assert 'TS1' in queued
+        # The artifact actually reaches the runner, so the hybrid can carry it. A label marked
+        # computed with nothing behind it is the defect this asserts against.
+        assert adopted_per_round[0] == {'TS0': artifact_path}
+
+    def test_a_bare_adopted_label_with_no_artifact_is_not_claimed_as_computed(self, tmp_path,
+                                                                             monkeypatch, config,
+                                                                             caplog):
+        """Fail closed: a label with no artifact cannot be folded into any hybrid, so the channel
+        would keep its RMG/ILT rate line and the final diagram would show an ESTIMATED barrier
+        while the run reported quantum chemistry for it. It must be queued normally instead."""
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
+        queued, adopted_per_round = [], []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            queued.extend(c.ts_label for c in candidates)
+            adopted_per_round.append(dict(adopted))
+            _touch_hybrid_file(paths, network_id)
+            return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
+
+        with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_loop'):
+            run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner,
+                         adopted_ts_labels=frozenset({'TS0'}))
+        assert 'TS0' in queued, 'a channel with no artifact must be computed, not claimed'
+        assert adopted_per_round[0] == {}
+        assert 'no artifact path' in caplog.text
+
+    def test_a_lone_artifactless_adopted_label_does_not_short_circuit_the_round(self, tmp_path,
+                                                                               monkeypatch):
+        """The sharp edge of the same defect: when the artifactless label is the ONLY candidate,
+        marking it computed made round 0 return 'no_candidates' before qm_runner was ever called,
+        leaving the final network and diagram on the RMG estimate while reporting the channel as
+        having QM."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               termination={'max_rounds': 1, 'stop_when_no_new_ts': False})
+        _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO'])
+        runner_calls = []
+
+        def _runner(candidates, paths, cfg, network_id, adopted=None):
+            runner_calls.append(tuple(c.ts_label for c in candidates))
+            _touch_hybrid_file(paths, network_id)
+            return (frozenset(c.ts_label for c in candidates),
+                    frozenset(c.ts_label for c in candidates))
+
+        result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner,
+                              adopted_ts_labels=frozenset({'TS0'}))
+        assert result.status != PES_LOOP_NO_CANDIDATES
+        assert runner_calls == [('TS0',)]
+
+    def test_an_adopted_label_whose_artifact_is_missing_is_not_claimed_either(self, tmp_path,
+                                                                             monkeypatch, config,
+                                                                             caplog):
+        """A path that does not exist is the same claim as no path at all."""
         _stub_explorer(monkeypatch, tmp_path, families=['1,2_Insertion_CO', '1,2_Insertion_CO'])
         queued = []
 
@@ -343,10 +413,11 @@ class TestRunPESLoop(object):
             _touch_hybrid_file(paths, network_id)
             return frozenset(c.ts_label for c in candidates), frozenset(c.ts_label for c in candidates)
 
-        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner,
-                    adopted_ts_labels=frozenset({'TS0'}))
-        assert 'TS0' not in queued
-        assert 'TS1' in queued
+        with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_loop'):
+            run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner,
+                         adopted_ts_labels={'TS0': str(tmp_path / 'gone' / 'TS0.py')})
+        assert 'TS0' in queued
+        assert 'does not exist' in caplog.text
 
     def test_reuse_config_calls_adopt_prior_qm_and_seeds_round_0(self, tmp_path, monkeypatch,
                                                                   config):

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -15,7 +15,8 @@ from t3.pdep.join import arc_ts_label
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
 from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_DIAGRAM_ONLY, PES_LOOP_FAILED,
                               PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES, PES_LOOP_STALLED,
-                              PESLoopResult, RoundRecord, hybrid_network_path, run_pes_loop)
+                              PESLoopResult, RoundRecord, _build_explorer_config,
+                              hybrid_network_path, run_pes_loop)
 from t3.pdep.pes_rounds import round_paths
 from t3.schema import PESLoopConfig
 
@@ -607,6 +608,17 @@ class TestRoundMeSensitivityWiring(object):
         assert sa_calls[0]['timeout'] == config.pes.timeout
         assert received[0].coefficient == -3.0e-5
         assert received[0].delta_ln_k == 0.25
+
+    def test_the_explorer_config_carries_the_configured_timeout(self, tmp_path):
+        """The other half of the same budget: explorer runtime is unbounded, so without this a
+        single pathological network parks the loop forever. Asserted against a value that is
+        neither the schema default nor the explorer's own, so a dropped ``timeout=`` cannot pass
+        by coincidence."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}, 'timeout': 137.0})
+        explorer_config = _build_explorer_config(config, str(tmp_path),
+                                                 round_paths(str(tmp_path), 0))
+        assert explorer_config.timeout == 137.0
 
     def test_a_failed_sa_fails_the_round_rather_than_inventing_evidence(self, tmp_path,
                                                                         monkeypatch, config):

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -1,0 +1,152 @@
+"""Tests for t3.pdep.pes_loop."""
+
+import os
+
+import pytest
+
+from t3.pdep.explorer.result import (EXPLORATION_STATUS_FAILED, EXPLORATION_STATUS_SUCCEEDED,
+                                     PDepExplorationResult)
+from t3.pdep.parser import PDepNetwork, PDepPathReaction
+from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES,
+                              PES_LOOP_STALLED, PESLoopResult, RoundRecord, run_pes_loop)
+from t3.schema import PESLoopConfig
+
+
+@pytest.fixture
+def config():
+    """A minimal config pointing at a network fixture.
+
+    ``bath_gas`` is required by ``PDepExplorerConfig`` (a config without one is a guaranteed
+    write-time failure -- see t3/pdep/explorer/config.py, issue #183), so it must be non-empty
+    here even though every test below stubs ``explore_pdep_network`` and never actually reaches
+    that construction's use.
+    """
+    return PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                              'bath_gas': {'He': 1.0}},
+                         termination={'max_rounds': 3})
+
+
+def _stub_explorer(monkeypatch, families, fail=False):
+    """
+    Patch ``explore_pdep_network``, ``parse_pdep_network_file``, and ``draw_pes_diagram`` at the
+    names bound in ``t3.pdep.pes_loop``, so ``run_pes_loop`` can be tested without Arkane.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture.
+        families (list): One path reaction is fabricated per entry, carrying that family in its
+            kinetics comment (recognized by ``t3.pdep.barrierless.classify_barrierless``).
+        fail (bool): If True, the stubbed explorer reports a failed exploration instead of a
+            succeeded one.
+    """
+    network_path = '/abs/network1_1.py'
+    network_id = 'network1_1'
+
+    if fail:
+        result = PDepExplorationResult(network_id=network_id, status=EXPLORATION_STATUS_FAILED,
+                                       reasons=('the explorer adapter crashed',))
+    else:
+        result = PDepExplorationResult(network_id=network_id, status=EXPLORATION_STATUS_SUCCEEDED,
+                                       network_paths=(network_path,))
+
+    path_reactions = tuple(
+        PDepPathReaction(label=f'reaction{i}', reactants=('A',), products=('B',),
+                         transition_state=f'TS{i}', kinetics_type='Arrhenius',
+                         kinetics_comment=f'family: {family}')
+        for i, family in enumerate(families))
+    network = PDepNetwork(network_id=network_id, path=network_path, label=None,
+                          species_labels=('A', 'B'),
+                          transition_state_labels=tuple(f'TS{i}' for i in range(len(families))),
+                          path_reactions=path_reactions, isomers=(), reactant_channels=(),
+                          product_channels=())
+
+    def _fake_explore(*args, **kwargs):
+        return result
+
+    def _fake_parse(*args, **kwargs):
+        return network
+
+    def _fake_draw(network_path, output_path):
+        open(output_path, 'w').close()
+
+    monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
+    monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file', _fake_parse)
+    monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram', _fake_draw)
+
+
+class TestRunPESLoop(object):
+
+    def test_no_candidates_terminates_immediately(self, tmp_path, monkeypatch, config):
+        """A network whose every channel is barrierless has nothing to compute: one explore, one
+        diagram, done -- not three empty rounds."""
+        _stub_explorer(monkeypatch, families=['R_Recombination', 'R_Recombination'])
+        result = run_pes_loop(config, project_directory=str(tmp_path))
+        assert result.status == PES_LOOP_NO_CANDIDATES
+        assert len(result.rounds) == 1
+        assert result.rounds[0].queued_ts_labels == ()
+        assert len(result.rounds[0].skipped) == 2
+
+    def test_max_rounds_is_honoured(self, tmp_path, monkeypatch, config):
+        """A runner that never converges anything must not loop forever."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                    'bath_gas': {'He': 1.0}},
+                               termination={'max_rounds': 3, 'stop_when_no_new_ts': False})
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        result = run_pes_loop(config, project_directory=str(tmp_path),
+                              qm_runner=lambda candidates, paths, cfg, network_id: frozenset())
+        assert result.status == PES_LOOP_MAX_ROUNDS
+        assert len(result.rounds) == 3
+
+    def test_a_round_that_stalls_stops_early(self, tmp_path, monkeypatch, config):
+        """With the default stop_when_no_new_ts=True, a runner that converges nothing must stop
+        after round 1 rather than spend the rest of the round budget -- this is what distinguishes
+        'stalled' from 'max_rounds' (ruling C3)."""
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        result = run_pes_loop(config, project_directory=str(tmp_path),
+                              qm_runner=lambda candidates, paths, cfg, network_id: frozenset())
+        assert result.status == PES_LOOP_STALLED
+        assert len(result.rounds) == 1
+
+    def test_converges_when_every_candidate_is_computed(self, tmp_path, monkeypatch, config):
+        """Once QM exists for every barriered channel, the loop stops on its own."""
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        result = run_pes_loop(config, project_directory=str(tmp_path),
+                              qm_runner=lambda candidates, paths, cfg, network_id:
+                                  frozenset(c.ts_label for c in candidates))
+        assert result.status == PES_LOOP_CONVERGED
+        assert len(result.rounds) == 2
+
+    def test_a_diagram_is_drawn_every_round(self, tmp_path, monkeypatch, config):
+        """The whole point: a picture per round, each from that round's own network."""
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        result = run_pes_loop(config, project_directory=str(tmp_path),
+                              qm_runner=lambda candidates, paths, cfg, network_id:
+                                  frozenset(c.ts_label for c in candidates))
+        for record in result.rounds:
+            assert record.diagram_path is not None
+            assert os.path.basename(record.diagram_path) == 'pes_diagram.png'
+
+    def test_barrierless_channels_are_never_queued(self, tmp_path, monkeypatch, config):
+        """The F21 gate, asserted end to end rather than only at the unit level."""
+        queued = []
+        _stub_explorer(monkeypatch, families=['R_Recombination', '1,2_Insertion_CO'])
+
+        def _runner(candidates, paths, cfg, network_id):
+            queued.extend(c.family for c in candidates)
+            return frozenset(c.ts_label for c in candidates)
+
+        run_pes_loop(config, project_directory=str(tmp_path), qm_runner=_runner)
+        assert 'R_Recombination' not in queued
+
+    def test_no_qm_runner_explores_and_draws_only(self, tmp_path, monkeypatch, config):
+        """The honest behaviour without a configured runner: one round, a diagram, no crash."""
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'])
+        result = run_pes_loop(config, project_directory=str(tmp_path))
+        assert len(result.rounds) == 1
+        assert result.rounds[0].diagram_path is not None
+
+    def test_a_failed_explore_stops_the_loop_and_says_why(self, tmp_path, monkeypatch, config):
+        """A round that cannot explore must not be papered over as convergence."""
+        _stub_explorer(monkeypatch, families=['1,2_Insertion_CO'], fail=True)
+        result = run_pes_loop(config, project_directory=str(tmp_path))
+        assert result.status == 'failed'
+        assert result.reason

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -42,7 +42,6 @@ from t3.pdep.hybrid import HybridNetworkResult
 from t3.pdep.join import (JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label,
                           expected_ts_artifact_path)
 from t3.pdep.parser import parse_pdep_network_file
-import t3.pdep.pes_qm as pes_qm
 from t3.pdep.pes_loop import run_pes_loop
 from t3.pdep.pes_qm import _explored_network_path, arc_qm_runner
 from t3.pdep.pes_rounds import hybrid_network_path, round_paths, split_qm_candidates
@@ -136,7 +135,7 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
 
     _FakeARC.constructions = []
     _FakeARC.execute_calls = 0
-    monkeypatch.setattr(pes_qm, 'ARC', _FakeARC)
+    monkeypatch.setattr('t3.pdep.pes_qm.ARC', _FakeARC)
 
     write_hybrid_calls = []
 
@@ -195,8 +194,8 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
         return HybridNetworkResult(dest_path=dest_path, qm_ts_labels=tuple(qm_transition_states),
                                    ilt_ts_labels=(), vendored_files=(), warnings=())
 
-    monkeypatch.setattr(pes_qm, 'capture_ts_artifacts', _fake_capture_ts_artifacts)
-    monkeypatch.setattr(pes_qm, 'write_hybrid_network_input_file',
+    monkeypatch.setattr('t3.pdep.pes_qm.capture_ts_artifacts', _fake_capture_ts_artifacts)
+    monkeypatch.setattr('t3.pdep.pes_qm.write_hybrid_network_input_file',
                         _fake_write_hybrid_network_input_file)
 
     config = _config(fixture_network_path, max_rounds=3)
@@ -464,7 +463,7 @@ def test_real_loop_real_capture_keeps_qm_on_the_right_channel_across_a_renumber(
     _ArtifactWritingFakeARC.converge_plan = ({_CH1_MARKER}, {_CH2_MARKER})
     _ArtifactWritingFakeARC.constructions = []
     _ArtifactWritingFakeARC.executions = 0
-    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr('t3.pdep.pes_qm.ARC', _ArtifactWritingFakeARC)
 
     config = PESLoopConfig(
         pes={'network': seed_path, 'source': ['O-2(13598)', 'CO2(11)'],
@@ -535,7 +534,7 @@ def test_real_loop_round_0_full_adoption_completes_with_real_vendoring(tmp_path,
     _ArtifactWritingFakeARC.converge_plan = ()
     _ArtifactWritingFakeARC.constructions = []
     _ArtifactWritingFakeARC.executions = 0
-    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr('t3.pdep.pes_qm.ARC', _ArtifactWritingFakeARC)
 
     config = PESLoopConfig(
         pes={'network': seed_path, 'source': ['O-2(13598)', 'CO2(11)'],
@@ -594,7 +593,7 @@ def test_pes_cli_main_drives_the_real_loop_end_to_end(tmp_path, monkeypatch):
     _ArtifactWritingFakeARC.converge_plan = ({_CH1_MARKER}, {_CH2_MARKER})
     _ArtifactWritingFakeARC.constructions = []
     _ArtifactWritingFakeARC.executions = 0
-    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr('t3.pdep.pes_qm.ARC', _ArtifactWritingFakeARC)
     monkeypatch.setattr(sys, 'argv', ['PES.py', input_path])
 
     result = PES.main()
@@ -663,7 +662,7 @@ def test_pes_cli_project_directory_flag_moves_the_whole_run(tmp_path, monkeypatc
     _ArtifactWritingFakeARC.converge_plan = ({_CH1_MARKER},)
     _ArtifactWritingFakeARC.constructions = []
     _ArtifactWritingFakeARC.executions = 0
-    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr('t3.pdep.pes_qm.ARC', _ArtifactWritingFakeARC)
     monkeypatch.setattr(sys, 'argv', ['PES.py', input_path, '-p', run_directory])
 
     result = PES.main()
@@ -704,7 +703,7 @@ def test_pes_cli_resolves_a_relative_reuse_path_against_the_input_file(tmp_path,
     _ArtifactWritingFakeARC.converge_plan = ()
     _ArtifactWritingFakeARC.constructions = []
     _ArtifactWritingFakeARC.executions = 0
-    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr('t3.pdep.pes_qm.ARC', _ArtifactWritingFakeARC)
     monkeypatch.setattr(sys, 'argv', ['PES.py', input_path])
 
     result = PES.main()
@@ -740,7 +739,7 @@ def test_pes_cli_diagram_only_explores_and_draws_without_touching_arc(tmp_path, 
     _ArtifactWritingFakeARC.converge_plan = ()
     _ArtifactWritingFakeARC.constructions = []
     _ArtifactWritingFakeARC.executions = 0
-    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr('t3.pdep.pes_qm.ARC', _ArtifactWritingFakeARC)
     monkeypatch.setattr(sys, 'argv', ['PES.py', input_path, '--diagram-only'])
 
     result = PES.main()

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -355,19 +355,19 @@ def _fixture_explorer(monkeypatch, project_directory, network_id):
 
 
 def test_real_loop_real_capture_carries_cumulative_qm_across_rounds(tmp_path, monkeypatch):
-    """The reviewer's exact scenario, against the REAL capture_ts_artifacts: round 0 adopts TS1
-    from a real prior capture and converges TS2; round 1 converges TS3. Before this fix round the
-    loop could not complete a single such round (defect 1), and when it did complete, round N+1's
-    hybrid dropped round N's QM back to Arrhenius lines (defect 3)."""
-    prior_project_dir = os.path.join(str(tmp_path), 'prior_project')
-    _build_prior_capture(prior_project_dir, ts_labels=('TS1',))
+    """Against the REAL capture_ts_artifacts: round 0 queues the two above-floor channels and
+    converges TS1's; round 1 converges TS2's; TS3's channel measures a ln(k) response of exactly
+    0.0 in the live ME SA -- below qm.min_delta_ln_k -- so it is never queued, and the loop
+    reports a measured convergence at round 2 with that skip on the record. Before this fix round
+    the loop could not complete a single such round (defect 1), and when it did complete, round
+    N+1's hybrid dropped round N's QM back to Arrhenius lines (defect 3)."""
     project_directory = os.path.join(str(tmp_path), 'loop_project')
     os.makedirs(project_directory)
     seed_path = os.path.join(str(tmp_path), 'network0_full.py')
     shutil.copyfile(_FIXTURE_NETWORK_PATH, seed_path)
 
     _fixture_explorer(monkeypatch, project_directory, 'network0_full')
-    _ArtifactWritingFakeARC.converge_plan = ({'TS2'}, {'TS3'})
+    _ArtifactWritingFakeARC.converge_plan = ({'TS1'}, {'TS2'})
     _ArtifactWritingFakeARC.constructions = []
     _ArtifactWritingFakeARC.executions = 0
     monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
@@ -376,30 +376,35 @@ def test_real_loop_real_capture_carries_cumulative_qm_across_rounds(tmp_path, mo
         pes={'network': seed_path, 'source': ['O-2(13598)', 'CO2(11)'],
              'bath_gas': {'Ar': 1.0}, 'method': 'MSC'},
         termination={'max_rounds': 4},
-        reuse={'from_t3_projects': [prior_project_dir]},
     )
     result = run_pes_loop(config, project_directory=project_directory, qm_runner=arc_qm_runner)
 
     assert result.status == 'converged', f'{result.status}: {result.reason}'
     assert [record.status for record in result.rounds] == ['continuing', 'continuing', 'converged']
-    assert sorted(result.rounds[0].queued_ts_labels) == ['TS2', 'TS3']
-    assert sorted(result.rounds[1].queued_ts_labels) == ['TS3']
+    assert sorted(result.rounds[0].queued_ts_labels) == ['TS1', 'TS2']
+    assert sorted(result.rounds[1].queued_ts_labels) == ['TS2']
+    # TS3's channel was gated by its own measured (zero) response, every round, on the record.
+    for record in result.rounds:
+        floor_skips = [s for s in record.skipped if 'below the min_delta_ln_k floor' in s.reason]
+        assert [s.label for s in floor_skips] == ['reaction3']
 
     round0_hybrid = hybrid_network_path(round_paths(project_directory, 0), 'network0_full')
     round1_hybrid = hybrid_network_path(round_paths(project_directory, 1), 'network0_full')
-    # Round 0: the adopted TS1 and the freshly converged TS2 are QM; TS3 is still ILT.
-    assert _hybrid_qm_ilt(round0_hybrid) == (['TS1', 'TS2'], ['TS3'])
+    assert _hybrid_qm_ilt(round0_hybrid) == (['TS1'], ['TS2', 'TS3'])
     # Round 1 -- THE defect-3 pin: the hybrid carries the CUMULATIVE QM, not just this round's.
-    # The defective loop wrote QM=['TS3'], ILT=['TS1', 'TS2'] here.
-    assert _hybrid_qm_ilt(round1_hybrid) == (['TS1', 'TS2', 'TS3'], [])
+    # The defective loop dropped round 0's QM back to an Arrhenius line here.
+    assert _hybrid_qm_ilt(round1_hybrid) == (['TS1', 'TS2'], ['TS3'])
 
     # Both rounds' captures are REAL and re-verify cleanly, sensitivity evidence included --
     # exactly what defect 1 made impossible.
+    verified_artifacts = 0
     for round_index in (0, 1):
         verified = verify_capture(round_paths(project_directory, round_index).capture)
         for record in verified.ts_records:
             if record.artifact_path is not None:
+                verified_artifacts += 1
                 assert record.coefficient is not None and record.delta_ln_k is not None
+    assert verified_artifacts == 2
 
 
 def test_real_loop_round_0_full_adoption_completes_with_real_vendoring(tmp_path, monkeypatch):

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -720,3 +720,41 @@ def test_pes_cli_resolves_a_relative_reuse_path_against_the_input_file(tmp_path,
     # LOOP's own, not the CLI's, so it can only be in the file if logger= reached run_pes_loop.
     with open(os.path.join(project_directory, 't3.log')) as f:
         assert "PES loop: reusing 3 prior QM result(s)" in f.read()
+
+
+def test_pes_cli_diagram_only_explores_and_draws_without_touching_arc(tmp_path, monkeypatch):
+    """``--diagram-only`` is the only way to smoke-test an input file without submitting real
+    cluster jobs, so what matters is not that the flag parses but that ARC is never CONSTRUCTED.
+    The fake ARC here records every construction, and this run must leave that list empty."""
+    project_directory = str(tmp_path)
+    input_path = os.path.join(project_directory, 'input.yml')
+    shutil.copyfile(_FIXTURE_NETWORK_PATH, os.path.join(project_directory, 'network0_full.py'))
+    with open(input_path, 'w') as f:
+        yaml.dump({'pes': {'network': 'network0_full.py',
+                           'source': ['O-2(13598)', 'CO2(11)'],
+                           'bath_gas': {'Ar': 1.0},
+                           'method': 'MSC'},
+                   'termination': {'max_rounds': 3}}, f)
+
+    explore_calls = _fixture_explorer(monkeypatch, project_directory, 'network0_full')
+    _ArtifactWritingFakeARC.converge_plan = ()
+    _ArtifactWritingFakeARC.constructions = []
+    _ArtifactWritingFakeARC.executions = 0
+    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr(sys, 'argv', ['PES.py', input_path, '--diagram-only'])
+
+    result = PES.main()
+
+    assert result.status == 'diagram_only', f'{result.status}: {result.reason}'
+    # Not one ARC object was even built, let alone executed.
+    assert _ArtifactWritingFakeARC.constructions == []
+    assert _ArtifactWritingFakeARC.executions == 0
+    # One exploration, one diagram, no QM: no hybrid network was written, and the loop stopped
+    # after round 0 rather than spending the three rounds the input file allows.
+    assert len(explore_calls) == 1
+    assert len(result.rounds) == 1
+    assert result.final_diagram_path == os.path.join(project_directory, 'round_0',
+                                                     'pes_diagram.png')
+    assert os.path.isfile(result.final_diagram_path)
+    assert not os.path.isfile(hybrid_network_path(round_paths(project_directory, 0),
+                                                  'network0_full'))

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -73,8 +73,8 @@ class _FakeARC(object):
         return dict(self.kwargs)
 
 
-def _config(max_rounds=3):
-    return PESLoopConfig(pes={'network': _FIXTURE_NETWORK_PATH, 'source': ['A'],
+def _config(network_path, max_rounds=3):
+    return PESLoopConfig(pes={'network': network_path, 'source': ['A'],
                               'bath_gas': {'He': 1.0}},
                          termination={'max_rounds': max_rounds, 'stop_when_no_new_ts': False})
 
@@ -85,7 +85,16 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
     least two rounds, and -- the actual N6 contract -- that the exact hybrid file arc_qm_runner
     writes for round 0 is the exact file run_pes_loop hands its round-1 explorer, observed end to
     end through the real loop rather than inferred from two separately-passing unit tests."""
-    real_network = parse_pdep_network_file(path=_FIXTURE_NETWORK_PATH)
+    # The fixture file's own stem ('network799_1') follows T3's own hybrid-file convention
+    # (network<digits>_<digits>), not the real Arkane explorer's
+    # ('^network(\\d+)_(full|reduced)\\.py$', t3.pdep.explorer.arkane._FINAL_NETWORK_FILENAME_RE).
+    # This fake explorer stands in for that real explorer, so it must hand downstream a network_id
+    # shaped the way Arkane's really is -- parse from a renamed copy rather than the fixture path
+    # directly, so real_network.network_id and every path derived from it looks like what Arkane
+    # would actually produce.
+    fixture_network_path = os.path.join(str(tmp_path), 'network0_full.py')
+    shutil.copyfile(_FIXTURE_NETWORK_PATH, fixture_network_path)
+    real_network = parse_pdep_network_file(path=fixture_network_path)
     real_split = split_qm_candidates(real_network, frozenset())
     assert real_split.candidates, 'fixture must offer at least one real QM candidate'
     target = real_split.candidates[0]
@@ -109,7 +118,7 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
         paths = round_paths(project_directory, round_index)
         dest_path = _explored_network_path(paths, real_network.network_id)
         os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-        shutil.copyfile(_FIXTURE_NETWORK_PATH, dest_path)
+        shutil.copyfile(fixture_network_path, dest_path)
         return PDepExplorationResult(network_id=real_network.network_id,
                                      status=EXPLORATION_STATUS_SUCCEEDED,
                                      network_paths=(dest_path,))
@@ -133,7 +142,8 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
                                  arc_ts_label=f'{real_network.network_id}_{target.ts_label}',
                                  status=ARTIFACT_STATUS_USABLE,
                                  artifact_path=os.path.join(capture_dir, f'{target.ts_label}.py'),
-                                 converged=True),
+                                 converged=True,
+                                 path_reaction_labels=(target.path_reaction.label,)),
             ),
             energy_settings=_ENERGY_SETTINGS,
             networks={
@@ -160,7 +170,7 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
     monkeypatch.setattr(pes_qm, 'write_hybrid_network_input_file',
                         _fake_write_hybrid_network_input_file)
 
-    config = _config(max_rounds=3)
+    config = _config(fixture_network_path, max_rounds=3)
     result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=arc_qm_runner)
 
     assert len(result.rounds) >= 2, (

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -131,7 +131,15 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
 
     write_hybrid_calls = []
 
-    def _fake_capture_ts_artifacts(*, join_records, arc_project_directory, capture_dir, networks):
+    def _fake_capture_ts_artifacts(*, join_records, arc_project_directory, capture_dir, networks,
+                                   sensitivity_by_ts):
+        # Defect 1: the real capture_ts_artifacts refuses (via its verify_capture self-check) any
+        # captured artifact whose join record carries no finite sensitivity evidence -- so even
+        # this double must insist the runner actually passed it, keyed and finite, or the pairing
+        # this module corroborates would still be one that cannot run against the real capture.
+        assert sensitivity_by_ts, 'arc_qm_runner must pass the sensitivity evidence to capture'
+        for key, (coefficient, delta_ln_k) in sensitivity_by_ts.items():
+            assert coefficient is not None and delta_ln_k is not None, key
         os.makedirs(capture_dir, exist_ok=True)
         return CaptureResult(
             capture_dir=capture_dir,

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -28,7 +28,8 @@ module only corroborates that the loop and the real runner agree with each other
 import os
 import shutil
 
-from t3.pdep.capture import CaptureResult
+from t3.pdep.capture import CaptureResult, captured_qm_artifact_path
+from t3.pdep.join import arc_ts_label
 from t3.pdep.discovery import ARTIFACT_STATUS_USABLE, TSArtifactRecord
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED, PDepExplorationResult
 from t3.pdep.hybrid import HybridNetworkResult
@@ -141,6 +142,18 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
         for key, (coefficient, delta_ln_k) in sensitivity_by_ts.items():
             assert coefficient is not None and delta_ln_k is not None, key
         os.makedirs(capture_dir, exist_ok=True)
+        # Defect 3: the loop carries a converged TS across the round boundary as an adopted
+        # artifact at the capture's own vendored path (captured_qm_artifact_path), and the REAL
+        # _vendor_adopted_artifacts in round 1 fails closed on a missing file -- so this double
+        # must actually write the artifact it claims was captured, not merely name it in a result
+        # object (the same rule the hybrid double below already follows).
+        vendored_path = captured_qm_artifact_path(
+            capture_dir, arc_ts_label(real_network.network_id, target.ts_label))
+        os.makedirs(os.path.dirname(vendored_path), exist_ok=True)
+        with open(os.path.join(os.path.dirname(vendored_path), 'output.out'), 'w') as f:
+            f.write('# stub ARC log output\n')
+        with open(vendored_path, 'w') as f:
+            f.write("geometry = Log('output.out')\n")
         return CaptureResult(
             capture_dir=capture_dir,
             manifest_path=os.path.join(capture_dir, 'manifest.yml'),

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -33,8 +33,8 @@ import sys
 import yaml
 
 import PES
-from t3.pdep.capture import (CaptureResult, capture_ts_artifacts, captured_qm_artifact_path,
-                             verify_capture)
+from t3.pdep.capture import (CAPTURE_MANIFEST_FILE_NAME, CaptureResult, VerifyResult,
+                             capture_ts_artifacts, captured_qm_artifact_path, verify_capture)
 from t3.pdep.discovery import ARTIFACT_STATUS_USABLE, TSArtifactRecord
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED, PDepExplorationResult
 from t3.pdep.hashing import hash_file
@@ -194,7 +194,21 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
         return HybridNetworkResult(dest_path=dest_path, qm_ts_labels=tuple(qm_transition_states),
                                    ilt_ts_labels=(), vendored_files=(), warnings=())
 
+    def _fake_verify_capture(root):
+        # arc_qm_runner reads the energy settings an ADOPTED artifact was computed under from that
+        # artifact's own prior capture manifest, so that a round which both captures new QM and
+        # folds in adopted artifacts can refuse a mismatch instead of silently rendering the
+        # adopted barriers under this round's header. The capture double above writes no manifest,
+        # so this double supplies what verify_capture would have read from one -- the same settings
+        # it reports as this round's own, which is the truth here: every round of this run computes
+        # at one level of theory.
+        return VerifyResult(capture_dir=root,
+                            manifest_path=os.path.join(root, CAPTURE_MANIFEST_FILE_NAME),
+                            record_count=1, captured_artifact_count=1, networks=dict(),
+                            energy_settings=_ENERGY_SETTINGS, ts_records=())
+
     monkeypatch.setattr('t3.pdep.pes_qm.capture_ts_artifacts', _fake_capture_ts_artifacts)
+    monkeypatch.setattr('t3.pdep.pes_qm.verify_capture', _fake_verify_capture)
     monkeypatch.setattr('t3.pdep.pes_qm.write_hybrid_network_input_file',
                         _fake_write_hybrid_network_input_file)
 

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -28,16 +28,19 @@ module only corroborates that the loop and the real runner agree with each other
 import os
 import shutil
 
-from t3.pdep.capture import CaptureResult, captured_qm_artifact_path
-from t3.pdep.join import arc_ts_label
+from t3.pdep.capture import (CaptureResult, capture_ts_artifacts, captured_qm_artifact_path,
+                             verify_capture)
 from t3.pdep.discovery import ARTIFACT_STATUS_USABLE, TSArtifactRecord
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED, PDepExplorationResult
+from t3.pdep.hashing import hash_file
 from t3.pdep.hybrid import HybridNetworkResult
+from t3.pdep.join import (JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label,
+                          expected_ts_artifact_path)
 from t3.pdep.parser import parse_pdep_network_file
 import t3.pdep.pes_qm as pes_qm
 from t3.pdep.pes_loop import run_pes_loop
 from t3.pdep.pes_qm import _explored_network_path, arc_qm_runner
-from t3.pdep.pes_rounds import round_paths, split_qm_candidates
+from t3.pdep.pes_rounds import hybrid_network_path, round_paths, split_qm_candidates
 from t3.schema import PESLoopConfig
 
 _FIXTURE_NETWORK_PATH = os.path.join(
@@ -204,3 +207,233 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
     # The actual N6 contract: round 1's explorer must be handed EXACTLY the file arc_qm_runner
     # wrote for round 0.
     assert received_network_paths[1] == round0_hybrid_path
+
+
+# ---------------------------------------------------------------------------------------------
+# Real-capture pairing (this fix round). Everything below drives the REAL run_pes_loop with the
+# REAL arc_qm_runner, the REAL capture_ts_artifacts (no capture double -- the gap every prior
+# test on this branch shared, which is how defects 1-3 stayed green), the REAL Arkane
+# master-equation SA (t3.pdep.pes_sa -- Arkane actually runs, once per round with candidates),
+# the REAL adopt_prior_qm against a REAL prior capture, the REAL vendoring, and the REAL hybrid
+# writer. Faked: ONLY the explorer (as everywhere in this suite) and ARC (execute() writes
+# converged statmech artifacts into the round's own ARC project instead of submitting cluster
+# jobs).
+# ---------------------------------------------------------------------------------------------
+
+_MODEL_CHEMISTRY = "LevelOfTheory(method='wb97xd2023',basis='def2tzvp',software='gaussian')"
+
+
+def _write_artifact(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(os.path.join(os.path.dirname(path), 'output.out'), 'w') as f:
+        f.write('stub quantum chemistry log\n')
+    with open(path, 'w') as f:
+        f.write("linear = False\n\nspinMultiplicity = 2\n\nenergy = Log('output.out')\n\n"
+                "geometry = Log('output.out')\n\nfrequencies = Log('output.out')\n")
+
+
+def _write_status(arc_dir, label, converged):
+    output_dir = os.path.join(arc_dir, 'output')
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, 'status.yml'), 'a') as f:
+        f.write(f"{label}:\n  convergence: {str(converged).lower()}\n  job_types: {{}}\n"
+                f"  paths: {{}}\n  info: ''\n  errors: ''\n")
+
+
+def _write_energy_settings(arc_dir):
+    statmech_dir = os.path.join(arc_dir, 'calcs', 'statmech', 'kinetics')
+    os.makedirs(statmech_dir, exist_ok=True)
+    with open(os.path.join(statmech_dir, 'input.py'), 'w') as f:
+        f.write(f"modelChemistry = {_MODEL_CHEMISTRY}\n\nuseHinderedRotors = True\n\n"
+                "useAtomCorrections = True\n\n"
+                "atomEnergies = {'C': -37.844411, 'H': -0.499818, 'O': -75.062219}\n\n"
+                "useBondCorrections = False\n")
+    output_dir = os.path.join(arc_dir, 'output')
+    os.makedirs(output_dir, exist_ok=True)
+    output_yml = os.path.join(output_dir, 'output.yml')
+    if not os.path.isfile(output_yml):
+        with open(output_yml, 'w') as f:
+            f.write('{}\n')
+
+
+def _build_prior_capture(prior_project_dir, ts_labels):
+    """A REAL prior capture for ``ts_labels`` (each joined to the fixture's own
+    ``reaction<i>``), built by capture_ts_artifacts itself so adopt_prior_qm, the vendoring, and
+    _adopted_energy_settings all run against the exact formats production writes."""
+    arc_dir = os.path.join(prior_project_dir, 'arc_project')
+    network_id = 'prior_run_network'
+    records = []
+    for ts_label in ts_labels:
+        label = arc_ts_label(network_id, ts_label)
+        record = TSJoinRecord(network_id=network_id, network_ts_label=ts_label,
+                              status=JOIN_STATUS_QUEUED, arc_ts_label=label,
+                              expected_artifact_path=expected_ts_artifact_path(arc_dir, label),
+                              reason='Queued to ARC.', coefficient=-9.5e-05, delta_ln_k=0.795,
+                              path_reaction_labels=(f'reaction{ts_label[2:]}',))
+        _write_artifact(record.expected_artifact_path)
+        _write_status(arc_dir, label, converged=True)
+        records.append(record)
+    _write_energy_settings(arc_dir)
+    networks_dir = os.path.join(prior_project_dir, 'networks')
+    os.makedirs(networks_dir, exist_ok=True)
+    source_path = os.path.join(networks_dir, f'{network_id}.py')
+    with open(source_path, 'w') as f:
+        f.write(f"# stub RMG network file\nnetwork(label='{network_id}')\n")
+    capture_ts_artifacts(
+        records, arc_dir, os.path.join(prior_project_dir, 'capture'),
+        networks={network_id: {'source_path': source_path,
+                               'source_sha256': hash_file(source_path), 'method': 'MSC'}},
+        sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)
+                           for record in records})
+
+
+class _ArtifactWritingFakeARC(object):
+    """Stands in for arc.main.ARC at exactly the cluster boundary: execute() writes the statmech
+    artifacts, convergence statuses, and energy settings a real ARC run would leave in the round's
+    own project directory, per the class-level ``converge_plan`` (one set of network-local TS
+    labels per execute() call)."""
+
+    converge_plan = ()
+    constructions = []
+    executions = 0
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _ArtifactWritingFakeARC.constructions.append(kwargs)
+
+    def as_dict(self):
+        return dict(self.kwargs)
+
+    def execute(self):
+        arc_dir = self.kwargs['project_directory']
+        to_converge = _ArtifactWritingFakeARC.converge_plan[_ArtifactWritingFakeARC.executions]
+        _ArtifactWritingFakeARC.executions += 1
+        _write_energy_settings(arc_dir)
+        for reaction in self.kwargs['reactions']:
+            label = reaction['ts_label']
+            if label.rsplit('_', 1)[-1] in to_converge:
+                _write_artifact(expected_ts_artifact_path(arc_dir, label))
+                _write_status(arc_dir, label, converged=True)
+            else:
+                _write_status(arc_dir, label, converged=False)
+
+
+def _hybrid_qm_ilt(hybrid_path):
+    """Which of the fixture's three TSs a hybrid file carries as QM/RRKM vs RMG/ILT: a QM'd TS's
+    reaction block drops its ``kinetics = Arrhenius(...)`` line, an ILT one keeps it. Scanned
+    textually because the hybrid's consumer is Arkane (which accepts its positional
+    ``transitionState(...)`` calls), not ``t3.pdep.parser``."""
+    with open(hybrid_path) as f:
+        content = f.read()
+    qm, ilt = [], []
+    for reaction_label, ts_label in (('reaction1', 'TS1'), ('reaction2', 'TS2'),
+                                     ('reaction3', 'TS3')):
+        start = content.index(f"label = '{reaction_label}'")
+        end = content.find('reaction(', start)
+        block = content[start:end if end != -1 else len(content)]
+        (ilt if 'kinetics = Arrhenius(' in block else qm).append(ts_label)
+    return sorted(qm), sorted(ilt)
+
+
+def _fixture_explorer(monkeypatch, project_directory, network_id):
+    """The canonical fake explorer of this module: each round's 'exploration' deposits a copy of
+    the real fixture at the exact path arc_qm_runner's real _explored_network_path recomputes."""
+    explore_calls = []
+
+    def _fake_explore(*, network_path, config, logger=None):
+        explore_calls.append(network_path)
+        paths = round_paths(project_directory, len(explore_calls) - 1)
+        dest_path = _explored_network_path(paths, network_id)
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        shutil.copyfile(_FIXTURE_NETWORK_PATH, dest_path)
+        return PDepExplorationResult(network_id=network_id,
+                                     status=EXPLORATION_STATUS_SUCCEEDED,
+                                     network_paths=(dest_path,))
+
+    monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
+    return explore_calls
+
+
+def test_real_loop_real_capture_carries_cumulative_qm_across_rounds(tmp_path, monkeypatch):
+    """The reviewer's exact scenario, against the REAL capture_ts_artifacts: round 0 adopts TS1
+    from a real prior capture and converges TS2; round 1 converges TS3. Before this fix round the
+    loop could not complete a single such round (defect 1), and when it did complete, round N+1's
+    hybrid dropped round N's QM back to Arrhenius lines (defect 3)."""
+    prior_project_dir = os.path.join(str(tmp_path), 'prior_project')
+    _build_prior_capture(prior_project_dir, ts_labels=('TS1',))
+    project_directory = os.path.join(str(tmp_path), 'loop_project')
+    os.makedirs(project_directory)
+    seed_path = os.path.join(str(tmp_path), 'network0_full.py')
+    shutil.copyfile(_FIXTURE_NETWORK_PATH, seed_path)
+
+    _fixture_explorer(monkeypatch, project_directory, 'network0_full')
+    _ArtifactWritingFakeARC.converge_plan = ({'TS2'}, {'TS3'})
+    _ArtifactWritingFakeARC.constructions = []
+    _ArtifactWritingFakeARC.executions = 0
+    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+
+    config = PESLoopConfig(
+        pes={'network': seed_path, 'source': ['O-2(13598)', 'CO2(11)'],
+             'bath_gas': {'Ar': 1.0}, 'method': 'MSC'},
+        termination={'max_rounds': 4},
+        reuse={'from_t3_projects': [prior_project_dir]},
+    )
+    result = run_pes_loop(config, project_directory=project_directory, qm_runner=arc_qm_runner)
+
+    assert result.status == 'converged', f'{result.status}: {result.reason}'
+    assert [record.status for record in result.rounds] == ['continuing', 'continuing', 'converged']
+    assert sorted(result.rounds[0].queued_ts_labels) == ['TS2', 'TS3']
+    assert sorted(result.rounds[1].queued_ts_labels) == ['TS3']
+
+    round0_hybrid = hybrid_network_path(round_paths(project_directory, 0), 'network0_full')
+    round1_hybrid = hybrid_network_path(round_paths(project_directory, 1), 'network0_full')
+    # Round 0: the adopted TS1 and the freshly converged TS2 are QM; TS3 is still ILT.
+    assert _hybrid_qm_ilt(round0_hybrid) == (['TS1', 'TS2'], ['TS3'])
+    # Round 1 -- THE defect-3 pin: the hybrid carries the CUMULATIVE QM, not just this round's.
+    # The defective loop wrote QM=['TS3'], ILT=['TS1', 'TS2'] here.
+    assert _hybrid_qm_ilt(round1_hybrid) == (['TS1', 'TS2', 'TS3'], [])
+
+    # Both rounds' captures are REAL and re-verify cleanly, sensitivity evidence included --
+    # exactly what defect 1 made impossible.
+    for round_index in (0, 1):
+        verified = verify_capture(round_paths(project_directory, round_index).capture)
+        for record in verified.ts_records:
+            if record.artifact_path is not None:
+                assert record.coefficient is not None and record.delta_ln_k is not None
+
+
+def test_real_loop_round_0_full_adoption_completes_with_real_vendoring(tmp_path, monkeypatch):
+    """Defect 2, end to end against the real vendoring and the real _adopted_energy_settings:
+    when EVERY candidate is adopted from a prior run, round 0 queues nothing, never touches ARC or
+    capture, and still writes a hybrid carrying all three TSs as QM; round 1 then converges."""
+    prior_project_dir = os.path.join(str(tmp_path), 'prior_project')
+    _build_prior_capture(prior_project_dir, ts_labels=('TS1', 'TS2', 'TS3'))
+    project_directory = os.path.join(str(tmp_path), 'loop_project')
+    os.makedirs(project_directory)
+    seed_path = os.path.join(str(tmp_path), 'network0_full.py')
+    shutil.copyfile(_FIXTURE_NETWORK_PATH, seed_path)
+
+    _fixture_explorer(monkeypatch, project_directory, 'network0_full')
+    _ArtifactWritingFakeARC.converge_plan = ()
+    _ArtifactWritingFakeARC.constructions = []
+    _ArtifactWritingFakeARC.executions = 0
+    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+
+    config = PESLoopConfig(
+        pes={'network': seed_path, 'source': ['O-2(13598)', 'CO2(11)'],
+             'bath_gas': {'Ar': 1.0}, 'method': 'MSC'},
+        termination={'max_rounds': 2},
+        reuse={'from_t3_projects': [prior_project_dir]},
+    )
+    result = run_pes_loop(config, project_directory=project_directory, qm_runner=arc_qm_runner)
+
+    assert result.status == 'converged', f'{result.status}: {result.reason}'
+    assert [record.status for record in result.rounds] == ['continuing', 'converged']
+    # Nothing was ever queued, so ARC must never even have been constructed.
+    assert _ArtifactWritingFakeARC.constructions == []
+    round0_hybrid = hybrid_network_path(round_paths(project_directory, 0), 'network0_full')
+    assert _hybrid_qm_ilt(round0_hybrid) == (['TS1', 'TS2', 'TS3'], [])
+    # The hybrid's energy settings came from the adopted artifacts' own prior manifest -- the
+    # _adopted_energy_settings path a capture-less round is forced through.
+    with open(round0_hybrid) as f:
+        assert 'wb97xd2023' in f.read()

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -26,6 +26,7 @@ module only corroborates that the loop and the real runner agree with each other
 """
 
 import os
+import re
 import shutil
 
 from t3.pdep.capture import (CaptureResult, capture_ts_artifacts, captured_qm_artifact_path,
@@ -218,18 +219,74 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
 # writer. Faked: ONLY the explorer (as everywhere in this suite) and ARC (execute() writes
 # converged statmech artifacts into the round's own ARC project instead of submitting cluster
 # jobs).
+#
+# The fake explorer RENUMBERS between rounds -- from round 1 on it swaps the fixture's
+# 'TS1'<->'TS2' and 'reaction1'<->'reaction2' labels while the channels stay put -- because every
+# label Arkane writes is purely positional (rmgpy/rmg/pdep.py:854) and a test whose labels are
+# trivially stable is blind to the wrong-saddle-point misattribution the structural carry exists
+# to prevent. Assertions are therefore by CHANNEL (reactant/product species), never by label, and
+# each fake ARC artifact carries a channel marker in its (hash-verified, verbatim-vendored) log
+# file so "the right barrier sits on the right channel" is checked on the bytes, not inferred.
 # ---------------------------------------------------------------------------------------------
 
 _MODEL_CHEMISTRY = "LevelOfTheory(method='wb97xd2023',basis='def2tzvp',software='gaussian')"
 
+# The fixture's three channels, by species labels (direction-insensitively sorted, as
+# _hybrid_channels below renders them).
+_CH1 = ('CO2(11) + O-2(13598)', 'O=C1OO1(21648)')
+_CH2 = ('O=C1OO1(21648)', '[O]C([O])=O(8160)')
+_CH3 = ('O=C1OO1(21648)', '[O]O[C]=O(8100)')
 
-def _write_artifact(path):
+
+def _channel_marker(reactants, products) -> str:
+    """A stable, label-free identity line for one channel, embedded in fake QM log files."""
+    return 'barrier-marker: ' + ' <=> '.join(
+        sorted((' + '.join(sorted(reactants)), ' + '.join(sorted(products)))))
+
+
+def _swap_quoted(text: str, a: str, b: str) -> str:
+    """Swap every quoted occurrence of two labels in a network file's text."""
+    return text.replace(f"'{a}'", "'@@SWAP@@'").replace(f"'{b}'", f"'{a}'") \
+               .replace("'@@SWAP@@'", f"'{b}'")
+
+
+def _renumbered_fixture_text() -> str:
+    """The real fixture with 'TS1'<->'TS2' and 'reaction1'<->'reaction2' swapped: the same three
+    channels, renumbered exactly the way a pruning/discovery re-exploration renumbers them."""
+    with open(_FIXTURE_NETWORK_PATH) as f:
+        text = f.read()
+    text = _swap_quoted(text, 'TS1', 'TS2')
+    return _swap_quoted(text, 'reaction1', 'reaction2')
+
+
+def _renamed_prior_network_text() -> str:
+    """The real fixture as a DIFFERENT project would have written it: every species label carries
+    that project's own indices, and the TS labels sit at different positions ('TS1'<->'TS3').
+    The adjacency lists -- the structures -- are untouched, so structural matching must still
+    recognize the channels."""
+    with open(_FIXTURE_NETWORK_PATH) as f:
+        text = f.read()
+    text = _swap_quoted(text, 'TS1', 'TS3')
+    for original, renamed in (('O=C1OO1(21648)', 'O=C1OO1(9)'),
+                              ('O-2(13598)', 'O-2(5)'),
+                              ('CO2(11)', 'CO2(7)'),
+                              ('[O]C([O])=O(8160)', '[O]C([O])=O(2)'),
+                              ('[O]O[C]=O(8100)', '[O]O[C]=O(3)')):
+        text = text.replace(f"'{original}'", f"'{renamed}'")
+    return text
+
+
+def _write_artifact(path, log_text='stub quantum chemistry log\n'):
+    # One log file PER artifact, named after it: ARC writes every transition state's statmech
+    # input into one shared TSs/ directory, so a shared 'output.out' would silently overwrite
+    # each artifact's channel marker with the last one written.
+    log_name = os.path.splitext(os.path.basename(path))[0] + '.out'
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(os.path.join(os.path.dirname(path), 'output.out'), 'w') as f:
-        f.write('stub quantum chemistry log\n')
+    with open(os.path.join(os.path.dirname(path), log_name), 'w') as f:
+        f.write(log_text)
     with open(path, 'w') as f:
-        f.write("linear = False\n\nspinMultiplicity = 2\n\nenergy = Log('output.out')\n\n"
-                "geometry = Log('output.out')\n\nfrequencies = Log('output.out')\n")
+        f.write(f"linear = False\n\nspinMultiplicity = 2\n\nenergy = Log('{log_name}')\n\n"
+                f"geometry = Log('{log_name}')\n\nfrequencies = Log('{log_name}')\n")
 
 
 def _write_status(arc_dir, label, converged):
@@ -256,29 +313,33 @@ def _write_energy_settings(arc_dir):
             f.write('{}\n')
 
 
-def _build_prior_capture(prior_project_dir, ts_labels):
-    """A REAL prior capture for ``ts_labels`` (each joined to the fixture's own
-    ``reaction<i>``), built by capture_ts_artifacts itself so adopt_prior_qm, the vendoring, and
-    _adopted_energy_settings all run against the exact formats production writes."""
+def _build_prior_capture(prior_project_dir, network_text, ts_labels):
+    """A REAL prior capture (built by capture_ts_artifacts itself) whose vendored network is a
+    REAL, parseable network file -- ``network_text`` -- and whose artifacts carry channel markers
+    in their log files. ``ts_labels`` are labels of THAT network's own numbering."""
     arc_dir = os.path.join(prior_project_dir, 'arc_project')
     network_id = 'prior_run_network'
+    networks_dir = os.path.join(prior_project_dir, 'networks')
+    os.makedirs(networks_dir, exist_ok=True)
+    source_path = os.path.join(networks_dir, f'{network_id}.py')
+    with open(source_path, 'w') as f:
+        f.write(network_text)
+    prior_network = parse_pdep_network_file(path=source_path)
+    reactions_by_ts = prior_network.path_reactions_by_ts()
     records = []
     for ts_label in ts_labels:
         label = arc_ts_label(network_id, ts_label)
         record = TSJoinRecord(network_id=network_id, network_ts_label=ts_label,
                               status=JOIN_STATUS_QUEUED, arc_ts_label=label,
                               expected_artifact_path=expected_ts_artifact_path(arc_dir, label),
-                              reason='Queued to ARC.', coefficient=-9.5e-05, delta_ln_k=0.795,
-                              path_reaction_labels=(f'reaction{ts_label[2:]}',))
-        _write_artifact(record.expected_artifact_path)
+                              reason='Queued to ARC.', coefficient=-9.5e-05, delta_ln_k=0.795)
+        path_reaction = reactions_by_ts[ts_label][0]
+        _write_artifact(record.expected_artifact_path,
+                        log_text=_channel_marker(path_reaction.reactants,
+                                                 path_reaction.products) + '\n')
         _write_status(arc_dir, label, converged=True)
         records.append(record)
     _write_energy_settings(arc_dir)
-    networks_dir = os.path.join(prior_project_dir, 'networks')
-    os.makedirs(networks_dir, exist_ok=True)
-    source_path = os.path.join(networks_dir, f'{network_id}.py')
-    with open(source_path, 'w') as f:
-        f.write(f"# stub RMG network file\nnetwork(label='{network_id}')\n")
     capture_ts_artifacts(
         records, arc_dir, os.path.join(prior_project_dir, 'capture'),
         networks={network_id: {'source_path': source_path,
@@ -290,8 +351,9 @@ def _build_prior_capture(prior_project_dir, ts_labels):
 class _ArtifactWritingFakeARC(object):
     """Stands in for arc.main.ARC at exactly the cluster boundary: execute() writes the statmech
     artifacts, convergence statuses, and energy settings a real ARC run would leave in the round's
-    own project directory, per the class-level ``converge_plan`` (one set of network-local TS
-    labels per execute() call)."""
+    own project directory. ``converge_plan`` names one set of CHANNELS (as _channel_marker
+    strings) per execute() call -- never labels, which renumber between rounds -- and every
+    converged artifact's log file records its channel marker."""
 
     converge_plan = ()
     constructions = []
@@ -311,41 +373,63 @@ class _ArtifactWritingFakeARC(object):
         _write_energy_settings(arc_dir)
         for reaction in self.kwargs['reactions']:
             label = reaction['ts_label']
-            if label.rsplit('_', 1)[-1] in to_converge:
-                _write_artifact(expected_ts_artifact_path(arc_dir, label))
+            channel = _channel_marker(reaction['reactants'], reaction['products'])
+            if channel in to_converge:
+                _write_artifact(expected_ts_artifact_path(arc_dir, label),
+                                log_text=channel + '\n')
                 _write_status(arc_dir, label, converged=True)
             else:
                 _write_status(arc_dir, label, converged=False)
 
 
-def _hybrid_qm_ilt(hybrid_path):
-    """Which of the fixture's three TSs a hybrid file carries as QM/RRKM vs RMG/ILT: a QM'd TS's
-    reaction block drops its ``kinetics = Arrhenius(...)`` line, an ILT one keeps it. Scanned
-    textually because the hybrid's consumer is Arkane (which accepts its positional
-    ``transitionState(...)`` calls), not ``t3.pdep.parser``."""
+def _hybrid_channels(hybrid_path):
+    """Read a hybrid file's reaction blocks by CHANNEL (never by label): channel pair ->
+    ``(local_ts_label, is_qm)``, where a QM'd channel's block has dropped its
+    ``kinetics = Arrhenius(...)`` line. Scanned textually because the hybrid's consumer is Arkane
+    (which accepts its positional ``transitionState(...)`` calls), not ``t3.pdep.parser``."""
     with open(hybrid_path) as f:
         content = f.read()
-    qm, ilt = [], []
-    for reaction_label, ts_label in (('reaction1', 'TS1'), ('reaction2', 'TS2'),
-                                     ('reaction3', 'TS3')):
-        start = content.index(f"label = '{reaction_label}'")
-        end = content.find('reaction(', start)
-        block = content[start:end if end != -1 else len(content)]
-        (ilt if 'kinetics = Arrhenius(' in block else qm).append(ts_label)
-    return sorted(qm), sorted(ilt)
+    channels = dict()
+    for block in re.split(r'\breaction\(', content)[1:]:
+        block = block.split('\n\n')[0]
+        # Greedy-to-end-of-line bracket matching: species labels themselves contain ']' (e.g.
+        # '[O]C([O])=O(8160)'), so a lazy or ]-excluding match truncates the list.
+        reactants = re.search(r"reactants = \[(.*)\],", block).group(1)
+        products = re.search(r"products = \[(.*)\],", block).group(1)
+        ts_label = re.search(r"transitionState = '([^']*)'", block).group(1)
+        sides = tuple(sorted(
+            ' + '.join(sorted(part.strip().strip("'") for part in side.split(',')))
+            for side in (reactants, products)))
+        channels[sides] = (ts_label, 'kinetics = Arrhenius(' not in block)
+    return channels
+
+
+def _hybrid_marker(hybrid_path, ts_label):
+    """The channel marker inside the hybrid's own vendored log for ``ts_label`` -- the bytes that
+    prove WHICH barrier was folded under that label."""
+    log_dir = os.path.join(os.path.dirname(hybrid_path), 'qm', 'logs', ts_label)
+    (log_name,) = os.listdir(log_dir)
+    with open(os.path.join(log_dir, log_name)) as f:
+        return f.read().strip()
 
 
 def _fixture_explorer(monkeypatch, project_directory, network_id):
-    """The canonical fake explorer of this module: each round's 'exploration' deposits a copy of
-    the real fixture at the exact path arc_qm_runner's real _explored_network_path recomputes."""
+    """The canonical fake explorer of this module: round 0's 'exploration' deposits the pristine
+    fixture; every later round deposits the RENUMBERED variant (_renumbered_fixture_text), so any
+    label-keyed carry across the round boundary is exposed rather than trivially stable."""
     explore_calls = []
 
     def _fake_explore(*, network_path, config, logger=None):
         explore_calls.append(network_path)
-        paths = round_paths(project_directory, len(explore_calls) - 1)
+        round_index = len(explore_calls) - 1
+        paths = round_paths(project_directory, round_index)
         dest_path = _explored_network_path(paths, network_id)
         os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-        shutil.copyfile(_FIXTURE_NETWORK_PATH, dest_path)
+        if round_index == 0:
+            shutil.copyfile(_FIXTURE_NETWORK_PATH, dest_path)
+        else:
+            with open(dest_path, 'w') as f:
+                f.write(_renumbered_fixture_text())
         return PDepExplorationResult(network_id=network_id,
                                      status=EXPLORATION_STATUS_SUCCEEDED,
                                      network_paths=(dest_path,))
@@ -354,20 +438,26 @@ def _fixture_explorer(monkeypatch, project_directory, network_id):
     return explore_calls
 
 
-def test_real_loop_real_capture_carries_cumulative_qm_across_rounds(tmp_path, monkeypatch):
-    """Against the REAL capture_ts_artifacts: round 0 queues the two above-floor channels and
-    converges TS1's; round 1 converges TS2's; TS3's channel measures a ln(k) response of exactly
-    0.0 in the live ME SA -- below qm.min_delta_ln_k -- so it is never queued, and the loop
-    reports a measured convergence at round 2 with that skip on the record. Before this fix round
-    the loop could not complete a single such round (defect 1), and when it did complete, round
-    N+1's hybrid dropped round N's QM back to Arrhenius lines (defect 3)."""
+_CH1_MARKER = _channel_marker(('O-2(13598)', 'CO2(11)'), ('O=C1OO1(21648)',))
+_CH2_MARKER = _channel_marker(('O=C1OO1(21648)',), ('[O]C([O])=O(8160)',))
+
+
+def test_real_loop_real_capture_keeps_qm_on_the_right_channel_across_a_renumber(tmp_path,
+                                                                                monkeypatch):
+    """Against the REAL capture_ts_artifacts, across a REAL renumbering: round 0 (pristine
+    labels) converges channel 1 (then labeled 'TS1'); round 1 explores the RENUMBERED network, in
+    which that same channel is labeled 'TS2' -- the loop must skip it under its new label, queue
+    channel 2 (now labeled 'TS1', which a label-keyed carry would have wrongly skipped as
+    computed), and fold round 0's barrier under the new label with the artifact bytes proving the
+    channel. Channel 3 measures a ln(k) response of exactly 0.0 in the live ME SA -- below
+    qm.min_delta_ln_k -- so it is never queued, and the loop converges at round 2."""
     project_directory = os.path.join(str(tmp_path), 'loop_project')
     os.makedirs(project_directory)
     seed_path = os.path.join(str(tmp_path), 'network0_full.py')
     shutil.copyfile(_FIXTURE_NETWORK_PATH, seed_path)
 
     _fixture_explorer(monkeypatch, project_directory, 'network0_full')
-    _ArtifactWritingFakeARC.converge_plan = ({'TS1'}, {'TS2'})
+    _ArtifactWritingFakeARC.converge_plan = ({_CH1_MARKER}, {_CH2_MARKER})
     _ArtifactWritingFakeARC.constructions = []
     _ArtifactWritingFakeARC.executions = 0
     monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
@@ -381,19 +471,32 @@ def test_real_loop_real_capture_carries_cumulative_qm_across_rounds(tmp_path, mo
 
     assert result.status == 'converged', f'{result.status}: {result.reason}'
     assert [record.status for record in result.rounds] == ['continuing', 'continuing', 'converged']
+    # Round 0 (pristine labels): channels 1 and 2 queued; channel 3 gated by its measured zero.
     assert sorted(result.rounds[0].queued_ts_labels) == ['TS1', 'TS2']
-    assert sorted(result.rounds[1].queued_ts_labels) == ['TS2']
-    # TS3's channel was gated by its own measured (zero) response, every round, on the record.
+    # Round 1 (renumbered): ONLY the still-uncomputed channel 2 queued -- under its NEW label
+    # 'TS1'. A label-keyed carry would have skipped 'TS1' as already computed and re-queued 'TS2'.
+    assert result.rounds[1].queued_ts_labels == ('TS1',)
     for record in result.rounds:
         floor_skips = [s for s in record.skipped if 'below the min_delta_ln_k floor' in s.reason]
-        assert [s.label for s in floor_skips] == ['reaction3']
+        assert len(floor_skips) == 1
 
-    round0_hybrid = hybrid_network_path(round_paths(project_directory, 0), 'network0_full')
-    round1_hybrid = hybrid_network_path(round_paths(project_directory, 1), 'network0_full')
-    assert _hybrid_qm_ilt(round0_hybrid) == (['TS1'], ['TS2', 'TS3'])
-    # Round 1 -- THE defect-3 pin: the hybrid carries the CUMULATIVE QM, not just this round's.
-    # The defective loop dropped round 0's QM back to an Arrhenius line here.
-    assert _hybrid_qm_ilt(round1_hybrid) == (['TS1', 'TS2'], ['TS3'])
+    round0 = _hybrid_channels(hybrid_network_path(round_paths(project_directory, 0),
+                                                  'network0_full'))
+    round1_hybrid_path = hybrid_network_path(round_paths(project_directory, 1), 'network0_full')
+    round1 = _hybrid_channels(round1_hybrid_path)
+    # Round 0 hybrid (pristine labels): channel 1 is QM as 'TS1'; channels 2, 3 are ILT.
+    assert round0[_CH1] == ('TS1', True)
+    assert round0[_CH2] == ('TS2', False)
+    assert round0[_CH3] == ('TS3', False)
+    # Round 1 hybrid (renumbered labels): cumulative QM, each channel under its NEW label.
+    assert round1[_CH1] == ('TS2', True)
+    assert round1[_CH2] == ('TS1', True)
+    assert round1[_CH3] == ('TS3', False)
+    # The bytes prove the attribution: under round 1's 'TS2' sits round 0's channel-1 barrier,
+    # and under 'TS1' sits this round's channel-2 barrier -- the right barrier on the right
+    # channel, across the renumber.
+    assert _hybrid_marker(round1_hybrid_path, 'TS2') == _CH1_MARKER
+    assert _hybrid_marker(round1_hybrid_path, 'TS1') == _CH2_MARKER
 
     # Both rounds' captures are REAL and re-verify cleanly, sensitivity evidence included --
     # exactly what defect 1 made impossible.
@@ -408,11 +511,14 @@ def test_real_loop_real_capture_carries_cumulative_qm_across_rounds(tmp_path, mo
 
 
 def test_real_loop_round_0_full_adoption_completes_with_real_vendoring(tmp_path, monkeypatch):
-    """Defect 2, end to end against the real vendoring and the real _adopted_energy_settings:
-    when EVERY candidate is adopted from a prior run, round 0 queues nothing, never touches ARC or
-    capture, and still writes a hybrid carrying all three TSs as QM; round 1 then converges."""
+    """Defect 2 end to end, with adoption made maximally hostile to label matching: the prior
+    project's vendored network carries DIFFERENT species label indices and different TS positions
+    ('TS1'<->'TS3') -- only the structures match. All three channels adopt, round 0 queues
+    nothing, never touches ARC or capture, and still writes a hybrid carrying all three channels
+    as QM (each barrier's bytes on its own channel); round 1 then converges."""
     prior_project_dir = os.path.join(str(tmp_path), 'prior_project')
-    _build_prior_capture(prior_project_dir, ts_labels=('TS1', 'TS2', 'TS3'))
+    _build_prior_capture(prior_project_dir, network_text=_renamed_prior_network_text(),
+                         ts_labels=('TS1', 'TS2', 'TS3'))
     project_directory = os.path.join(str(tmp_path), 'loop_project')
     os.makedirs(project_directory)
     seed_path = os.path.join(str(tmp_path), 'network0_full.py')
@@ -436,9 +542,21 @@ def test_real_loop_round_0_full_adoption_completes_with_real_vendoring(tmp_path,
     assert [record.status for record in result.rounds] == ['continuing', 'converged']
     # Nothing was ever queued, so ARC must never even have been constructed.
     assert _ArtifactWritingFakeARC.constructions == []
-    round0_hybrid = hybrid_network_path(round_paths(project_directory, 0), 'network0_full')
-    assert _hybrid_qm_ilt(round0_hybrid) == (['TS1', 'TS2', 'TS3'], [])
+    round0_hybrid_path = hybrid_network_path(round_paths(project_directory, 0), 'network0_full')
+    round0 = _hybrid_channels(round0_hybrid_path)
+    assert round0[_CH1] == ('TS1', True)
+    assert round0[_CH2] == ('TS2', True)
+    assert round0[_CH3] == ('TS3', True)
+    # Each adopted barrier's bytes sit on their own channel, matched purely structurally: the
+    # prior project's markers carry ITS species labels, so equality here proves the artifact came
+    # from the structurally-matching prior channel, not from any label agreement.
+    assert _hybrid_marker(round0_hybrid_path, 'TS1') \
+        == _channel_marker(('O-2(5)', 'CO2(7)'), ('O=C1OO1(9)',))
+    assert _hybrid_marker(round0_hybrid_path, 'TS2') \
+        == _channel_marker(('O=C1OO1(9)',), ('[O]C([O])=O(2)',))
+    assert _hybrid_marker(round0_hybrid_path, 'TS3') \
+        == _channel_marker(('O=C1OO1(9)',), ('[O]O[C]=O(3)',))
     # The hybrid's energy settings came from the adopted artifacts' own prior manifest -- the
     # _adopted_energy_settings path a capture-less round is forced through.
-    with open(round0_hybrid) as f:
+    with open(round0_hybrid_path) as f:
         assert 'wb97xd2023' in f.read()

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -1,0 +1,175 @@
+"""
+t3 tests test_pdep test_pes_loop_integration module
+
+N6 (round 3 of the Task 6 review): nothing anywhere paired the REAL ``t3.pdep.pes_loop.run_pes_loop``
+with the REAL ``t3.pdep.pes_qm.arc_qm_runner``. Every ``test_pes_loop.py`` test injects a
+hand-written ``qm_runner`` double whose two-tuple return can never disagree with what the loop
+offered (that gap is exactly what round 3's N3 fix addressed on the loop side). Every
+``test_pes_qm.py`` test drives ``arc_qm_runner`` directly, with no ``run_pes_loop`` around it, so it
+can never observe whether the hybrid network file ``arc_qm_runner`` writes for round N is actually
+the file ``run_pes_loop`` hands its round-(N+1) explorer -- each half's tests only ever check that
+convention against itself.
+
+This module is that missing pairing. It fakes only the three boundaries ``arc_qm_runner`` itself
+cannot cross in a test process -- ``ARC`` (no cluster here), ``capture_ts_artifacts`` (no real QM
+job to capture from), and ``write_hybrid_network_input_file`` (no real QM artifacts to fold into a
+hybrid network) -- with argument-recording doubles. ``explore_pdep_network`` is also faked, the same
+way every other ``pes_loop`` test fakes it (Arkane itself is out of scope for this loop's own test
+suite, and always has been); everything downstream of that -- the real ``parse_pdep_network_file``,
+the real ``split_qm_candidates``, the real ``draw_pes_diagram``, the real ``build_arc_input``, and
+every join/capture computation inside ``arc_qm_runner`` -- runs unfaked, against the real
+``network799_1`` fixture also used by ``test_pes_qm.py``.
+
+Wiring ``run_pes_loop``'s ``qm_runner`` argument into ``t3.main`` stays deliberately out of scope --
+this loop is standalone until corroborated (see ``pes_loop.py``'s own module docstring) -- this
+module only corroborates that the loop and the real runner agree with each other.
+"""
+
+import os
+import shutil
+
+from t3.pdep.capture import CaptureResult
+from t3.pdep.discovery import ARTIFACT_STATUS_USABLE, TSArtifactRecord
+from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED, PDepExplorationResult
+from t3.pdep.hybrid import HybridNetworkResult
+from t3.pdep.parser import parse_pdep_network_file
+import t3.pdep.pes_qm as pes_qm
+from t3.pdep.pes_loop import run_pes_loop
+from t3.pdep.pes_qm import _explored_network_path, arc_qm_runner
+from t3.pdep.pes_rounds import round_paths, split_qm_candidates
+from t3.schema import PESLoopConfig
+
+_FIXTURE_NETWORK_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'data', 'pdep_real_networks', 'network799_1', 'network799_1.py')
+
+# The same frozen energy-settings shape t3.pdep.pes_qm.QMEnergySettings.from_frozen expects,
+# mirroring test_pes_qm.py's own _FROZEN_ENERGY_SETTINGS.
+_ENERGY_SETTINGS = {
+    'model_chemistry': 'wb97xd/def2tzvp',
+    'frequency_scale_factor': None,
+    'use_hindered_rotors': True,
+    'use_bond_corrections': False,
+    'bond_correction_type': None,
+    'atom_energies': None,
+    'use_atom_corrections': True,
+    'bond_additivity_corrections': None,
+}
+
+
+class _FakeARC(object):
+    """Stands in for arc.main.ARC: no cluster, no execute -- just records what it was built with."""
+
+    constructions = []
+    execute_calls = 0
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _FakeARC.constructions.append(kwargs)
+
+    def execute(self):
+        _FakeARC.execute_calls += 1
+
+    def as_dict(self):
+        return dict(self.kwargs)
+
+
+def _config(max_rounds=3):
+    return PESLoopConfig(pes={'network': _FIXTURE_NETWORK_PATH, 'source': ['A'],
+                              'bath_gas': {'He': 1.0}},
+                         termination={'max_rounds': max_rounds, 'stop_when_no_new_ts': False})
+
+
+def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, monkeypatch):
+    """Drive the real run_pes_loop with the real arc_qm_runner injected as qm_runner, faking only
+    ARC, capture_ts_artifacts, and write_hybrid_network_input_file. Assert the loop completes at
+    least two rounds, and -- the actual N6 contract -- that the exact hybrid file arc_qm_runner
+    writes for round 0 is the exact file run_pes_loop hands its round-1 explorer, observed end to
+    end through the real loop rather than inferred from two separately-passing unit tests."""
+    real_network = parse_pdep_network_file(path=_FIXTURE_NETWORK_PATH)
+    real_split = split_qm_candidates(real_network, frozenset())
+    assert real_split.candidates, 'fixture must offer at least one real QM candidate'
+    target = real_split.candidates[0]
+
+    project_directory = str(tmp_path)
+    # What run_pes_loop actually handed this fake as `network_path` each round -- the N6 contract
+    # (round 1 gets round 0's hybrid file) is about THIS list, not about wherever the fake itself
+    # chooses to write.
+    received_network_paths = []
+
+    def _fake_explore(*, network_path, config, logger=None):
+        received_network_paths.append(network_path)
+        # Not one of the three edges N6 names -- Arkane itself stays faked here exactly as it is
+        # in every other pes_loop test -- but the file this hands downstream is a real, on-disk
+        # copy of network799_1, written to the SAME canonical location the real Arkane explorer
+        # would use (paths.explorer_output/pdep/final/<network_id>.py, round_paths(...)'s own
+        # convention), because arc_qm_runner's real, unfaked _explored_network_path(paths,
+        # network_id) recomputes that exact path independently rather than trusting whatever this
+        # fake returns in network_paths -- so writing anywhere else would desync the two halves.
+        round_index = len(received_network_paths) - 1
+        paths = round_paths(project_directory, round_index)
+        dest_path = _explored_network_path(paths, real_network.network_id)
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        shutil.copyfile(_FIXTURE_NETWORK_PATH, dest_path)
+        return PDepExplorationResult(network_id=real_network.network_id,
+                                     status=EXPLORATION_STATUS_SUCCEEDED,
+                                     network_paths=(dest_path,))
+
+    monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
+
+    _FakeARC.constructions = []
+    _FakeARC.execute_calls = 0
+    monkeypatch.setattr(pes_qm, 'ARC', _FakeARC)
+
+    write_hybrid_calls = []
+
+    def _fake_capture_ts_artifacts(*, join_records, arc_project_directory, capture_dir, networks):
+        os.makedirs(capture_dir, exist_ok=True)
+        return CaptureResult(
+            capture_dir=capture_dir,
+            manifest_path=os.path.join(capture_dir, 'manifest.yml'),
+            records=(
+                TSArtifactRecord(network_id=real_network.network_id,
+                                 network_ts_label=target.ts_label,
+                                 arc_ts_label=f'{real_network.network_id}_{target.ts_label}',
+                                 status=ARTIFACT_STATUS_USABLE,
+                                 artifact_path=os.path.join(capture_dir, f'{target.ts_label}.py'),
+                                 converged=True),
+            ),
+            energy_settings=_ENERGY_SETTINGS,
+            networks={
+                real_network.network_id: {
+                    'source_path': _FIXTURE_NETWORK_PATH,
+                    'captured_path': f'{target.ts_label}.py',
+                    'method': 'MSC',
+                },
+            },
+        )
+
+    def _fake_write_hybrid_network_input_file(*, source_path, dest_path, method,
+                                              qm_transition_states, energy_settings,
+                                              qm_artifacts_root):
+        write_hybrid_calls.append({'source_path': source_path, 'dest_path': dest_path})
+        # run_pes_loop's own round>0 guard checks for this file's existence on disk for real, so
+        # the double must actually write it, not merely return a result object claiming to.
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        open(dest_path, 'w').close()
+        return HybridNetworkResult(dest_path=dest_path, qm_ts_labels=tuple(qm_transition_states),
+                                   ilt_ts_labels=(), vendored_files=(), warnings=())
+
+    monkeypatch.setattr(pes_qm, 'capture_ts_artifacts', _fake_capture_ts_artifacts)
+    monkeypatch.setattr(pes_qm, 'write_hybrid_network_input_file',
+                        _fake_write_hybrid_network_input_file)
+
+    config = _config(max_rounds=3)
+    result = run_pes_loop(config, project_directory=str(tmp_path), qm_runner=arc_qm_runner)
+
+    assert len(result.rounds) >= 2, (
+        f'expected at least two rounds, got {len(result.rounds)}: '
+        f'{[r.status for r in result.rounds]} ({result.status}: {result.reason})')
+    assert len(write_hybrid_calls) >= 1
+    round0_hybrid_path = write_hybrid_calls[0]['dest_path']
+    assert os.path.isfile(round0_hybrid_path)
+    assert len(received_network_paths) >= 2
+    # The actual N6 contract: round 1's explorer must be handed EXACTLY the file arc_qm_runner
+    # wrote for round 0.
+    assert received_network_paths[1] == round0_hybrid_path

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -572,11 +572,12 @@ def test_real_loop_round_0_full_adoption_completes_with_real_vendoring(tmp_path,
 def test_pes_cli_main_drives_the_real_loop_end_to_end(tmp_path, monkeypatch):
     """``PES.main()`` for real, from a real input file: the only things faked are the two external
     engines (Arkane's explorer and ARC). The real ``run_pes_loop``, the real ``arc_qm_runner`` and
-    the real ``capture_ts_artifacts`` all execute, and every assertion below is about what landed
-    on disk under the input file's own directory -- which is what proves the CLI's
-    ``project_directory`` default reached ``round_paths``, that its relative ``pes.network`` was
-    resolved against the input file, and that ``termination.max_rounds`` parsed out of the YAML
-    (2) governed the run rather than the schema default (5)."""
+    the real ``capture_ts_artifacts`` all execute, and the assertions are on artifacts only
+    production writes -- the hybrid network under the input file's own directory (the
+    ``project_directory`` default reaching ``round_paths``), the path the explorer was handed (the
+    relative ``pes.network`` resolved against the input file), and the round count
+    (``termination.max_rounds`` parsed out of the YAML, 2, governing the run rather than the
+    schema default of 5)."""
     project_directory = str(tmp_path)
     input_path = os.path.join(project_directory, 'input.yml')
     shutil.copyfile(_FIXTURE_NETWORK_PATH, os.path.join(project_directory, 'network0_full.py'))
@@ -610,13 +611,23 @@ def test_pes_cli_main_drives_the_real_loop_end_to_end(tmp_path, monkeypatch):
     assert _ArtifactWritingFakeARC.executions == 2
     assert PES.exit_code_for(result.status) == 0
 
-    # The round directories landed under the INPUT FILE's own directory: the project_directory
-    # default is what the loop actually ran with, not merely what main() computed.
+    # The fake explorer makes its own round directories under this same path, so these two say
+    # only that the run got as far as two rounds -- what proves the CLI's project_directory
+    # default reached round_paths is the hybrid below, which production alone writes. The absence
+    # of round_2 does reflect production: it is the round budget, via the explorer call count.
     assert os.path.isdir(os.path.join(project_directory, 'round_0'))
     assert os.path.isdir(os.path.join(project_directory, 'round_1'))
     assert not os.path.isdir(os.path.join(project_directory, 'round_2'))
-    # Ruling 3: the run left a real log behind.
-    assert os.path.isfile(os.path.join(project_directory, 't3.log'))
+
+    # Ruling 6: the final status, its reason, and the diagram reached the log, and the run was
+    # closed out -- not merely returned to a caller who might never print it.
+    with open(os.path.join(project_directory, 't3.log')) as f:
+        log_text = f.read()
+    assert "terminated with status 'max_rounds' after 2 round(s)." in log_text
+    assert f'Reason: {result.reason}' in log_text
+    assert f'PES diagram: {result.final_diagram_path}' in log_text
+    assert f'Final network: {result.final_network_path}' in log_text
+    assert 'Total T3 execution time' in log_text
 
     round1_hybrid_path = hybrid_network_path(round_paths(project_directory, 1), 'network0_full')
     assert os.path.isfile(round1_hybrid_path)
@@ -629,3 +640,83 @@ def test_pes_cli_main_drives_the_real_loop_end_to_end(tmp_path, monkeypatch):
     # The bytes prove which barrier landed on which channel through the CLI's own run.
     assert _hybrid_marker(round1_hybrid_path, 'TS2') == _CH1_MARKER
     assert _hybrid_marker(round1_hybrid_path, 'TS1') == _CH2_MARKER
+
+
+def test_pes_cli_project_directory_flag_moves_the_whole_run(tmp_path, monkeypatch):
+    """``-p`` end to end: the run must land in the given directory and NOTHING may land beside the
+    input file. Asserted on the hybrid network and the log -- artifacts only production writes --
+    because the fake explorer creates round directories under whatever path it was handed and so
+    cannot distinguish the flag from the default."""
+    input_directory = os.path.join(str(tmp_path), 'inputs')
+    run_directory = os.path.join(str(tmp_path), 'elsewhere', 'run')
+    os.makedirs(input_directory)
+    input_path = os.path.join(input_directory, 'input.yml')
+    shutil.copyfile(_FIXTURE_NETWORK_PATH, os.path.join(input_directory, 'network0_full.py'))
+    with open(input_path, 'w') as f:
+        yaml.dump({'pes': {'network': 'network0_full.py',
+                           'source': ['O-2(13598)', 'CO2(11)'],
+                           'bath_gas': {'Ar': 1.0},
+                           'method': 'MSC'},
+                   'termination': {'max_rounds': 1}}, f)
+
+    _fixture_explorer(monkeypatch, run_directory, 'network0_full')
+    _ArtifactWritingFakeARC.converge_plan = ({_CH1_MARKER},)
+    _ArtifactWritingFakeARC.constructions = []
+    _ArtifactWritingFakeARC.executions = 0
+    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr(sys, 'argv', ['PES.py', input_path, '-p', run_directory])
+
+    result = PES.main()
+
+    assert result.status == 'max_rounds', f'{result.status}: {result.reason}'
+    # The hybrid network -- written by arc_qm_runner, at a path derived from the project_directory
+    # the LOOP was given -- landed under the -p directory, which the CLI also had to create.
+    round0_hybrid_path = hybrid_network_path(round_paths(run_directory, 0), 'network0_full')
+    assert os.path.isfile(round0_hybrid_path)
+    assert _hybrid_channels(round0_hybrid_path)[_CH1] == ('TS1', True)
+    assert os.path.isfile(os.path.join(run_directory, 't3.log'))
+    # Nothing whatsoever landed beside the input file.
+    assert sorted(os.listdir(input_directory)) == ['input.yml', 'network0_full.py']
+
+
+def test_pes_cli_resolves_a_relative_reuse_path_against_the_input_file(tmp_path, monkeypatch):
+    """``reuse.from_t3_projects`` is anchored exactly like ``pes.network``: relative to the input
+    file. Unresolved it fails silently rather than loudly -- the prior project is simply not found,
+    nothing adopts, and the loop pays for it by queueing real quantum chemistry it already had.
+    Here the prior capture holds all three channels, so a correctly resolved path means ARC is
+    never even constructed."""
+    prior_project_dir = os.path.join(str(tmp_path), 'prior_project')
+    _build_prior_capture(prior_project_dir, network_text=_renamed_prior_network_text(),
+                         ts_labels=('TS1', 'TS2', 'TS3'))
+    project_directory = os.path.join(str(tmp_path), 'loop_project')
+    os.makedirs(project_directory)
+    input_path = os.path.join(project_directory, 'input.yml')
+    shutil.copyfile(_FIXTURE_NETWORK_PATH, os.path.join(project_directory, 'network0_full.py'))
+    with open(input_path, 'w') as f:
+        yaml.dump({'pes': {'network': 'network0_full.py',
+                           'source': ['O-2(13598)', 'CO2(11)'],
+                           'bath_gas': {'Ar': 1.0},
+                           'method': 'MSC'},
+                   'termination': {'max_rounds': 2},
+                   'reuse': {'from_t3_projects': ['../prior_project']}}, f)
+
+    _fixture_explorer(monkeypatch, project_directory, 'network0_full')
+    _ArtifactWritingFakeARC.converge_plan = ()
+    _ArtifactWritingFakeARC.constructions = []
+    _ArtifactWritingFakeARC.executions = 0
+    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr(sys, 'argv', ['PES.py', input_path])
+
+    result = PES.main()
+
+    assert result.status == 'converged', f'{result.status}: {result.reason}'
+    # All three channels adopted from the prior project, so nothing was ever queued: an
+    # unresolved reuse path would have adopted nothing and run a real ARC round instead.
+    assert _ArtifactWritingFakeARC.constructions == []
+    round0_hybrid_path = hybrid_network_path(round_paths(project_directory, 0), 'network0_full')
+    round0 = _hybrid_channels(round0_hybrid_path)
+    assert [round0[channel][1] for channel in (_CH1, _CH2, _CH3)] == [True, True, True]
+    # Ruling 3: the Logger main() built was actually handed to the loop -- this line is the
+    # LOOP's own, not the CLI's, so it can only be in the file if logger= reached run_pes_loop.
+    with open(os.path.join(project_directory, 't3.log')) as f:
+        assert "PES loop: reusing 3 prior QM result(s)" in f.read()

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -612,11 +612,17 @@ def test_pes_cli_main_drives_the_real_loop_end_to_end(tmp_path, monkeypatch):
 
     # The fake explorer makes its own round directories under this same path, so these two say
     # only that the run got as far as two rounds -- what proves the CLI's project_directory
-    # default reached round_paths is the hybrid below, which production alone writes. The absence
-    # of round_2 does reflect production: it is the round budget, via the explorer call count.
+    # default reached round_paths is the hybrid below, which production alone writes.
     assert os.path.isdir(os.path.join(project_directory, 'round_0'))
     assert os.path.isdir(os.path.join(project_directory, 'round_1'))
-    assert not os.path.isdir(os.path.join(project_directory, 'round_2'))
+    # round_2 is the final draw pass over round 1's hybrid -- the whole point of the branch, since
+    # round 1's own diagram predates round 1's own quantum chemistry. It is a draw, not a round:
+    # the budget stayed at 2 (rounds, and ARC executions, both asserted above) and it has no ARC
+    # project directory at all.
+    assert os.path.isdir(os.path.join(project_directory, 'round_2'))
+    assert not os.path.isdir(round_paths(project_directory, 2).arc_project)
+    assert result.final_diagram_path == round_paths(project_directory, 2).diagram
+    assert os.path.isfile(result.final_diagram_path)
 
     # Ruling 6: the final status, its reason, and the diagram reached the log, and the run was
     # closed out -- not merely returned to a caller who might never print it.

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -137,7 +137,7 @@ def test_real_run_pes_loop_wires_the_real_arc_qm_runner_across_rounds(tmp_path, 
     write_hybrid_calls = []
 
     def _fake_capture_ts_artifacts(*, join_records, arc_project_directory, capture_dir, networks,
-                                   sensitivity_by_ts):
+                                   sensitivity_by_ts, sensitivity_aggregation):
         # Defect 1: the real capture_ts_artifacts refuses (via its verify_capture self-check) any
         # captured artifact whose join record carries no finite sensitivity evidence -- so even
         # this double must insist the runner actually passed it, keyed and finite, or the pairing
@@ -503,6 +503,9 @@ def test_real_loop_real_capture_keeps_qm_on_the_right_channel_across_a_renumber(
     verified_artifacts = 0
     for round_index in (0, 1):
         verified = verify_capture(round_paths(project_directory, round_index).capture)
+        # Loop-written manifests carry the aggregation marker, so their ungated all-directions
+        # evidence can never be silently compared against T3's in-run (observable-gated) values.
+        assert verified.sensitivity_aggregation == 'all_directions_max_abs'
         for record in verified.ts_records:
             if record.artifact_path is not None:
                 verified_artifacts += 1

--- a/tests/test_pdep/test_pes_loop_integration.py
+++ b/tests/test_pdep/test_pes_loop_integration.py
@@ -28,7 +28,11 @@ module only corroborates that the loop and the real runner agree with each other
 import os
 import re
 import shutil
+import sys
 
+import yaml
+
+import PES
 from t3.pdep.capture import (CaptureResult, capture_ts_artifacts, captured_qm_artifact_path,
                              verify_capture)
 from t3.pdep.discovery import ARTIFACT_STATUS_USABLE, TSArtifactRecord
@@ -563,3 +567,65 @@ def test_real_loop_round_0_full_adoption_completes_with_real_vendoring(tmp_path,
     # _adopted_energy_settings path a capture-less round is forced through.
     with open(round0_hybrid_path) as f:
         assert 'wb97xd2023' in f.read()
+
+
+def test_pes_cli_main_drives_the_real_loop_end_to_end(tmp_path, monkeypatch):
+    """``PES.main()`` for real, from a real input file: the only things faked are the two external
+    engines (Arkane's explorer and ARC). The real ``run_pes_loop``, the real ``arc_qm_runner`` and
+    the real ``capture_ts_artifacts`` all execute, and every assertion below is about what landed
+    on disk under the input file's own directory -- which is what proves the CLI's
+    ``project_directory`` default reached ``round_paths``, that its relative ``pes.network`` was
+    resolved against the input file, and that ``termination.max_rounds`` parsed out of the YAML
+    (2) governed the run rather than the schema default (5)."""
+    project_directory = str(tmp_path)
+    input_path = os.path.join(project_directory, 'input.yml')
+    shutil.copyfile(_FIXTURE_NETWORK_PATH, os.path.join(project_directory, 'network0_full.py'))
+    with open(input_path, 'w') as f:
+        # 'network' is deliberately RELATIVE: the CLI must resolve it against the input file's
+        # directory, or the explorer never sees a readable seed.
+        yaml.dump({'pes': {'network': 'network0_full.py',
+                           'source': ['O-2(13598)', 'CO2(11)'],
+                           'bath_gas': {'Ar': 1.0},
+                           'method': 'MSC'},
+                   'termination': {'max_rounds': 2}}, f)
+
+    explore_calls = _fixture_explorer(monkeypatch, project_directory, 'network0_full')
+    _ArtifactWritingFakeARC.converge_plan = ({_CH1_MARKER}, {_CH2_MARKER})
+    _ArtifactWritingFakeARC.constructions = []
+    _ArtifactWritingFakeARC.executions = 0
+    monkeypatch.setattr(pes_qm, 'ARC', _ArtifactWritingFakeARC)
+    monkeypatch.setattr(sys, 'argv', ['PES.py', input_path])
+
+    result = PES.main()
+
+    # What the explorer was actually HANDED for round 0: the relative 'network0_full.py' of the
+    # input file, resolved to an absolute path against that file's own directory. Asserted on the
+    # engine's argument rather than on the run's success, because the fake explorer would have
+    # succeeded on an unresolved path too -- and the real one would not.
+    assert explore_calls[0] == os.path.join(project_directory, 'network0_full.py')
+
+    # max_rounds: 2 from the input file, not the schema's default of 5.
+    assert result.status == 'max_rounds', f'{result.status}: {result.reason}'
+    assert len(result.rounds) == 2
+    assert _ArtifactWritingFakeARC.executions == 2
+    assert PES.exit_code_for(result.status) == 0
+
+    # The round directories landed under the INPUT FILE's own directory: the project_directory
+    # default is what the loop actually ran with, not merely what main() computed.
+    assert os.path.isdir(os.path.join(project_directory, 'round_0'))
+    assert os.path.isdir(os.path.join(project_directory, 'round_1'))
+    assert not os.path.isdir(os.path.join(project_directory, 'round_2'))
+    # Ruling 3: the run left a real log behind.
+    assert os.path.isfile(os.path.join(project_directory, 't3.log'))
+
+    round1_hybrid_path = hybrid_network_path(round_paths(project_directory, 1), 'network0_full')
+    assert os.path.isfile(round1_hybrid_path)
+    round1 = _hybrid_channels(round1_hybrid_path)
+    # Round 1 explored the RENUMBERED network, so channel 1 -- QM'd in round 0 -- carries the new
+    # label 'TS2' here, and this round's channel 2 carries 'TS1'.
+    assert round1[_CH1] == ('TS2', True)
+    assert round1[_CH2] == ('TS1', True)
+    assert round1[_CH3] == ('TS3', False)
+    # The bytes prove which barrier landed on which channel through the CLI's own run.
+    assert _hybrid_marker(round1_hybrid_path, 'TS2') == _CH1_MARKER
+    assert _hybrid_marker(round1_hybrid_path, 'TS1') == _CH2_MARKER

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -1,6 +1,15 @@
 """Tests for t3.pdep.pes_qm."""
 
-from t3.pdep.pes_qm import build_arc_input
+import os
+import shutil
+
+import t3.pdep.pes_qm as pes_qm
+from t3.pdep.capture import CaptureResult
+from t3.pdep.discovery import ARTIFACT_STATUS_UNVERIFIED, ARTIFACT_STATUS_USABLE, TSArtifactRecord
+from t3.pdep.hybrid import HybridNetworkResult
+from t3.pdep.parser import PDepPathReaction
+from t3.pdep.pes_loop import hybrid_network_path
+from t3.pdep.pes_qm import ARC_INPUT_FILE_NAME, arc_qm_runner, build_arc_input
 from t3.pdep.pes_rounds import QMCandidate, round_paths
 from t3.schema import PESLoopConfig
 
@@ -9,38 +18,370 @@ def _config(**qm) -> PESLoopConfig:
     return PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']}, **({'qm': qm} if qm else {}))
 
 
+def _candidate(ts_label='TS1', family='1,2_Insertion_CO', reactants=('A',), products=('B',),
+              label='reaction1') -> QMCandidate:
+    path_reaction = PDepPathReaction(
+        label=label, reactants=reactants, products=products,
+        transition_state=ts_label, kinetics_type='Arrhenius', kinetics_comment='',
+    )
+    return QMCandidate(path_reaction=path_reaction, ts_label=ts_label, family=family)
+
+
+# Adjacency-list text is opaque to build_arc_input -- any non-empty string exercises the
+# species_structures plumbing without needing a chemically valid structure.
+_STRUCTURES = {'A': '1 A u0 p0 c0\n', 'B': '1 B u0 p0 c0\n'}
+
+
 class TestBuildARCInput(object):
 
     def test_levels_reach_arc_undashed(self):
-        arc_input = build_arc_input((), round_paths('/proj', 0), _config(), 'network1_1')
+        arc_input = build_arc_input((), round_paths('/proj', 0), _config(), 'network1_1', {})
         assert arc_input['opt_level'] == 'wb97xd/def2tzvp'
         assert '-' not in arc_input['opt_level'].split('/')[1]
 
     def test_rotors_and_irc_off_by_default(self):
-        arc_input = build_arc_input((), round_paths('/proj', 0), _config(), 'network1_1')
+        arc_input = build_arc_input((), round_paths('/proj', 0), _config(), 'network1_1', {})
         assert arc_input['job_types']['rotors'] is False
         assert arc_input['job_types']['irc'] is False
 
     def test_rotors_and_irc_can_be_turned_on(self):
         arc_input = build_arc_input((), round_paths('/proj', 0),
-                                    _config(rotors=True, irc=True), 'network1_1')
+                                    _config(rotors=True, irc=True), 'network1_1', {})
         assert arc_input['job_types']['rotors'] is True
         assert arc_input['job_types']['irc'] is True
 
     def test_ts_adapters_are_passed_through(self):
         arc_input = build_arc_input((), round_paths('/proj', 0),
-                                    _config(ts_adapters=['linear', 'rits']), 'network1_1')
+                                    _config(ts_adapters=['linear', 'rits']), 'network1_1', {})
         assert arc_input['ts_adapters'] == ['linear', 'rits']
 
     def test_project_directory_is_the_rounds_own_arc_project(self):
         paths = round_paths('/proj', 2)
-        arc_input = build_arc_input((), paths, _config(), 'network1_1')
+        arc_input = build_arc_input((), paths, _config(), 'network1_1', {})
         assert arc_input['project_directory'] == paths.arc_project
 
     def test_ts_labels_are_namespaced_not_network_local(self):
         """A network-local 'TS1' collides across networks; join.arc_ts_label namespaces it so a
         network can never be joined to another network's quantum chemistry."""
-        candidate = QMCandidate(path_reaction=None, ts_label='TS1', family='1,2_Insertion_CO')
-        arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1')
-        assert arc_input['reactions'][0]['ts_label'] != 'TS1'
-        assert 'TS1' in arc_input['reactions'][0]['ts_label']
+        candidate = _candidate(ts_label='TS1')
+        arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1',
+                                    _STRUCTURES)
+        assert arc_input['reactions'][0]['ts_label'] == 'T3PDep_network1_1_TS1'
+
+    def test_sp_scan_irc_level_and_family_reach_arc_input(self):
+        candidate = _candidate(family='1,2_Insertion_CO')
+        arc_input = build_arc_input(
+            (candidate,), round_paths('/proj', 0),
+            _config(sp_level='ccsd(t)-f12/cc-pvtz-f12', scan_level='wb97xd/def2tzvp',
+                   irc_level='wb97xd/def2tzvp'),
+            'network1_1', _STRUCTURES)
+        assert arc_input['sp_level'] == 'ccsd(t)-f12/cc-pvtz-f12'
+        assert arc_input['scan_level'] == 'wb97xd/def2tzvp'
+        assert arc_input['irc_level'] == 'wb97xd/def2tzvp'
+        assert arc_input['reactions'][0]['family'] == '1,2_Insertion_CO'
+
+    def test_reaction_and_species_dicts_can_construct_a_real_arc_reaction(self):
+        """C2: a reaction dict alone (no top-level 'species' list) cannot construct a valid
+        ARCReaction -- ARCReaction.from_dict resolves r_species/p_species by matching their
+        'label' against ARC's own top-level species list. This asserts build_arc_input emits
+        both halves of that contract."""
+        candidate = _candidate(reactants=('A',), products=('B',))
+        arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1',
+                                    _STRUCTURES)
+        reaction = arc_input['reactions'][0]
+        assert reaction['reactants'] == ['A']
+        assert reaction['products'] == ['B']
+        assert reaction['r_species'] == [{'label': 'A'}]
+        assert reaction['p_species'] == [{'label': 'B'}]
+        species_by_label = {spc['label']: spc for spc in arc_input['species']}
+        assert set(species_by_label) == {'A', 'B'}
+        assert species_by_label['A']['adjlist'] == _STRUCTURES['A']
+        assert species_by_label['B']['adjlist'] == _STRUCTURES['B']
+
+    def test_compute_thermo_is_explicitly_disabled_on_every_species(self):
+        """ARC defaults a bare species dict's compute_thermo to True, which would queue full
+        thermo for every reactant/product reaching ARC through this path -- unbounded by
+        config.qm.max_transition_states_per_round. This loop only ever needs the TS itself."""
+        candidate = _candidate()
+        arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1',
+                                    _STRUCTURES)
+        assert arc_input['species']
+        assert all(spc['compute_thermo'] is False for spc in arc_input['species'])
+
+    def test_candidate_with_no_structure_is_dropped_not_crashed(self):
+        candidate = _candidate(reactants=('A',), products=('unknown_species',))
+        arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1',
+                                    _STRUCTURES)
+        assert arc_input['reactions'] == []
+        assert arc_input['species'] == []
+
+    def test_dead_network_ts_label_key_is_not_emitted(self):
+        candidate = _candidate()
+        arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1',
+                                    _STRUCTURES)
+        assert 'network_ts_label' not in arc_input['reactions'][0]
+
+
+# --- arc_qm_runner ------------------------------------------------------------------------------
+#
+# Real fixture network (tests/data/pdep_real_networks/network799_1/network799_1.py): 3 reactions
+# (TS1/TS2/TS3), matching real adjacency-list species. arc_qm_runner is exercised against argument-
+# recording doubles for every impure boundary it crosses (ARC, capture_ts_artifacts,
+# write_hybrid_network_input_file, save_yaml_file) rather than canned-return stubs, so each test
+# asserts on what arc_qm_runner actually HANDED those boundaries, not merely that it called them.
+
+_NETWORK_ID = 'network799_1'
+_FIXTURE_NETWORK_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'data', 'pdep_real_networks', 'network799_1', 'network799_1.py')
+
+_FROZEN_ENERGY_SETTINGS = {
+    'model_chemistry': 'wb97xd/def2tzvp',
+    'frequency_scale_factor': None,
+    'use_hindered_rotors': True,
+    'use_bond_corrections': False,
+    'bond_correction_type': None,
+    'atom_energies': None,
+    'use_atom_corrections': True,
+    'bond_additivity_corrections': None,
+}
+
+
+class _FakeARC(object):
+    """Records every construction's kwargs and every .execute()/.as_dict() call, class-wide."""
+
+    constructions = []
+    execute_calls = 0
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _FakeARC.constructions.append(kwargs)
+
+    def execute(self):
+        _FakeARC.execute_calls += 1
+
+    def as_dict(self):
+        return {'fake_as_dict_of': self.kwargs.get('project')}
+
+
+class _FakeCalls(object):
+    """Argument recorder shared by the capture_ts_artifacts/write_hybrid_network_input_file/
+    save_yaml_file doubles below -- each call's kwargs are appended verbatim."""
+
+    def __init__(self):
+        self.capture_ts_artifacts_calls = []
+        self.write_hybrid_calls = []
+        self.save_yaml_file_calls = []
+        self.capture_result = None
+        self.hybrid_result = None
+
+    def fake_capture_ts_artifacts(self, **kwargs):
+        self.capture_ts_artifacts_calls.append(kwargs)
+        return self.capture_result
+
+    def fake_write_hybrid_network_input_file(self, **kwargs):
+        self.write_hybrid_calls.append(kwargs)
+        return self.hybrid_result
+
+    def fake_save_yaml_file(self, **kwargs):
+        self.save_yaml_file_calls.append(kwargs)
+
+
+def _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result):
+    """Build real RoundPaths/candidates against the real network799_1 fixture, monkeypatch every
+    impure boundary arc_qm_runner crosses with argument-recording doubles, and return the recorder
+    plus the RoundPaths used, so a test can drive arc_qm_runner and then inspect exactly what it
+    handed each boundary."""
+    project_directory = str(tmp_path)
+    paths = round_paths(project_directory, 0)
+    final_dir = os.path.join(paths.explorer_output, 'pdep', 'final')
+    os.makedirs(final_dir)
+    dest_network_path = os.path.join(final_dir, f'{_NETWORK_ID}.py')
+    shutil.copyfile(_FIXTURE_NETWORK_PATH, dest_network_path)
+
+    candidate = _candidate(ts_label='TS1', family='1+2_Cycloaddition',
+                           reactants=('O-2(13598)', 'CO2(11)'), products=('O=C1OO1(21648)',),
+                           label='reaction1')
+
+    _FakeARC.constructions = []
+    _FakeARC.execute_calls = 0
+    monkeypatch.setattr(pes_qm, 'ARC', _FakeARC)
+
+    recorder = _FakeCalls()
+    recorder.capture_result = capture_result
+    monkeypatch.setattr(pes_qm, 'capture_ts_artifacts', recorder.fake_capture_ts_artifacts)
+    monkeypatch.setattr(pes_qm, 'write_hybrid_network_input_file',
+                        recorder.fake_write_hybrid_network_input_file)
+    monkeypatch.setattr(pes_qm, 'save_yaml_file', recorder.fake_save_yaml_file)
+
+    return paths, (candidate,), recorder, dest_network_path
+
+
+def _usable_capture_result(paths, capture_dir, network_path):
+    return CaptureResult(
+        capture_dir=capture_dir,
+        manifest_path=os.path.join(capture_dir, 'manifest.yml'),
+        records=(
+            TSArtifactRecord(network_id=_NETWORK_ID, network_ts_label='TS1',
+                             arc_ts_label='T3PDep_network799_1_TS1', status=ARTIFACT_STATUS_USABLE,
+                             artifact_path=os.path.join(capture_dir, 'qm', 'TS1.py'), converged=True),
+        ),
+        energy_settings=_FROZEN_ENERGY_SETTINGS,
+        networks={
+            _NETWORK_ID: {
+                'source_path': network_path,
+                'source_sha256': 'deadbeef',
+                'captured_path': os.path.join('networks', f'{_NETWORK_ID}.py'),
+                'method': 'MSC',
+            },
+        },
+    )
+
+
+def _empty_capture_result(capture_dir):
+    return CaptureResult(
+        capture_dir=capture_dir,
+        manifest_path=os.path.join(capture_dir, 'manifest.yml'),
+        records=(
+            TSArtifactRecord(network_id=_NETWORK_ID, network_ts_label='TS1', arc_ts_label=None,
+                             status=ARTIFACT_STATUS_UNVERIFIED,
+                             artifact_path=os.path.join(capture_dir, 'qm', 'TS1.py')),
+        ),
+        energy_settings=None,
+        networks=None,
+    )
+
+
+class TestArcQmRunner(object):
+
+    def test_arc_is_constructed_with_the_reactions_and_species_build_arc_input_built(self, tmp_path, monkeypatch):
+        """Regression for C1: reactions/species must reach ARC(**arc_kwargs), not be dropped."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _empty_capture_result(capture_dir))
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert len(_FakeARC.constructions) == 1
+        kwargs = _FakeARC.constructions[0]
+        assert kwargs['reactions'], 'ARC received zero reactions'
+        assert kwargs['species'], 'ARC received zero species'
+        assert kwargs['reactions'][0]['ts_label'] == 'T3PDep_network799_1_TS1'
+
+    def test_arc_execute_is_called_exactly_once(self, tmp_path, monkeypatch):
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _empty_capture_result(capture_dir))
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert _FakeARC.execute_calls == 1
+
+    def test_arc_input_yml_is_persisted_from_arc_as_dict_after_construction(self, tmp_path, monkeypatch):
+        """I2: persisted only after ARC(**arc_kwargs) exists, from arc.as_dict()."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _empty_capture_result(capture_dir))
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert len(recorder.save_yaml_file_calls) == 1
+        call = recorder.save_yaml_file_calls[0]
+        assert call['path'] == os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME)
+        assert call['content'] == {'fake_as_dict_of': _NETWORK_ID}
+
+    def test_arc_input_yml_is_not_rewritten_when_it_already_exists(self, tmp_path, monkeypatch):
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _empty_capture_result(capture_dir))
+        os.makedirs(paths.arc_project)
+        with open(os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME), 'w') as f:
+            f.write('already here')
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert recorder.save_yaml_file_calls == []
+
+    def test_capture_ts_artifacts_is_called_with_this_rounds_own_project_and_capture_dirs(self, tmp_path, monkeypatch):
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _empty_capture_result(capture_dir))
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert len(recorder.capture_ts_artifacts_calls) == 1
+        call = recorder.capture_ts_artifacts_calls[0]
+        assert call['arc_project_directory'] == paths.arc_project
+        assert call['capture_dir'] == paths.capture
+        assert call['networks'][_NETWORK_ID]['source_path'] == network_path
+        assert call['networks'][_NETWORK_ID]['method'] == 'MSC'
+        assert len(call['join_records']) == 1
+        assert call['join_records'][0].network_ts_label == 'TS1'
+
+    def test_no_usable_artifact_returns_empty_and_skips_hybrid_write(self, tmp_path, monkeypatch):
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _empty_capture_result(capture_dir))
+        result = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert result == frozenset()
+        assert recorder.write_hybrid_calls == []
+
+    def test_usable_artifact_triggers_hybrid_write_from_the_captures_own_network_copy(self, tmp_path, monkeypatch):
+        """I1: source_path/method must come from CaptureResult.networks, never the live network."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        capture_result = _usable_capture_result(None, capture_dir, None)
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result)
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',), ilt_ts_labels=(),
+            vendored_files=(), warnings=())
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert len(recorder.write_hybrid_calls) == 1
+        call = recorder.write_hybrid_calls[0]
+        assert call['source_path'] == os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py')
+        assert call['method'] == 'MSC'
+        assert call['qm_artifacts_root'] == capture_dir
+
+    def test_hybrid_write_dest_path_is_the_loops_own_hybrid_network_path(self, tmp_path, monkeypatch):
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        capture_result = _usable_capture_result(None, capture_dir, None)
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result)
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',), ilt_ts_labels=(),
+            vendored_files=(), warnings=())
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert recorder.write_hybrid_calls[0]['dest_path'] == hybrid_network_path(paths, _NETWORK_ID)
+
+    def test_qm_transition_states_dict_only_carries_usable_records(self, tmp_path, monkeypatch):
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        capture_result = CaptureResult(
+            capture_dir=capture_dir, manifest_path=os.path.join(capture_dir, 'manifest.yml'),
+            records=(
+                TSArtifactRecord(network_id=_NETWORK_ID, network_ts_label='TS1',
+                                 arc_ts_label='T3PDep_network799_1_TS1', status=ARTIFACT_STATUS_USABLE,
+                                 artifact_path=os.path.join(capture_dir, 'qm', 'TS1.py'), converged=True),
+                TSArtifactRecord(network_id=_NETWORK_ID, network_ts_label='TS2', arc_ts_label=None,
+                                 status=ARTIFACT_STATUS_UNVERIFIED,
+                                 artifact_path=os.path.join(capture_dir, 'qm', 'TS2.py')),
+            ),
+            energy_settings=_FROZEN_ENERGY_SETTINGS,
+            networks={_NETWORK_ID: {'source_path': '', 'source_sha256': '', 'method': 'MSC',
+                                    'captured_path': os.path.join('networks', f'{_NETWORK_ID}.py')}},
+        )
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result)
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',), ilt_ts_labels=(),
+            vendored_files=(), warnings=())
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        qm_transition_states = recorder.write_hybrid_calls[0]['qm_transition_states']
+        assert qm_transition_states == {'TS1': os.path.join(capture_dir, 'qm', 'TS1.py')}
+
+    def test_return_value_is_the_frozenset_of_usable_network_ts_labels_only(self, tmp_path, monkeypatch):
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        capture_result = _usable_capture_result(None, capture_dir, None)
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result)
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',), ilt_ts_labels=(),
+            vendored_files=(), warnings=())
+        result = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert result == frozenset({'TS1'})

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -185,7 +185,12 @@ class _FakeARC(object):
         _FakeARC.execute_calls += 1
 
     def as_dict(self):
-        return dict(self.kwargs)
+        # N5 (round 3): must be DERIVED from self.kwargs but not equal to it, or a test
+        # asserting content == _FakeARC.constructions[0] can no longer tell 'the persisted
+        # content came from arc.as_dict()' apart from 'the persisted content is just
+        # arc_kwargs verbatim' -- which is exactly the I2 defect (persisting arc_kwargs
+        # instead of calling as_dict()) that round 2's tightening silently stopped catching.
+        return dict(self.kwargs) | {'_from_as_dict': True}
 
 
 class _FakeCalls(object):
@@ -309,7 +314,11 @@ class TestArcQmRunner(object):
         assert _FakeARC.execute_calls == 1
 
     def test_arc_input_yml_is_persisted_from_arc_as_dict_after_construction(self, tmp_path, monkeypatch):
-        """I2: persisted only after ARC(**arc_kwargs) exists, from arc.as_dict()."""
+        """I2: persisted only after ARC(**arc_kwargs) exists, from arc.as_dict() -- not from
+        arc_kwargs itself. _FakeARC.as_dict() returns arc_kwargs PLUS a '_from_as_dict' marker
+        (N5, round 3) specifically so this assertion can tell the two apart: content must carry
+        the marker (proving it came from as_dict()) AND match arc_kwargs on every other key
+        (proving as_dict() wasn't just handed something unrelated)."""
         capture_dir = os.path.join(str(tmp_path), 'capture')
         paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
             tmp_path, monkeypatch, _empty_capture_result(capture_dir))
@@ -317,7 +326,8 @@ class TestArcQmRunner(object):
         assert len(recorder.save_yaml_file_calls) == 1
         call = recorder.save_yaml_file_calls[0]
         assert call['path'] == os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME)
-        assert call['content'] == _FakeARC.constructions[0]
+        assert call['content'].get('_from_as_dict') is True
+        assert call['content'] == dict(_FakeARC.constructions[0]) | {'_from_as_dict': True}
 
     def test_arc_input_yml_is_not_rewritten_when_it_already_exists(self, tmp_path, monkeypatch):
         capture_dir = os.path.join(str(tmp_path), 'capture')
@@ -411,6 +421,34 @@ class TestArcQmRunner(object):
             vendored_files=(), warnings=())
         arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
         assert recorder.write_hybrid_calls[0]['dest_path'] == hybrid_network_path(paths, _NETWORK_ID)
+
+    def test_missing_network_entry_in_capture_result_raises_keyerror(self, tmp_path, monkeypatch):
+        """Round 2's guard: ARC converged transition states for network_id, but
+        CaptureResult.networks has no entry for it (e.g. a concurrent/prior capture vendored a
+        different network under this id, or capture_ts_artifacts's own bookkeeping is stale).
+        Writing the hybrid network file from a nonexistent captured source would either crash
+        confusingly deep inside write_hybrid_network_input_file or -- worse -- silently read the
+        wrong file; the guard must fail loudly and immediately instead."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        capture_result = CaptureResult(
+            capture_dir=capture_dir,
+            manifest_path=os.path.join(capture_dir, 'manifest.yml'),
+            records=(
+                TSArtifactRecord(network_id=_NETWORK_ID, network_ts_label='TS1',
+                                 arc_ts_label='T3PDep_network799_1_TS1', status=ARTIFACT_STATUS_USABLE,
+                                 artifact_path=os.path.join(capture_dir, 'qm', 'TS1.py'), converged=True),
+            ),
+            energy_settings=_FROZEN_ENERGY_SETTINGS,
+            networks={},  # no entry for _NETWORK_ID even though TS1 converged for it
+        )
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result)
+        try:
+            arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+            assert False, 'expected a KeyError'
+        except KeyError as err:
+            assert _NETWORK_ID in str(err)
+        assert len(recorder.write_hybrid_calls) == 0
 
     def test_qm_transition_states_dict_only_carries_usable_records(self, tmp_path, monkeypatch):
         capture_dir = os.path.join(str(tmp_path), 'capture')

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -23,7 +23,7 @@ from t3.schema import PESLoopConfig
 
 
 def _config(**qm) -> PESLoopConfig:
-    return PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']}, **({'qm': qm} if qm else {}))
+    return PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}}, **({'qm': qm} if qm else {}))
 
 
 def _candidate(ts_label='TS1', family='1,2_Insertion_CO', reactants=('A',), products=('B',),

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -26,12 +26,13 @@ def _config(**qm) -> PESLoopConfig:
 
 
 def _candidate(ts_label='TS1', family='1,2_Insertion_CO', reactants=('A',), products=('B',),
-              label='reaction1') -> QMCandidate:
+              label='reaction1', coefficient=0.05, delta_ln_k=0.02) -> QMCandidate:
     path_reaction = PDepPathReaction(
         label=label, reactants=reactants, products=products,
         transition_state=ts_label, kinetics_type='Arrhenius', kinetics_comment='',
     )
-    return QMCandidate(path_reaction=path_reaction, ts_label=ts_label, family=family)
+    return QMCandidate(path_reaction=path_reaction, ts_label=ts_label, family=family,
+                       coefficient=coefficient, delta_ln_k=delta_ln_k)
 
 
 # Adjacency-list text is opaque to build_arc_input -- any non-empty string exercises the
@@ -839,3 +840,29 @@ class TestAdoptedEnergySettings(object):
                                    {'TS2': ('reaction2',)})
         with pytest.raises(ValueError, match='conflicting'):
             pes_qm._adopted_energy_settings(adopted_a | adopted_b)
+
+
+class TestArcQmRunnerSensitivityEvidence(object):
+    """Defect 1: arc_qm_runner must freeze real sensitivity evidence onto its join records and
+    hand it to capture_ts_artifacts -- and must refuse, BEFORE any QM is spent, a candidate that
+    carries none, rather than let capture (rightly) refuse the artifact after ARC already ran."""
+
+    def test_capture_receives_the_candidates_own_evidence_keyed_by_record(self, tmp_path, monkeypatch):
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, capture_result=None)
+        recorder.capture_result = _empty_capture_result(os.path.join(str(tmp_path), 'capture'))
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert len(recorder.capture_ts_artifacts_calls) == 1
+        sensitivity_by_ts = recorder.capture_ts_artifacts_calls[0]['sensitivity_by_ts']
+        assert sensitivity_by_ts == {(_NETWORK_ID, 'TS1'): (0.05, 0.02)}
+
+    def test_a_candidate_without_evidence_is_refused_before_arc_ever_runs(self, tmp_path, monkeypatch):
+        paths, _candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, capture_result=None)
+        naked = (_candidate(ts_label='TS1', reactants=('O-2(13598)', 'CO2(11)'),
+                            products=('O=C1OO1(21648)',), coefficient=None, delta_ln_k=None),)
+        with pytest.raises(ValueError, match='no sensitivity evidence'):
+            arc_qm_runner(naked, paths, _config(), _NETWORK_ID)
+        assert _FakeARC.constructions == []
+        assert _FakeARC.execute_calls == 0
+        assert recorder.capture_ts_artifacts_calls == []

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -9,14 +9,16 @@ import pytest
 from arc.reaction.reaction import ARCReaction
 from arc.species.species import ARCSpecies
 
-import t3.pdep.pes_qm as pes_qm
-from t3.pdep.capture import CaptureResult, VerifyResult, capture_ts_artifacts
+from t3.pdep.capture import (CAPTURE_MANIFEST_FILE_NAME, CaptureResult, VerifyResult,
+                             capture_ts_artifacts)
 from t3.pdep.discovery import ARTIFACT_STATUS_UNVERIFIED, ARTIFACT_STATUS_USABLE, TSArtifactRecord
 from t3.pdep.hashing import hash_file
 from t3.pdep.hybrid import HybridNetworkResult
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label, expected_ts_artifact_path
 from t3.pdep.parser import PDepPathReaction, parse_pdep_network_file
-from t3.pdep.pes_qm import ARC_INPUT_FILE_NAME, adopt_prior_qm, arc_qm_runner, build_arc_input
+from t3.pdep.pes_qm import (ARC_INPUT_FILE_NAME, _adopted_energy_settings,
+                            _normalized_model_chemistry, adopt_prior_qm, arc_qm_runner,
+                            build_arc_input)
 from t3.pdep.pes_rounds import (QMCandidate, channel_keys_by_ts_label, hybrid_network_path,
                                 round_paths)
 from t3.schema import PESLoopConfig
@@ -239,14 +241,14 @@ def _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result):
 
     _FakeARC.constructions = []
     _FakeARC.execute_calls = 0
-    monkeypatch.setattr(pes_qm, 'ARC', _FakeARC)
+    monkeypatch.setattr('t3.pdep.pes_qm.ARC', _FakeARC)
 
     recorder = _FakeCalls()
     recorder.capture_result = capture_result
-    monkeypatch.setattr(pes_qm, 'capture_ts_artifacts', recorder.fake_capture_ts_artifacts)
-    monkeypatch.setattr(pes_qm, 'write_hybrid_network_input_file',
+    monkeypatch.setattr('t3.pdep.pes_qm.capture_ts_artifacts', recorder.fake_capture_ts_artifacts)
+    monkeypatch.setattr('t3.pdep.pes_qm.write_hybrid_network_input_file',
                         recorder.fake_write_hybrid_network_input_file)
-    monkeypatch.setattr(pes_qm, 'save_yaml_file', recorder.fake_save_yaml_file)
+    monkeypatch.setattr('t3.pdep.pes_qm.save_yaml_file', recorder.fake_save_yaml_file)
 
     return paths, (candidate,), recorder, dest_network_path
 
@@ -731,7 +733,7 @@ class TestAdoptPriorQM(object):
         non-usable (e.g. UNVERIFIED) record be adopted."""
         manifest_dir = tmp_path / 'proj' / 'capture'
         manifest_dir.mkdir(parents=True)
-        (manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME).write_text('stub')
+        (manifest_dir / CAPTURE_MANIFEST_FILE_NAME).write_text('stub')
         networks_dir = manifest_dir / 'networks'
         networks_dir.mkdir()
         shutil.copyfile(_FIXTURE_NETWORK_PATH, str(networks_dir / 'network1_1.py'))
@@ -741,12 +743,12 @@ class TestAdoptPriorQM(object):
                                   path_reaction_labels=('reaction1',))
         verify_result = VerifyResult(
             capture_dir=str(manifest_dir),
-            manifest_path=str(manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME),
+            manifest_path=str(manifest_dir / CAPTURE_MANIFEST_FILE_NAME),
             record_count=1, captured_artifact_count=1,
             networks={'network1_1': {'captured_path': os.path.join('networks', 'network1_1.py')}},
             energy_settings={'model_chemistry': _arc_model_chemistry_text('wb97xd/def2tzvp')},
             ts_records=(record,))
-        monkeypatch.setattr(pes_qm, 'verify_capture', lambda root: verify_result)
+        monkeypatch.setattr('t3.pdep.pes_qm.verify_capture', lambda root: verify_result)
         adopted = adopt_prior_qm([str(tmp_path / 'proj')], 'network1_1', 'wb97xd/def2tzvp',
                                  _FIXTURE_CHANNEL_KEYS)
         assert adopted == {}
@@ -769,7 +771,7 @@ class TestAdoptPriorQM(object):
         for name, record in (('proj_a', record_a), ('proj_b', record_b)):
             manifest_dir = tmp_path / name / 'capture'
             manifest_dir.mkdir(parents=True)
-            (manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME).write_text('stub')
+            (manifest_dir / CAPTURE_MANIFEST_FILE_NAME).write_text('stub')
             # Each fake capture must vendor a REAL, parseable network copy: adoption resolves the
             # record's transition state to its structural channel in that copy, and a capture
             # without one offers nothing adoptable (so the conflict logic under test would never
@@ -779,12 +781,12 @@ class TestAdoptPriorQM(object):
             shutil.copyfile(_FIXTURE_NETWORK_PATH, str(networks_dir / 'network1_1.py'))
             results_by_root[str(manifest_dir)] = VerifyResult(
                 capture_dir=str(manifest_dir),
-                manifest_path=str(manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME),
+                manifest_path=str(manifest_dir / CAPTURE_MANIFEST_FILE_NAME),
                 record_count=1, captured_artifact_count=1,
                 networks={'network1_1': {'captured_path': os.path.join('networks', 'network1_1.py')}},
                 energy_settings=energy_settings, ts_records=(record,))
 
-        monkeypatch.setattr(pes_qm, 'verify_capture', _fake_verify_capture)
+        monkeypatch.setattr('t3.pdep.pes_qm.verify_capture', _fake_verify_capture)
         adopted = adopt_prior_qm([str(tmp_path / 'proj_a'), str(tmp_path / 'proj_b')],
                                  'network1_1', 'wb97xd/def2tzvp', _FIXTURE_CHANNEL_KEYS)
         assert adopted == {}
@@ -796,7 +798,7 @@ class TestNormalizedModelChemistry(object):
     with no tabulated frequency scale factor) killed the loop before round 0."""
 
     def test_resolvable_level_returns_arcs_own_literal(self):
-        assert pes_qm._normalized_model_chemistry('wb97xd/def2tzvp') \
+        assert _normalized_model_chemistry('wb97xd/def2tzvp') \
             == _arc_model_chemistry_text('wb97xd/def2tzvp')
 
     def test_year_suffixed_level_with_no_tabulated_scale_factor_returns_none_not_raise(self, caplog):
@@ -806,7 +808,7 @@ class TestNormalizedModelChemistry(object):
         required when freq_scale_factor isn't provided'; this function must convert that raise
         into its documented None answer rather than letting it kill the run."""
         with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_qm'):
-            assert pes_qm._normalized_model_chemistry('wb97xd2023/def2tzvp') is None
+            assert _normalized_model_chemistry('wb97xd2023/def2tzvp') is None
         assert 'could not normalize' in caplog.text
 
     def test_adopt_prior_qm_survives_an_unresolvable_level(self, tmp_path, caplog):
@@ -844,13 +846,13 @@ class TestAdoptedEnergySettings(object):
     its whole fallback left the suite green."""
 
     def test_empty_adopted_returns_none(self):
-        assert pes_qm._adopted_energy_settings(dict()) is None
+        assert _adopted_energy_settings(dict()) is None
 
     def test_settings_come_from_the_adopted_artifacts_own_prior_manifest(self, tmp_path):
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
         adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
                                  _FIXTURE_CHANNEL_KEYS)
-        settings = pes_qm._adopted_energy_settings(adopted)
+        settings = _adopted_energy_settings(adopted)
         assert settings['model_chemistry'] == _arc_model_chemistry_text('wb97xd/def2tzvp')
         assert settings['use_hindered_rotors'] is True
 
@@ -862,7 +864,7 @@ class TestAdoptedEnergySettings(object):
         adopted_b = adopt_prior_qm([str(tmp_path / 'proj_b')], 'network1_1', 'b3lyp/def2tzvp',
                                    {'TS2': _FIXTURE_CHANNEL_KEYS['TS2']})
         with pytest.raises(ValueError, match='conflicting'):
-            pes_qm._adopted_energy_settings(adopted_a | adopted_b)
+            _adopted_energy_settings(adopted_a | adopted_b)
 
 
 class TestArcQmRunnerSensitivityEvidence(object):

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -137,15 +137,42 @@ class TestBuildARCInput(object):
         assert all(spc['compute_thermo'] is False for spc in arc_input['species'])
 
     def test_candidate_with_no_structure_is_dropped_not_crashed(self, caplog):
+        """The warning IS the evidence that the candidate was dropped rather than crashed on, so
+        this must not select records on ``levelname``: ``arc.common.initialize_log`` (and
+        ``arc.species.conformers``) call ``logging.addLevelName(logging.WARNING, 'Warning: ')``,
+        a PROCESS-GLOBAL rename that outlives the test that triggered it. Every WARNING record
+        emitted afterwards carries ``levelname == 'Warning: '``, so a levelname filter silently
+        selects nothing -- passing whenever this file runs alone and failing in CI's whole-suite
+        run purely on which test ran first. ``levelno`` is the numeric level, which no ARC entry
+        point can move."""
         candidate = _candidate(reactants=('A',), products=('unknown_species',))
-        with caplog.at_level('WARNING', logger='t3.pdep.pes_qm'):
+        with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_qm'):
             arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(),
                                         'network1_1', _STRUCTURES)
         assert arc_input['reactions'] == []
         assert arc_input['species'] == []
-        warnings = [r.message for r in caplog.records if r.levelname == 'WARNING']
+        warnings = [record.getMessage() for record in caplog.records
+                    if record.levelno == logging.WARNING]
         assert any('unknown_species' in message for message in warnings), \
             f'expected a WARNING naming the missing species, got: {warnings}'
+
+    def test_the_missing_structure_warning_survives_an_arc_level_name_rename(self, caplog):
+        """The regression guard for the test above: with ARC's global level rename in force, the
+        drop-not-crash evidence must still be visible. Without this, that whole assertion can
+        evaporate into an empty list that proves nothing, and only CI's test ORDER decides
+        whether it does."""
+        logging.addLevelName(logging.WARNING, 'Warning: ')
+        try:
+            candidate = _candidate(reactants=('A',), products=('unknown_species',))
+            with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_qm'):
+                build_arc_input((candidate,), round_paths('/proj', 0), _config(),
+                                'network1_1', _STRUCTURES)
+            warnings = [record.getMessage() for record in caplog.records
+                        if record.levelno == logging.WARNING]
+            assert any('unknown_species' in message for message in warnings), \
+                f'expected a WARNING naming the missing species, got: {warnings}'
+        finally:
+            logging.addLevelName(logging.WARNING, 'WARNING')
 
     def test_dead_network_ts_label_key_is_not_emitted(self):
         candidate = _candidate()

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -3,10 +3,8 @@
 import os
 import shutil
 
-from arc.level import Level, assign_frequency_scale_factor
 from arc.reaction.reaction import ARCReaction
 from arc.species.species import ARCSpecies
-from arc.statmech.arkane import get_arkane_model_chemistry
 
 import t3.pdep.pes_qm as pes_qm
 from t3.pdep.capture import CaptureResult, VerifyResult, capture_ts_artifacts
@@ -519,11 +517,17 @@ class TestArcQmRunner(object):
             dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',), ilt_ts_labels=(),
             vendored_files=(), warnings=())
 
+        # Critical 1 (fix round 2): the adopted artifact's own Log(...) argument is relative to
+        # its OWN directory (SPs/), the same way a real captured artifact's is (see
+        # t3.pdep.hybrid.write_hybrid_network_input_file's docstring) -- so the referenced log file
+        # actually has to exist next to it for a real (non-mocked) vendoring pass to succeed.
         prior_artifact_dir = str(tmp_path / 'prior_project' / 'output' / 'SPs')
         os.makedirs(prior_artifact_dir)
         prior_artifact_path = os.path.join(prior_artifact_dir, 'TS1.py')
         with open(prior_artifact_path, 'w') as f:
             f.write("geometry = Log('output.out')\n")
+        with open(os.path.join(prior_artifact_dir, 'output.out'), 'w') as f:
+            f.write('# stub ARC log output\n')
 
         converged, queued = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID,
                                           adopted={'TS1': prior_artifact_path})
@@ -536,7 +540,14 @@ class TestArcQmRunner(object):
         assert os.path.dirname(vendored_path) == os.path.join(capture_dir, 'adopted')
         assert os.path.isfile(vendored_path)
         with open(vendored_path) as f:
-            assert "geometry = Log('output.out')" in f.read()
+            vendored_content = f.read()
+        # C1: the artifact's Log(...) reference must be rewritten to point at the log file that was
+        # ALSO vendored alongside it (t3.pdep.hybrid._vendor_qm_artifacts), not left pointing at
+        # 'output.out' relative to a directory that no longer exists next to the vendored copy.
+        assert "geometry = Log('output.out')" not in vendored_content
+        assert "geometry = Log('logs/TS1/output.out')" in vendored_content
+        vendored_log_path = os.path.join(capture_dir, 'adopted', 'logs', 'TS1', 'output.out')
+        assert os.path.isfile(vendored_log_path)
         assert call['qm_artifacts_root'] == capture_dir
 
     def test_mutant_adopted_artifact_path_is_not_silently_accepted(self, tmp_path, monkeypatch):
@@ -562,14 +573,27 @@ class TestArcQmRunner(object):
         assert recorder.write_hybrid_calls == []
 
 
+# The exact modelChemistry source text a real ARC project writes, keyed by T3 sp_level. The
+# 'wb97xd/def2tzvp' entry is copied verbatim (not recomputed) from a real ARC-written
+# calcs/statmech/kinetics/input.py -- see
+# tests/data/pdep_energy_settings/xl1001_project/calcs/statmech/kinetics/input.py:9. The
+# 'b3lyp/def2tzvp' entry was captured once, out-of-band, the same way (by inspecting real ARC
+# output), NOT by calling _normalized_model_chemistry's own Level/get_arkane_model_chemistry chain
+# at test-collection time -- doing that would make this fixture pass or fail in lockstep with
+# whatever that chain currently does, so a real bug in it could never be caught by a test built
+# from it. A stored manifest written by an older ARC version is exactly the case a fixture that
+# re-derives its own expectation at test time cannot represent.
+_ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL = {
+    'wb97xd/def2tzvp': "LevelOfTheory(method='wb97xd2023',basis='def2tzvp',software='gaussian')",
+    'b3lyp/def2tzvp': "LevelOfTheory(method='b3lyp2023',basis='def2tzvp',software='gaussian')",
+}
+
+
 def _arc_model_chemistry_text(sp_level: str) -> str:
-    """The exact ``modelChemistry`` source text ARC itself writes for ``sp_level`` -- run the
-    same normalization chain C1's fix in ``adopt_prior_qm`` uses, so this fixture's manifest is
-    faithful to what a real ARC project's ``calcs/statmech/kinetics/input.py`` actually contains
-    (see ``tests/data/pdep_energy_settings/xl1001_project/calcs/statmech/kinetics/input.py``)."""
-    level = Level(repr=sp_level)
-    scale = assign_frequency_scale_factor(level)
-    return get_arkane_model_chemistry(level, freq_scale_factor=scale)
+    """The exact ``modelChemistry`` source text a real ARC project writes for ``sp_level`` -- a
+    fixed, pre-captured literal (see ``_ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL`` above), not one
+    recomputed via the same normalization chain the code under test uses."""
+    return _ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL[sp_level]
 
 
 def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
@@ -667,13 +691,17 @@ class TestAdoptPriorQM(object):
         assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
                               _TS1_PATH_REACTION_LABELS) == {}
 
-    def test_a_different_network_is_not_adopted(self, tmp_path):
-        """network_id is a pre-filter: another network's manifest is not adopted even when its
-        recorded path_reaction_labels happen to match, since network_id itself never matches."""
+    def test_a_different_network_id_is_still_adopted_on_structural_match(self, tmp_path):
+        """Important (fix round 2): network_id is NEVER a gate -- this function's own docstring
+        states Arkane's network_id never matches across independent PES-loop runs by construction,
+        so gating on it would refuse the exact case adoption exists to serve. A manifest recorded
+        under a completely different network_id is still adopted when its path_reaction_labels
+        structurally match THIS run's own candidates."""
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
                                 network_id='network9_9')
-        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
-                              _TS1_PATH_REACTION_LABELS) == {}
+        adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
+                                 _TS1_PATH_REACTION_LABELS)
+        assert 'TS1' in adopted
 
     def test_no_structural_match_is_not_adopted(self, tmp_path):
         """C3/I1: network_id alone is not enough -- a record whose path_reaction_labels do not

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -3,19 +3,20 @@
 import os
 import shutil
 
+from arc.level import Level, assign_frequency_scale_factor
 from arc.reaction.reaction import ARCReaction
 from arc.species.species import ARCSpecies
+from arc.statmech.arkane import get_arkane_model_chemistry
 
 import t3.pdep.pes_qm as pes_qm
-from t3.pdep.capture import CaptureResult, capture_ts_artifacts
+from t3.pdep.capture import CaptureResult, VerifyResult, capture_ts_artifacts
 from t3.pdep.discovery import ARTIFACT_STATUS_UNVERIFIED, ARTIFACT_STATUS_USABLE, TSArtifactRecord
 from t3.pdep.hashing import hash_file
 from t3.pdep.hybrid import HybridNetworkResult
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label, expected_ts_artifact_path
 from t3.pdep.parser import PDepPathReaction
-from t3.pdep.pes_loop import hybrid_network_path
 from t3.pdep.pes_qm import ARC_INPUT_FILE_NAME, adopt_prior_qm, arc_qm_runner, build_arc_input
-from t3.pdep.pes_rounds import QMCandidate, round_paths
+from t3.pdep.pes_rounds import QMCandidate, hybrid_network_path, round_paths
 from t3.schema import PESLoopConfig
 
 
@@ -493,9 +494,86 @@ class TestArcQmRunner(object):
         assert converged == frozenset({'TS1'})
         assert queued == frozenset({'TS1'})
 
+    def test_adopted_artifact_is_vendored_and_folded_into_hybrid_write(self, tmp_path, monkeypatch):
+        """C2: an adopted prior-round artifact must be copied into this round's own
+        paths.capture/adopted/ subdir and merged into qm_transition_states -- even when ARC itself
+        converges nothing new this round -- so the hybrid write still fires and the adopted TS
+        does not silently revert to an ILT estimate."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        capture_result = CaptureResult(
+            capture_dir=capture_dir, manifest_path=os.path.join(capture_dir, 'manifest.yml'),
+            records=(
+                TSArtifactRecord(network_id=_NETWORK_ID, network_ts_label='TS1', arc_ts_label=None,
+                                 status=ARTIFACT_STATUS_UNVERIFIED,
+                                 artifact_path=os.path.join(capture_dir, 'qm', 'TS1.py')),
+            ),
+            energy_settings=_FROZEN_ENERGY_SETTINGS,
+            networks={_NETWORK_ID: {'source_path': '', 'source_sha256': '', 'method': 'MSC',
+                                    'captured_path': os.path.join('networks', f'{_NETWORK_ID}.py')}},
+        )
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result)
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',), ilt_ts_labels=(),
+            vendored_files=(), warnings=())
+
+        prior_artifact_dir = str(tmp_path / 'prior_project' / 'output' / 'SPs')
+        os.makedirs(prior_artifact_dir)
+        prior_artifact_path = os.path.join(prior_artifact_dir, 'TS1.py')
+        with open(prior_artifact_path, 'w') as f:
+            f.write("geometry = Log('output.out')\n")
+
+        converged, queued = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID,
+                                          adopted={'TS1': prior_artifact_path})
+        assert converged == frozenset()
+        assert queued == frozenset({'TS1'})
+        assert len(recorder.write_hybrid_calls) == 1
+        call = recorder.write_hybrid_calls[0]
+        vendored_path = call['qm_transition_states']['TS1']
+        assert vendored_path != prior_artifact_path
+        assert os.path.dirname(vendored_path) == os.path.join(capture_dir, 'adopted')
+        assert os.path.isfile(vendored_path)
+        with open(vendored_path) as f:
+            assert "geometry = Log('output.out')" in f.read()
+        assert call['qm_artifacts_root'] == capture_dir
+
+    def test_mutant_adopted_artifact_path_is_not_silently_accepted(self, tmp_path, monkeypatch):
+        """Deliverable mutation: substituting an adopted artifact's path with a nonexistent path
+        must fail loudly at the hybrid-write boundary, not silently reach
+        write_hybrid_network_input_file's qm_transition_states."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        capture_result = _empty_capture_result(capture_dir)
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(tmp_path, monkeypatch, capture_result)
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',), ilt_ts_labels=(),
+            vendored_files=(), warnings=())
+
+        try:
+            arc_qm_runner(candidates, paths, _config(), _NETWORK_ID,
+                          adopted={'TS1': 'MUTANT-NOT-A-PATH'})
+            assert False, 'expected a FileNotFoundError'
+        except FileNotFoundError:
+            pass
+        assert recorder.write_hybrid_calls == []
+
+
+def _arc_model_chemistry_text(sp_level: str) -> str:
+    """The exact ``modelChemistry`` source text ARC itself writes for ``sp_level`` -- run the
+    same normalization chain C1's fix in ``adopt_prior_qm`` uses, so this fixture's manifest is
+    faithful to what a real ARC project's ``calcs/statmech/kinetics/input.py`` actually contains
+    (see ``tests/data/pdep_energy_settings/xl1001_project/calcs/statmech/kinetics/input.py``)."""
+    level = Level(repr=sp_level)
+    scale = assign_frequency_scale_factor(level)
+    return get_arkane_model_chemistry(level, freq_scale_factor=scale)
+
 
 def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
-                            network_id='network1_1') -> None:
+                            network_id='network1_1', path_reaction_labels=('reaction1',)) -> None:
     """Build a real capture manifest under ``tmp_path`` by calling ``capture_ts_artifacts`` itself
     (mirrors ``tests/test_pdep/test_capture.py``'s own fixture-building style), so
     ``adopt_prior_qm`` is exercised against the exact format ``t3.pdep.capture`` writes rather than
@@ -510,7 +588,8 @@ def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
     expected_path = expected_ts_artifact_path(arc_dir, arc_label)
     record = TSJoinRecord(network_id=network_id, network_ts_label=ts_label, status=JOIN_STATUS_QUEUED,
                           arc_ts_label=arc_label, expected_artifact_path=expected_path,
-                          reason='Queued to ARC.', coefficient=0.05, delta_ln_k=0.02)
+                          reason='Queued to ARC.', coefficient=0.05, delta_ln_k=0.02,
+                          path_reaction_labels=path_reaction_labels)
 
     os.makedirs(os.path.dirname(expected_path), exist_ok=True)
     log_path = os.path.join(os.path.dirname(expected_path), 'output.out')
@@ -531,7 +610,8 @@ def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
     statmech_dir = os.path.join(arc_dir, 'calcs', 'statmech', 'kinetics')
     os.makedirs(statmech_dir, exist_ok=True)
     with open(os.path.join(statmech_dir, 'input.py'), 'w') as f:
-        f.write(f"modelChemistry = '{level}'\n\nuseHinderedRotors = True\n\nuseAtomCorrections = True\n\n"
+        f.write(f"modelChemistry = {_arc_model_chemistry_text(level)}\n\nuseHinderedRotors = True\n\n"
+                "useAtomCorrections = True\n\n"
                 "atomEnergies = {'C': -37.844411, 'H': -0.499818, 'N': -54.581501, 'O': -75.062219}\n\n"
                 "useBondCorrections = False\n")
 
@@ -548,28 +628,110 @@ def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
                          sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)})
 
 
+_TS1_PATH_REACTION_LABELS = {'TS1': ('reaction1',)}
+
+
 class TestAdoptPriorQM(object):
 
     def test_no_projects_adopts_nothing(self):
-        assert adopt_prior_qm([], 'network1_1', 'wb97xd/def2tzvp') == {}
+        assert adopt_prior_qm([], 'network1_1', 'wb97xd/def2tzvp', _TS1_PATH_REACTION_LABELS) == {}
 
     def test_a_missing_project_is_skipped_not_fatal(self, tmp_path):
         """A stale path in a config must not kill a run that would otherwise work."""
-        assert adopt_prior_qm([str(tmp_path / 'gone')], 'network1_1', 'wb97xd/def2tzvp') == {}
+        assert adopt_prior_qm([str(tmp_path / 'gone')], 'network1_1', 'wb97xd/def2tzvp',
+                              _TS1_PATH_REACTION_LABELS) == {}
 
     def test_matching_level_of_theory_is_adopted(self, tmp_path):
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
-        adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp')
+        adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
+                                 _TS1_PATH_REACTION_LABELS)
         assert 'TS1' in adopted
+
+    def test_adopted_artifact_path_points_at_the_real_captured_file(self, tmp_path):
+        """Regression for mutation (f): a prior round asserted only key membership, so a mutant
+        that returns the wrong path (or a constant) still passed. Assert the value itself."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
+        adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
+                                 _TS1_PATH_REACTION_LABELS)
+        assert os.path.isfile(adopted['TS1'])
+        with open(adopted['TS1']) as f:
+            content = f.read()
+        assert "geometry = Log(" in content and 'output.out' in content
+        assert adopted['TS1'] != 'MUTANT-NOT-A-PATH'
 
     def test_mismatched_level_of_theory_is_refused(self, tmp_path):
         """Mixing levels inside one barrier makes the rate inconsistent, so a non-matching prior
-        result is not adopted even though it exists and converged."""
-        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2svp')
-        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp') == {}
+        result is not adopted even though it exists and converged. b3lyp/def2tzvp normalizes to a
+        genuinely different LevelOfTheory(...) string, not merely a different raw string."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='b3lyp/def2tzvp')
+        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
+                              _TS1_PATH_REACTION_LABELS) == {}
 
     def test_a_different_network_is_not_adopted(self, tmp_path):
-        """Labels are namespace-local: another network's TS1 is not this network's TS1."""
+        """network_id is a pre-filter: another network's manifest is not adopted even when its
+        recorded path_reaction_labels happen to match, since network_id itself never matches."""
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
                                 network_id='network9_9')
-        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp') == {}
+        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
+                              _TS1_PATH_REACTION_LABELS) == {}
+
+    def test_no_structural_match_is_not_adopted(self, tmp_path):
+        """C3/I1: network_id alone is not enough -- a record whose path_reaction_labels do not
+        structurally match any of THIS run's own candidates is refused, even with a matching
+        network_id and level of theory."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
+                                path_reaction_labels=('reaction7',))
+        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
+                              _TS1_PATH_REACTION_LABELS) == {}
+
+    def test_status_gate_refuses_non_usable_artifacts(self, tmp_path, monkeypatch):
+        """Regression for mutation (d): dropping the ARTIFACT_STATUS_USABLE check must not let a
+        non-usable (e.g. UNVERIFIED) record be adopted."""
+        manifest_dir = tmp_path / 'proj' / 'capture'
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME).write_text('stub')
+        record = TSArtifactRecord(network_id='network1_1', network_ts_label='TS1', arc_ts_label='X',
+                                  status=ARTIFACT_STATUS_UNVERIFIED,
+                                  artifact_path=str(tmp_path / 'qm' / 'TS1.py'),
+                                  path_reaction_labels=('reaction1',))
+        verify_result = VerifyResult(
+            capture_dir=str(manifest_dir),
+            manifest_path=str(manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME),
+            record_count=1, captured_artifact_count=1,
+            networks={'network1_1': {}},
+            energy_settings={'model_chemistry': _arc_model_chemistry_text('wb97xd/def2tzvp')},
+            ts_records=(record,))
+        monkeypatch.setattr(pes_qm, 'verify_capture', lambda root: verify_result)
+        adopted = adopt_prior_qm([str(tmp_path / 'proj')], 'network1_1', 'wb97xd/def2tzvp',
+                                 _TS1_PATH_REACTION_LABELS)
+        assert adopted == {}
+
+    def test_conflicting_prior_captures_are_refused_not_last_write_wins(self, tmp_path, monkeypatch):
+        """I5: two manifests offering different artifacts for the same structurally-matched local
+        TS label must not silently pick one by os.walk order -- reuse for that label is refused."""
+        record_a = TSArtifactRecord(network_id='network1_1', network_ts_label='TS1', arc_ts_label='A',
+                                    status=ARTIFACT_STATUS_USABLE, artifact_path='/a/TS1.py',
+                                    path_reaction_labels=('reaction1',))
+        record_b = TSArtifactRecord(network_id='network1_1', network_ts_label='TS1', arc_ts_label='B',
+                                    status=ARTIFACT_STATUS_USABLE, artifact_path='/b/TS1.py',
+                                    path_reaction_labels=('reaction1',))
+        energy_settings = {'model_chemistry': _arc_model_chemistry_text('wb97xd/def2tzvp')}
+        results_by_root = {}
+
+        def _fake_verify_capture(root):
+            return results_by_root[root]
+
+        for name, record in (('proj_a', record_a), ('proj_b', record_b)):
+            manifest_dir = tmp_path / name / 'capture'
+            manifest_dir.mkdir(parents=True)
+            (manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME).write_text('stub')
+            results_by_root[str(manifest_dir)] = VerifyResult(
+                capture_dir=str(manifest_dir),
+                manifest_path=str(manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME),
+                record_count=1, captured_artifact_count=1, networks={'network1_1': {}},
+                energy_settings=energy_settings, ts_records=(record,))
+
+        monkeypatch.setattr(pes_qm, 'verify_capture', _fake_verify_capture)
+        adopted = adopt_prior_qm([str(tmp_path / 'proj_a'), str(tmp_path / 'proj_b')],
+                                 'network1_1', 'wb97xd/def2tzvp', _TS1_PATH_REACTION_LABELS)
+        assert adopted == {}

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -866,3 +866,63 @@ class TestArcQmRunnerSensitivityEvidence(object):
         assert _FakeARC.constructions == []
         assert _FakeARC.execute_calls == 0
         assert recorder.capture_ts_artifacts_calls == []
+
+
+class TestArcQmRunnerWithNothingQueued(object):
+    """Defect 2: a round with nothing to queue (every candidate satisfied by adoption) must skip
+    ARC and capture ENTIRELY -- capture_ts_artifacts refuses an empty join_records by design, and
+    the previous behaviour crashed a fully-adopted round 0 out of run_pes_loop -- and go straight
+    to vendoring the adopted artifacts and writing the hybrid."""
+
+    def test_all_adopted_round_skips_arc_and_capture_and_still_writes_the_hybrid(self, tmp_path,
+                                                                                 monkeypatch):
+        # A REAL prior capture (built by capture_ts_artifacts itself), adopted through the real
+        # adopt_prior_qm, so the vendoring below and _adopted_energy_settings both run against the
+        # exact artifact and manifest formats production writes -- no hand-rolled shapes.
+        _write_capture_manifest(tmp_path / 'prior_project', ts_label='TS1',
+                                level='wb97xd/def2tzvp')
+        adopted = adopt_prior_qm([str(tmp_path / 'prior_project')], _NETWORK_ID,
+                                 'wb97xd/def2tzvp', _TS1_PATH_REACTION_LABELS)
+        assert adopted, 'fixture must adopt TS1 for this test to mean anything'
+
+        paths, _candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, capture_result=None)
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',),
+            ilt_ts_labels=(), vendored_files=(), warnings=())
+
+        converged, queued = arc_qm_runner((), paths, _config(), _NETWORK_ID, adopted=adopted)
+
+        assert converged == frozenset()
+        assert queued == frozenset()
+        # Nothing was queued, so ARC must never have been constructed or executed, and
+        # capture_ts_artifacts must never have been called at all.
+        assert _FakeARC.constructions == []
+        assert _FakeARC.execute_calls == 0
+        assert recorder.capture_ts_artifacts_calls == []
+        # The hybrid still fires: the adopted artifact is vendored under THIS round's own capture
+        # directory, the source is the round's explored network (no captured copy exists), the
+        # method is the configured one, and the energy settings come from the adopted artifact's
+        # own prior manifest.
+        assert len(recorder.write_hybrid_calls) == 1
+        call = recorder.write_hybrid_calls[0]
+        vendored_path = call['qm_transition_states']['TS1']
+        assert os.path.dirname(vendored_path) == os.path.join(paths.capture, 'adopted')
+        assert os.path.isfile(vendored_path)
+        assert call['source_path'] == network_path
+        assert call['method'] == 'MSC'
+        assert call['qm_artifacts_root'] == paths.capture
+        assert call['dest_path'] == hybrid_network_path(paths, _NETWORK_ID)
+        assert call['energy_settings'].model_chemistry == _arc_model_chemistry_text('wb97xd/def2tzvp')
+
+    def test_nothing_queued_and_nothing_adopted_returns_empty_without_touching_arc(self, tmp_path,
+                                                                                   monkeypatch):
+        paths, _candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, capture_result=None)
+        converged, queued = arc_qm_runner((), paths, _config(), _NETWORK_ID)
+        assert converged == frozenset()
+        assert queued == frozenset()
+        assert _FakeARC.constructions == []
+        assert _FakeARC.execute_calls == 0
+        assert recorder.capture_ts_artifacts_calls == []
+        assert recorder.write_hybrid_calls == []

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -15,9 +15,10 @@ from t3.pdep.discovery import ARTIFACT_STATUS_UNVERIFIED, ARTIFACT_STATUS_USABLE
 from t3.pdep.hashing import hash_file
 from t3.pdep.hybrid import HybridNetworkResult
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label, expected_ts_artifact_path
-from t3.pdep.parser import PDepPathReaction
+from t3.pdep.parser import PDepPathReaction, parse_pdep_network_file
 from t3.pdep.pes_qm import ARC_INPUT_FILE_NAME, adopt_prior_qm, arc_qm_runner, build_arc_input
-from t3.pdep.pes_rounds import QMCandidate, hybrid_network_path, round_paths
+from t3.pdep.pes_rounds import (QMCandidate, channel_keys_by_ts_label, hybrid_network_path,
+                                round_paths)
 from t3.schema import PESLoopConfig
 
 
@@ -601,14 +602,17 @@ def _arc_model_chemistry_text(sp_level: str) -> str:
 
 
 def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
-                            network_id='network1_1', path_reaction_labels=('reaction1',)) -> None:
+                            network_id='network1_1', network_source_text=None) -> None:
     """Build a real capture manifest under ``tmp_path`` by calling ``capture_ts_artifacts`` itself
     (mirrors ``tests/test_pdep/test_capture.py``'s own fixture-building style), so
     ``adopt_prior_qm`` is exercised against the exact format ``t3.pdep.capture`` writes rather than
     a hand-rolled shape. The manifest ends up at ``tmp_path/capture/capture_manifest.yml``, nested
     the same way a real T3 project's ``PDep_capture`` directory is nested under an iteration
     subdirectory -- ``adopt_prior_qm`` must find it by walking ``tmp_path``, not by assuming a
-    fixed relative path.
+    fixed relative path. The vendored network source defaults to the REAL ``network799_1``
+    fixture, because adoption resolves each record's transition state to its structural channel
+    in the capture's own vendored network copy -- a capture vendored over an unparseable stub
+    offers nothing adoptable (a case one test pins deliberately, via ``network_source_text``).
     """
     arc_dir = str(tmp_path / 'arc_project')
     os.makedirs(arc_dir, exist_ok=True)
@@ -617,7 +621,7 @@ def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
     record = TSJoinRecord(network_id=network_id, network_ts_label=ts_label, status=JOIN_STATUS_QUEUED,
                           arc_ts_label=arc_label, expected_artifact_path=expected_path,
                           reason='Queued to ARC.', coefficient=0.05, delta_ln_k=0.02,
-                          path_reaction_labels=path_reaction_labels)
+                          path_reaction_labels=(f'reaction{ts_label[2:]}',))
 
     os.makedirs(os.path.dirname(expected_path), exist_ok=True)
     log_path = os.path.join(os.path.dirname(expected_path), 'output.out')
@@ -646,8 +650,11 @@ def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
     networks_dir = str(tmp_path / 'networks')
     os.makedirs(networks_dir, exist_ok=True)
     source_path = os.path.join(networks_dir, f'{network_id}.py')
-    with open(source_path, 'w') as f:
-        f.write(f"# stub RMG network file\nnetwork(label='{network_id}')\n")
+    if network_source_text is None:
+        shutil.copyfile(_FIXTURE_NETWORK_PATH, source_path)
+    else:
+        with open(source_path, 'w') as f:
+            f.write(network_source_text)
     networks = {network_id: {'source_path': source_path, 'source_sha256': hash_file(source_path),
                              'method': 'MSC'}}
 
@@ -656,23 +663,26 @@ def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
                          sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)})
 
 
-_TS1_PATH_REACTION_LABELS = {'TS1': ('reaction1',)}
+# THIS run's own structural channel-key map, computed over the same real fixture the prior
+# captures vendor -- what run_pes_loop itself hands adopt_prior_qm (via channel_keys_by_ts_label
+# over the seed network).
+_FIXTURE_CHANNEL_KEYS = channel_keys_by_ts_label(parse_pdep_network_file(path=_FIXTURE_NETWORK_PATH))
 
 
 class TestAdoptPriorQM(object):
 
     def test_no_projects_adopts_nothing(self):
-        assert adopt_prior_qm([], 'network1_1', 'wb97xd/def2tzvp', _TS1_PATH_REACTION_LABELS) == {}
+        assert adopt_prior_qm([], 'network1_1', 'wb97xd/def2tzvp', _FIXTURE_CHANNEL_KEYS) == {}
 
     def test_a_missing_project_is_skipped_not_fatal(self, tmp_path):
         """A stale path in a config must not kill a run that would otherwise work."""
         assert adopt_prior_qm([str(tmp_path / 'gone')], 'network1_1', 'wb97xd/def2tzvp',
-                              _TS1_PATH_REACTION_LABELS) == {}
+                              _FIXTURE_CHANNEL_KEYS) == {}
 
     def test_matching_level_of_theory_is_adopted(self, tmp_path):
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
         adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
-                                 _TS1_PATH_REACTION_LABELS)
+                                 _FIXTURE_CHANNEL_KEYS)
         assert 'TS1' in adopted
 
     def test_adopted_artifact_path_points_at_the_real_captured_file(self, tmp_path):
@@ -680,7 +690,7 @@ class TestAdoptPriorQM(object):
         that returns the wrong path (or a constant) still passed. Assert the value itself."""
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
         adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
-                                 _TS1_PATH_REACTION_LABELS)
+                                 _FIXTURE_CHANNEL_KEYS)
         assert os.path.isfile(adopted['TS1'])
         with open(adopted['TS1']) as f:
             content = f.read()
@@ -693,7 +703,7 @@ class TestAdoptPriorQM(object):
         genuinely different LevelOfTheory(...) string, not merely a different raw string."""
         _write_capture_manifest(tmp_path, ts_label='TS1', level='b3lyp/def2tzvp')
         assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
-                              _TS1_PATH_REACTION_LABELS) == {}
+                              _FIXTURE_CHANNEL_KEYS) == {}
 
     def test_a_different_network_id_is_still_adopted_on_structural_match(self, tmp_path):
         """Important (fix round 2): network_id is NEVER a gate -- this function's own docstring
@@ -704,17 +714,17 @@ class TestAdoptPriorQM(object):
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
                                 network_id='network9_9')
         adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
-                                 _TS1_PATH_REACTION_LABELS)
+                                 _FIXTURE_CHANNEL_KEYS)
         assert 'TS1' in adopted
 
     def test_no_structural_match_is_not_adopted(self, tmp_path):
-        """C3/I1: network_id alone is not enough -- a record whose path_reaction_labels do not
-        structurally match any of THIS run's own candidates is refused, even with a matching
-        network_id and level of theory."""
-        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
-                                path_reaction_labels=('reaction7',))
+        """C3/I1: network_id alone is not enough -- a record whose structural channel key matches
+        none of THIS run's own transition states is refused, even with a matching network_id and
+        level of theory."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
+        other_channels_only = {ts: key for ts, key in _FIXTURE_CHANNEL_KEYS.items() if ts != 'TS1'}
         assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
-                              _TS1_PATH_REACTION_LABELS) == {}
+                              other_channels_only) == {}
 
     def test_status_gate_refuses_non_usable_artifacts(self, tmp_path, monkeypatch):
         """Regression for mutation (d): dropping the ARTIFACT_STATUS_USABLE check must not let a
@@ -722,6 +732,9 @@ class TestAdoptPriorQM(object):
         manifest_dir = tmp_path / 'proj' / 'capture'
         manifest_dir.mkdir(parents=True)
         (manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME).write_text('stub')
+        networks_dir = manifest_dir / 'networks'
+        networks_dir.mkdir()
+        shutil.copyfile(_FIXTURE_NETWORK_PATH, str(networks_dir / 'network1_1.py'))
         record = TSArtifactRecord(network_id='network1_1', network_ts_label='TS1', arc_ts_label='X',
                                   status=ARTIFACT_STATUS_UNVERIFIED,
                                   artifact_path=str(tmp_path / 'qm' / 'TS1.py'),
@@ -730,12 +743,12 @@ class TestAdoptPriorQM(object):
             capture_dir=str(manifest_dir),
             manifest_path=str(manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME),
             record_count=1, captured_artifact_count=1,
-            networks={'network1_1': {}},
+            networks={'network1_1': {'captured_path': os.path.join('networks', 'network1_1.py')}},
             energy_settings={'model_chemistry': _arc_model_chemistry_text('wb97xd/def2tzvp')},
             ts_records=(record,))
         monkeypatch.setattr(pes_qm, 'verify_capture', lambda root: verify_result)
         adopted = adopt_prior_qm([str(tmp_path / 'proj')], 'network1_1', 'wb97xd/def2tzvp',
-                                 _TS1_PATH_REACTION_LABELS)
+                                 _FIXTURE_CHANNEL_KEYS)
         assert adopted == {}
 
     def test_conflicting_prior_captures_are_refused_not_last_write_wins(self, tmp_path, monkeypatch):
@@ -757,15 +770,23 @@ class TestAdoptPriorQM(object):
             manifest_dir = tmp_path / name / 'capture'
             manifest_dir.mkdir(parents=True)
             (manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME).write_text('stub')
+            # Each fake capture must vendor a REAL, parseable network copy: adoption resolves the
+            # record's transition state to its structural channel in that copy, and a capture
+            # without one offers nothing adoptable (so the conflict logic under test would never
+            # even be reached).
+            networks_dir = manifest_dir / 'networks'
+            networks_dir.mkdir()
+            shutil.copyfile(_FIXTURE_NETWORK_PATH, str(networks_dir / 'network1_1.py'))
             results_by_root[str(manifest_dir)] = VerifyResult(
                 capture_dir=str(manifest_dir),
                 manifest_path=str(manifest_dir / pes_qm.CAPTURE_MANIFEST_FILE_NAME),
-                record_count=1, captured_artifact_count=1, networks={'network1_1': {}},
+                record_count=1, captured_artifact_count=1,
+                networks={'network1_1': {'captured_path': os.path.join('networks', 'network1_1.py')}},
                 energy_settings=energy_settings, ts_records=(record,))
 
         monkeypatch.setattr(pes_qm, 'verify_capture', _fake_verify_capture)
         adopted = adopt_prior_qm([str(tmp_path / 'proj_a'), str(tmp_path / 'proj_b')],
-                                 'network1_1', 'wb97xd/def2tzvp', _TS1_PATH_REACTION_LABELS)
+                                 'network1_1', 'wb97xd/def2tzvp', _FIXTURE_CHANNEL_KEYS)
         assert adopted == {}
 
 
@@ -794,25 +815,28 @@ class TestNormalizedModelChemistry(object):
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
         with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_qm'):
             adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd2023/def2tzvp',
-                                     _TS1_PATH_REACTION_LABELS)
+                                     _FIXTURE_CHANNEL_KEYS)
         assert adopted == {}
         assert 'nothing will be adopted' in caplog.text
 
 
 class TestAdoptPriorQMRefusesRecordsWithoutStructuralEvidence(object):
 
-    def test_record_with_no_path_reaction_labels_is_refused_with_its_own_reason(self, tmp_path, caplog):
-        """A usable record that carries NO path_reaction_labels cannot be structurally matched at
-        all -- it must be refused with a log line saying exactly that, not fall through the match
-        loop to a misleading 'matches none of this run's candidates' message."""
+    def test_record_whose_vendored_network_offers_no_structural_identity_is_refused(self, tmp_path,
+                                                                                    caplog):
+        """A usable record whose transition state cannot be resolved to a channel in the
+        capture's own vendored network copy (here: a stub network with no reactions at all) cannot
+        be structurally matched -- it must be refused with a log line saying exactly that, never
+        matched by any label."""
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
-                                path_reaction_labels=())
+                                network_source_text="# stub RMG network file\n"
+                                                    "network(label='network1_1')\n")
         with caplog.at_level(logging.INFO, logger='t3.pdep.pes_qm'):
             adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
-                                     _TS1_PATH_REACTION_LABELS)
+                                     _FIXTURE_CHANNEL_KEYS)
         assert adopted == {}
-        assert 'records no path_reaction_labels' in caplog.text
-        assert 'match none of' not in caplog.text
+        assert 'no unambiguous structural channel identity' in caplog.text
+        assert 'matches none of' not in caplog.text
 
 
 class TestAdoptedEnergySettings(object):
@@ -825,19 +849,18 @@ class TestAdoptedEnergySettings(object):
     def test_settings_come_from_the_adopted_artifacts_own_prior_manifest(self, tmp_path):
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
         adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
-                                 _TS1_PATH_REACTION_LABELS)
+                                 _FIXTURE_CHANNEL_KEYS)
         settings = pes_qm._adopted_energy_settings(adopted)
         assert settings['model_chemistry'] == _arc_model_chemistry_text('wb97xd/def2tzvp')
         assert settings['use_hindered_rotors'] is True
 
     def test_conflicting_prior_manifests_raise_rather_than_guess(self, tmp_path):
         _write_capture_manifest(tmp_path / 'proj_a', ts_label='TS1', level='wb97xd/def2tzvp')
-        _write_capture_manifest(tmp_path / 'proj_b', ts_label='TS2', level='b3lyp/def2tzvp',
-                                path_reaction_labels=('reaction2',))
+        _write_capture_manifest(tmp_path / 'proj_b', ts_label='TS2', level='b3lyp/def2tzvp')
         adopted_a = adopt_prior_qm([str(tmp_path / 'proj_a')], 'network1_1', 'wb97xd/def2tzvp',
-                                   _TS1_PATH_REACTION_LABELS)
+                                   _FIXTURE_CHANNEL_KEYS)
         adopted_b = adopt_prior_qm([str(tmp_path / 'proj_b')], 'network1_1', 'b3lyp/def2tzvp',
-                                   {'TS2': ('reaction2',)})
+                                   {'TS2': _FIXTURE_CHANNEL_KEYS['TS2']})
         with pytest.raises(ValueError, match='conflicting'):
             pes_qm._adopted_energy_settings(adopted_a | adopted_b)
 
@@ -882,7 +905,7 @@ class TestArcQmRunnerWithNothingQueued(object):
         _write_capture_manifest(tmp_path / 'prior_project', ts_label='TS1',
                                 level='wb97xd/def2tzvp')
         adopted = adopt_prior_qm([str(tmp_path / 'prior_project')], _NETWORK_ID,
-                                 'wb97xd/def2tzvp', _TS1_PATH_REACTION_LABELS)
+                                 'wb97xd/def2tzvp', _FIXTURE_CHANNEL_KEYS)
         assert adopted, 'fixture must adopt TS1 for this test to mean anything'
 
         paths, _candidates, recorder, network_path = _arc_qm_runner_fixture(

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -3,10 +3,14 @@
 import os
 import shutil
 
+from arc.reaction.reaction import ARCReaction
+from arc.species.species import ARCSpecies
+
 import t3.pdep.pes_qm as pes_qm
 from t3.pdep.capture import CaptureResult
 from t3.pdep.discovery import ARTIFACT_STATUS_UNVERIFIED, ARTIFACT_STATUS_USABLE, TSArtifactRecord
 from t3.pdep.hybrid import HybridNetworkResult
+from t3.pdep.join import JOIN_STATUS_QUEUED, arc_ts_label
 from t3.pdep.parser import PDepPathReaction
 from t3.pdep.pes_loop import hybrid_network_path
 from t3.pdep.pes_qm import ARC_INPUT_FILE_NAME, arc_qm_runner, build_arc_input
@@ -30,6 +34,18 @@ def _candidate(ts_label='TS1', family='1,2_Insertion_CO', reactants=('A',), prod
 # Adjacency-list text is opaque to build_arc_input -- any non-empty string exercises the
 # species_structures plumbing without needing a chemically valid structure.
 _STRUCTURES = {'A': '1 A u0 p0 c0\n', 'B': '1 B u0 p0 c0\n'}
+
+# A real, atom-balanced RMG adjacency list (ethyl radical) used for the one test (N1) that must
+# construct a genuine ARCReaction/ARCSpecies rather than merely assert on dict shape -- ARC's own
+# atom-balance check (check_atom_balance) requires both wells to carry the same molecular formula.
+_ETHYL_ADJLIST = ('1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}\n'
+                  '2 C u1 p0 c0 {1,S} {6,S} {7,S}\n'
+                  '3 H u0 p0 c0 {1,S}\n'
+                  '4 H u0 p0 c0 {1,S}\n'
+                  '5 H u0 p0 c0 {1,S}\n'
+                  '6 H u0 p0 c0 {2,S}\n'
+                  '7 H u0 p0 c0 {2,S}')
+_BALANCED_STRUCTURES = {'A': _ETHYL_ADJLIST, 'B': _ETHYL_ADJLIST}
 
 
 class TestBuildARCInput(object):
@@ -80,23 +96,28 @@ class TestBuildARCInput(object):
         assert arc_input['irc_level'] == 'wb97xd/def2tzvp'
         assert arc_input['reactions'][0]['family'] == '1,2_Insertion_CO'
 
-    def test_reaction_and_species_dicts_can_construct_a_real_arc_reaction(self):
-        """C2: a reaction dict alone (no top-level 'species' list) cannot construct a valid
-        ARCReaction -- ARCReaction.from_dict resolves r_species/p_species by matching their
-        'label' against ARC's own top-level species list. This asserts build_arc_input emits
-        both halves of that contract."""
-        candidate = _candidate(reactants=('A',), products=('B',))
+    def test_reaction_and_species_dicts_construct_a_real_arc_reaction(self):
+        """N1: build_arc_input must not set a 'label' key on the reaction dict it emits.
+        ARCReaction.from_dict only synthesizes a label from reactants/products when self.label
+        starts empty (arc/reaction/reaction.py, set_label_reactants_products) -- a raw network
+        label like 'reaction1' passed through as 'label' short-circuits that fallback, and
+        check_atom_balance then crashes with IndexError on self.label.split('<=>')[well] because
+        'reaction1' has no '<=>' in it. This constructs a REAL ARCReaction (mirroring ARC.__init__'s
+        own order: ARCSpecies built first, then ARCReaction(reaction_dict=..., species_list=...))
+        to prove the emitted dict actually survives ARC's construction path, not just that it has
+        the right shape."""
+        candidate = _candidate(ts_label='TS1', reactants=('A',), products=('B',), label='reaction1')
         arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1',
-                                    _STRUCTURES)
+                                    _BALANCED_STRUCTURES)
         reaction = arc_input['reactions'][0]
-        assert reaction['reactants'] == ['A']
-        assert reaction['products'] == ['B']
-        assert reaction['r_species'] == [{'label': 'A'}]
-        assert reaction['p_species'] == [{'label': 'B'}]
-        species_by_label = {spc['label']: spc for spc in arc_input['species']}
-        assert set(species_by_label) == {'A', 'B'}
-        assert species_by_label['A']['adjlist'] == _STRUCTURES['A']
-        assert species_by_label['B']['adjlist'] == _STRUCTURES['B']
+        assert 'label' not in reaction
+
+        species_list = [ARCSpecies(**spc) for spc in arc_input['species']]
+        rxn = ARCReaction(reaction_dict=reaction, species_list=species_list)
+
+        assert rxn.ts_label == reaction['ts_label']
+        assert [spc.label for spc in rxn.r_species] == ['A']
+        assert [spc.label for spc in rxn.p_species] == ['B']
 
     def test_compute_thermo_is_explicitly_disabled_on_every_species(self):
         """ARC defaults a bare species dict's compute_thermo to True, which would queue full
@@ -108,12 +129,16 @@ class TestBuildARCInput(object):
         assert arc_input['species']
         assert all(spc['compute_thermo'] is False for spc in arc_input['species'])
 
-    def test_candidate_with_no_structure_is_dropped_not_crashed(self):
+    def test_candidate_with_no_structure_is_dropped_not_crashed(self, caplog):
         candidate = _candidate(reactants=('A',), products=('unknown_species',))
-        arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1',
-                                    _STRUCTURES)
+        with caplog.at_level('WARNING', logger='t3.pdep.pes_qm'):
+            arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(),
+                                        'network1_1', _STRUCTURES)
         assert arc_input['reactions'] == []
         assert arc_input['species'] == []
+        warnings = [r.message for r in caplog.records if r.levelname == 'WARNING']
+        assert any('unknown_species' in message for message in warnings), \
+            f'expected a WARNING naming the missing species, got: {warnings}'
 
     def test_dead_network_ts_label_key_is_not_emitted(self):
         candidate = _candidate()
@@ -160,7 +185,7 @@ class _FakeARC(object):
         _FakeARC.execute_calls += 1
 
     def as_dict(self):
-        return {'fake_as_dict_of': self.kwargs.get('project')}
+        return dict(self.kwargs)
 
 
 class _FakeCalls(object):
@@ -265,6 +290,17 @@ class TestArcQmRunner(object):
         assert kwargs['species'], 'ARC received zero species'
         assert kwargs['reactions'][0]['ts_label'] == 'T3PDep_network799_1_TS1'
 
+    def test_arc_is_constructed_with_this_rounds_own_project_and_project_directory(self, tmp_path, monkeypatch):
+        """#9: project/project_directory must be asserted on the recorded ARC(**kwargs) call
+        itself, not merely inferred from build_arc_input's own output."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _empty_capture_result(capture_dir))
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        kwargs = _FakeARC.constructions[0]
+        assert kwargs['project'] == _NETWORK_ID
+        assert kwargs['project_directory'] == paths.arc_project
+
     def test_arc_execute_is_called_exactly_once(self, tmp_path, monkeypatch):
         capture_dir = os.path.join(str(tmp_path), 'capture')
         paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
@@ -281,7 +317,7 @@ class TestArcQmRunner(object):
         assert len(recorder.save_yaml_file_calls) == 1
         call = recorder.save_yaml_file_calls[0]
         assert call['path'] == os.path.join(paths.arc_project, ARC_INPUT_FILE_NAME)
-        assert call['content'] == {'fake_as_dict_of': _NETWORK_ID}
+        assert call['content'] == _FakeARC.constructions[0]
 
     def test_arc_input_yml_is_not_rewritten_when_it_already_exists(self, tmp_path, monkeypatch):
         capture_dir = os.path.join(str(tmp_path), 'capture')
@@ -305,15 +341,45 @@ class TestArcQmRunner(object):
         assert call['networks'][_NETWORK_ID]['source_path'] == network_path
         assert call['networks'][_NETWORK_ID]['method'] == 'MSC'
         assert len(call['join_records']) == 1
-        assert call['join_records'][0].network_ts_label == 'TS1'
+        join_record = call['join_records'][0]
+        assert join_record.network_ts_label == 'TS1'
+        assert join_record.arc_ts_label == arc_ts_label(_NETWORK_ID, 'TS1')
+        assert join_record.network_id == _NETWORK_ID
+        assert join_record.status == JOIN_STATUS_QUEUED
 
     def test_no_usable_artifact_returns_empty_and_skips_hybrid_write(self, tmp_path, monkeypatch):
         capture_dir = os.path.join(str(tmp_path), 'capture')
         paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
             tmp_path, monkeypatch, _empty_capture_result(capture_dir))
-        result = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
-        assert result == frozenset()
+        converged, queued = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert converged == frozenset()
+        assert queued == frozenset({'TS1'})
         assert recorder.write_hybrid_calls == []
+
+    def test_dropped_candidate_is_not_reported_as_queued(self, tmp_path, monkeypatch):
+        """N3: build_arc_input silently drops a candidate with no adjacency list for a
+        reactant/product (a warning, not a crash) -- arc_qm_runner's own queued_ts_labels must not
+        claim that dropped candidate was ever sent to ARC, even though it was among the candidates
+        this function was handed."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _empty_capture_result(capture_dir))
+        dropped = _candidate(ts_label='TS_missing', family='1,2_Insertion_CO',
+                             reactants=('no_such_species',), products=('also_missing',),
+                             label='reaction_missing')
+        candidates = candidates + (dropped,)
+        converged, queued = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert queued == frozenset({'TS1'})
+        assert 'TS_missing' not in queued
+        # The dropped candidate must not have reached ARC either.
+        assert len(_FakeARC.constructions) == 1
+        ts_labels_sent_to_arc = {r['ts_label'] for r in _FakeARC.constructions[0]['reactions']}
+        assert 'TS_missing' not in {label.rsplit('_', 1)[-1] for label in ts_labels_sent_to_arc}
+        # And the join record capture_ts_artifacts was handed must not claim it was queued either.
+        assert len(recorder.capture_ts_artifacts_calls) == 1
+        join_ts_labels = {jr.network_ts_label
+                          for jr in recorder.capture_ts_artifacts_calls[0]['join_records']}
+        assert join_ts_labels == {'TS1'}
 
     def test_usable_artifact_triggers_hybrid_write_from_the_captures_own_network_copy(self, tmp_path, monkeypatch):
         """I1: source_path/method must come from CaptureResult.networks, never the live network."""
@@ -373,7 +439,8 @@ class TestArcQmRunner(object):
         qm_transition_states = recorder.write_hybrid_calls[0]['qm_transition_states']
         assert qm_transition_states == {'TS1': os.path.join(capture_dir, 'qm', 'TS1.py')}
 
-    def test_return_value_is_the_frozenset_of_usable_network_ts_labels_only(self, tmp_path, monkeypatch):
+    def test_return_value_is_converged_and_queued_ts_labels_as_a_tuple(self, tmp_path, monkeypatch):
+        """arc_qm_runner returns (converged_ts_labels, queued_ts_labels) -- N3."""
         capture_dir = os.path.join(str(tmp_path), 'capture')
         os.makedirs(os.path.join(capture_dir, 'networks'))
         shutil.copyfile(_FIXTURE_NETWORK_PATH,
@@ -383,5 +450,6 @@ class TestArcQmRunner(object):
         recorder.hybrid_result = HybridNetworkResult(
             dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1',), ilt_ts_labels=(),
             vendored_files=(), warnings=())
-        result = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
-        assert result == frozenset({'TS1'})
+        converged, queued = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
+        assert converged == frozenset({'TS1'})
+        assert queued == frozenset({'TS1'})

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -17,8 +17,8 @@ from t3.pdep.hybrid import HybridNetworkResult
 from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label, expected_ts_artifact_path
 from t3.pdep.parser import PDepPathReaction, parse_pdep_network_file
 from t3.pdep.pes_qm import (ARC_INPUT_FILE_NAME, _adopted_energy_settings,
-                            _normalized_model_chemistry, adopt_prior_qm, arc_qm_runner,
-                            build_arc_input)
+                            _normalized_model_chemistries, _normalized_model_chemistry,
+                            adopt_prior_qm, arc_qm_runner, build_arc_input)
 from t3.pdep.pes_rounds import (QMCandidate, channel_keys_by_ts_label, hybrid_network_path,
                                 round_paths)
 from t3.schema import PESLoopConfig
@@ -725,20 +725,33 @@ class TestArcQmRunner(object):
 # whatever that chain currently does, so a real bug in it could never be caught by a test built
 # from it. A stored manifest written by an older ARC version is exactly the case a fixture that
 # re-derives its own expectation at test time cannot represent.
+# The composite entry is likewise copied verbatim from real ARC output vendored in this
+# repository -- tests/data/pdep_energy_settings/composite_level_project/calcs/statmech/thermo/
+# input.py:9-12, whose exact text tests/test_pdep/test_energy_settings.py already pins as what
+# t3.pdep.energy_settings freezes into a manifest. It is keyed by the (sp_level, freq_level) pair
+# it was written for.
 _ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL = {
     'wb97xd/def2tzvp': "LevelOfTheory(method='wb97xd2023',basis='def2tzvp',software='gaussian')",
     'b3lyp/def2tzvp': "LevelOfTheory(method='b3lyp2023',basis='def2tzvp',software='gaussian')",
+    ('dlpno-ccsd(t)-f12/cc-pvtz-f12', 'wb97xd/def2tzvp'): (
+        "CompositeLevelOfTheory(\n"
+        "    freq=LevelOfTheory(method='wb97xd',basis='def2tzvp',software='gaussian'),\n"
+        "    energy=LevelOfTheory(method='dlpnoccsd(t)f122023',basis='ccpvtzf12',software='orca')\n"
+        ")"
+    ),
 }
 
 
-def _arc_model_chemistry_text(sp_level: str) -> str:
-    """The exact ``modelChemistry`` source text a real ARC project writes for ``sp_level`` -- a
-    fixed, pre-captured literal (see ``_ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL`` above), not one
-    recomputed via the same normalization chain the code under test uses."""
+def _arc_model_chemistry_text(sp_level: str, freq_level: str | None = None) -> str:
+    """The exact ``modelChemistry`` source text a real ARC project writes for this level (or
+    sp/freq pair) -- a fixed, pre-captured literal (see ``_ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL``
+    above), not one recomputed via the same normalization chain the code under test uses."""
+    if freq_level is not None and (sp_level, freq_level) in _ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL:
+        return _ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL[(sp_level, freq_level)]
     return _ARC_MODEL_CHEMISTRY_TEXT_BY_LEVEL[sp_level]
 
 
-def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
+def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp', freq_level=None,
                             network_id='network1_1', network_source_text=None) -> None:
     """Build a real capture manifest under ``tmp_path`` by calling ``capture_ts_artifacts`` itself
     (mirrors ``tests/test_pdep/test_capture.py``'s own fixture-building style), so
@@ -779,7 +792,7 @@ def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
     statmech_dir = os.path.join(arc_dir, 'calcs', 'statmech', 'kinetics')
     os.makedirs(statmech_dir, exist_ok=True)
     with open(os.path.join(statmech_dir, 'input.py'), 'w') as f:
-        f.write(f"modelChemistry = {_arc_model_chemistry_text(level)}\n\nuseHinderedRotors = True\n\n"
+        f.write(f"modelChemistry = {_arc_model_chemistry_text(level, freq_level)}\n\nuseHinderedRotors = True\n\n"
                 "useAtomCorrections = True\n\n"
                 "atomEnergies = {'C': -37.844411, 'H': -0.499818, 'N': -54.581501, 'O': -75.062219}\n\n"
                 "useBondCorrections = False\n")
@@ -928,33 +941,76 @@ class TestAdoptPriorQM(object):
 
 
 class TestNormalizedModelChemistry(object):
-    """Direct coverage for _normalized_model_chemistry, which previously had none -- and whose
-    raise-instead-of-None defect (a ValueError out of ARC's get_arkane_model_chemistry for a level
-    with no tabulated frequency scale factor) killed the loop before round 0."""
+    """Direct coverage for _normalized_model_chemistry. Its job is to reproduce, byte for byte,
+    the model_chemistry string ARC itself wrote into the capture manifest -- anything less and
+    every prior capture is refused on a mismatch that does not exist."""
 
     def test_resolvable_level_returns_arcs_own_literal(self):
         assert _normalized_model_chemistry('wb97xd/def2tzvp') \
             == _arc_model_chemistry_text('wb97xd/def2tzvp')
 
-    def test_year_suffixed_level_with_no_tabulated_scale_factor_returns_none_not_raise(self, caplog):
+    def test_a_composite_sp_freq_pair_resolves_instead_of_going_dead(self):
+        """The schema permits sp_level != freq_level. ARC settles its frequency scale factor from
+        the FREQUENCY level (ARC.check_freq_scaling_factor) before the Arkane adapter runs, so the
+        manifest carries the plain LevelOfTheory repr of the SP level. Deriving the factor from the
+        SP level instead yields None for an SP level with no tabulated factor of its own,
+        get_arkane_model_chemistry then raises, this function reported 'unresolvable', and reuse
+        was silently dead for the entire composite configuration."""
+        normalized = _normalized_model_chemistry('dlpno-ccsd(t)-f12/cc-pvtz-f12',
+                                                 'wb97xd/def2tzvp')
+        assert normalized is not None, 'reuse is dead for every composite sp/freq configuration'
+        assert normalized.startswith('LevelOfTheory('), \
+            "ARC writes the SP level's plain repr once its own freq scale factor is settled"
+        # The energy half is the SP level, spelled the way the vendored real ARC output spells it.
+        assert "method='dlpnoccsd(t)f122023',basis='ccpvtzf12',software='orca'" in normalized
+        # The OTHER spelling -- what an ARC that had not settled a scale factor wrote, vendored
+        # verbatim in this repository -- must be accepted too: it is the same pair of levels, and
+        # refusing it would refuse reuse from every capture written on that side of the change.
+        assert _arc_model_chemistry_text('dlpno-ccsd(t)-f12/cc-pvtz-f12', 'wb97xd/def2tzvp') \
+            in _normalized_model_chemistries('dlpno-ccsd(t)-f12/cc-pvtz-f12', 'wb97xd/def2tzvp')
+
+    def test_arcs_own_year_suffixed_spelling_resolves_to_the_same_level(self):
         """'wb97xd2023/def2tzvp' is ARC's OWN normalized form -- exactly what a user copying a
-        level out of a prior capture manifest would write. ARC has no tabulated frequency scale
-        factor for the year-suffixed spelling, so get_arkane_model_chemistry raises 'freq_level
-        required when freq_scale_factor isn't provided'; this function must convert that raise
-        into its documented None answer rather than letting it kill the run."""
+        level out of a prior capture manifest writes back into their config. It has no tabulated
+        frequency scale factor under that spelling, which used to make it unresolvable; it must
+        normalize to the very level it was copied from."""
+        assert _normalized_model_chemistry('wb97xd2023/def2tzvp') \
+            == _normalized_model_chemistry('wb97xd/def2tzvp')
+
+    def test_a_level_arc_cannot_resolve_at_all_returns_none_not_raise(self, caplog):
+        """The documented degradation: a level with no AEC entry anywhere yields None with a
+        warning, so adopt_prior_qm reports 'nothing will be adopted' rather than the run dying
+        before round 0."""
         with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_qm'):
-            assert _normalized_model_chemistry('wb97xd2023/def2tzvp') is None
-        assert 'could not normalize' in caplog.text
+            assert _normalized_model_chemistry('notamethod/notabasis') is None
 
     def test_adopt_prior_qm_survives_an_unresolvable_level(self, tmp_path, caplog):
         """End to end through adopt_prior_qm: an unresolvable requested level must degrade to
         'nothing adopted' with a warning, never to a crash before round 0."""
         _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
         with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_qm'):
-            adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd2023/def2tzvp',
+            adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'notamethod/notabasis',
                                      _FIXTURE_CHANNEL_KEYS)
         assert adopted == {}
         assert 'nothing will be adopted' in caplog.text
+
+    def test_adopt_prior_qm_reuses_a_composite_level_capture(self, tmp_path):
+        """The end-to-end shape of the dead-reuse defect: a prior capture made under a composite
+        sp/freq pair must actually be adopted when this run asks for the same pair."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='dlpno-ccsd(t)-f12/cc-pvtz-f12',
+                                freq_level='wb97xd/def2tzvp')
+        adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'dlpno-ccsd(t)-f12/cc-pvtz-f12',
+                                 _FIXTURE_CHANNEL_KEYS, freq_level='wb97xd/def2tzvp')
+        assert 'TS1' in adopted
+
+    def test_a_composite_capture_is_refused_without_the_frequency_level(self, tmp_path):
+        """The negative half, and the reason freq_level had to be threaded through the API at all:
+        a caller that does not supply it cannot reconstruct the spelling ARC wrote, so the same
+        capture is refused. This is what the fix moves -- not a match that was loosened."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='dlpno-ccsd(t)-f12/cc-pvtz-f12',
+                                freq_level='wb97xd/def2tzvp')
+        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'dlpno-ccsd(t)-f12/cc-pvtz-f12',
+                              _FIXTURE_CHANNEL_KEYS) == {}
 
 
 class TestAdoptPriorQMRefusesRecordsWithoutStructuralEvidence(object):

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -1,0 +1,46 @@
+"""Tests for t3.pdep.pes_qm."""
+
+from t3.pdep.pes_qm import build_arc_input
+from t3.pdep.pes_rounds import QMCandidate, round_paths
+from t3.schema import PESLoopConfig
+
+
+def _config(**qm) -> PESLoopConfig:
+    return PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']}, **({'qm': qm} if qm else {}))
+
+
+class TestBuildARCInput(object):
+
+    def test_levels_reach_arc_undashed(self):
+        arc_input = build_arc_input((), round_paths('/proj', 0), _config(), 'network1_1')
+        assert arc_input['opt_level'] == 'wb97xd/def2tzvp'
+        assert '-' not in arc_input['opt_level'].split('/')[1]
+
+    def test_rotors_and_irc_off_by_default(self):
+        arc_input = build_arc_input((), round_paths('/proj', 0), _config(), 'network1_1')
+        assert arc_input['job_types']['rotors'] is False
+        assert arc_input['job_types']['irc'] is False
+
+    def test_rotors_and_irc_can_be_turned_on(self):
+        arc_input = build_arc_input((), round_paths('/proj', 0),
+                                    _config(rotors=True, irc=True), 'network1_1')
+        assert arc_input['job_types']['rotors'] is True
+        assert arc_input['job_types']['irc'] is True
+
+    def test_ts_adapters_are_passed_through(self):
+        arc_input = build_arc_input((), round_paths('/proj', 0),
+                                    _config(ts_adapters=['linear', 'rits']), 'network1_1')
+        assert arc_input['ts_adapters'] == ['linear', 'rits']
+
+    def test_project_directory_is_the_rounds_own_arc_project(self):
+        paths = round_paths('/proj', 2)
+        arc_input = build_arc_input((), paths, _config(), 'network1_1')
+        assert arc_input['project_directory'] == paths.arc_project
+
+    def test_ts_labels_are_namespaced_not_network_local(self):
+        """A network-local 'TS1' collides across networks; join.arc_ts_label namespaces it so a
+        network can never be joined to another network's quantum chemistry."""
+        candidate = QMCandidate(path_reaction=None, ts_label='TS1', family='1,2_Insertion_CO')
+        arc_input = build_arc_input((candidate,), round_paths('/proj', 0), _config(), 'network1_1')
+        assert arc_input['reactions'][0]['ts_label'] != 'TS1'
+        assert 'TS1' in arc_input['reactions'][0]['ts_label']

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -7,13 +7,14 @@ from arc.reaction.reaction import ARCReaction
 from arc.species.species import ARCSpecies
 
 import t3.pdep.pes_qm as pes_qm
-from t3.pdep.capture import CaptureResult
+from t3.pdep.capture import CaptureResult, capture_ts_artifacts
 from t3.pdep.discovery import ARTIFACT_STATUS_UNVERIFIED, ARTIFACT_STATUS_USABLE, TSArtifactRecord
+from t3.pdep.hashing import hash_file
 from t3.pdep.hybrid import HybridNetworkResult
-from t3.pdep.join import JOIN_STATUS_QUEUED, arc_ts_label
+from t3.pdep.join import JOIN_STATUS_QUEUED, TSJoinRecord, arc_ts_label, expected_ts_artifact_path
 from t3.pdep.parser import PDepPathReaction
 from t3.pdep.pes_loop import hybrid_network_path
-from t3.pdep.pes_qm import ARC_INPUT_FILE_NAME, arc_qm_runner, build_arc_input
+from t3.pdep.pes_qm import ARC_INPUT_FILE_NAME, adopt_prior_qm, arc_qm_runner, build_arc_input
 from t3.pdep.pes_rounds import QMCandidate, round_paths
 from t3.schema import PESLoopConfig
 
@@ -491,3 +492,84 @@ class TestArcQmRunner(object):
         converged, queued = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID)
         assert converged == frozenset({'TS1'})
         assert queued == frozenset({'TS1'})
+
+
+def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
+                            network_id='network1_1') -> None:
+    """Build a real capture manifest under ``tmp_path`` by calling ``capture_ts_artifacts`` itself
+    (mirrors ``tests/test_pdep/test_capture.py``'s own fixture-building style), so
+    ``adopt_prior_qm`` is exercised against the exact format ``t3.pdep.capture`` writes rather than
+    a hand-rolled shape. The manifest ends up at ``tmp_path/capture/capture_manifest.yml``, nested
+    the same way a real T3 project's ``PDep_capture`` directory is nested under an iteration
+    subdirectory -- ``adopt_prior_qm`` must find it by walking ``tmp_path``, not by assuming a
+    fixed relative path.
+    """
+    arc_dir = str(tmp_path / 'arc_project')
+    os.makedirs(arc_dir, exist_ok=True)
+    arc_label = arc_ts_label(network_id, ts_label)
+    expected_path = expected_ts_artifact_path(arc_dir, arc_label)
+    record = TSJoinRecord(network_id=network_id, network_ts_label=ts_label, status=JOIN_STATUS_QUEUED,
+                          arc_ts_label=arc_label, expected_artifact_path=expected_path,
+                          reason='Queued to ARC.', coefficient=0.05, delta_ln_k=0.02)
+
+    os.makedirs(os.path.dirname(expected_path), exist_ok=True)
+    log_path = os.path.join(os.path.dirname(expected_path), 'output.out')
+    with open(log_path, 'w') as f:
+        f.write('stub quantum chemistry log\n')
+    with open(expected_path, 'w') as f:
+        f.write("linear = False\n\nspinMultiplicity = 2\n\nenergy = Log('output.out')\n\n"
+                "geometry = Log('output.out')\n\nfrequencies = Log('output.out')\n")
+
+    output_dir = os.path.join(arc_dir, 'output')
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, 'status.yml'), 'a') as f:
+        f.write(f"{arc_label}:\n  convergence: true\n  job_types: {{}}\n  paths: {{}}\n  info: ''\n"
+                "  errors: ''\n")
+    with open(os.path.join(output_dir, 'output.yml'), 'w') as f:
+        f.write('{}\n')
+
+    statmech_dir = os.path.join(arc_dir, 'calcs', 'statmech', 'kinetics')
+    os.makedirs(statmech_dir, exist_ok=True)
+    with open(os.path.join(statmech_dir, 'input.py'), 'w') as f:
+        f.write(f"modelChemistry = '{level}'\n\nuseHinderedRotors = True\n\nuseAtomCorrections = True\n\n"
+                "atomEnergies = {'C': -37.844411, 'H': -0.499818, 'N': -54.581501, 'O': -75.062219}\n\n"
+                "useBondCorrections = False\n")
+
+    networks_dir = str(tmp_path / 'networks')
+    os.makedirs(networks_dir, exist_ok=True)
+    source_path = os.path.join(networks_dir, f'{network_id}.py')
+    with open(source_path, 'w') as f:
+        f.write(f"# stub RMG network file\nnetwork(label='{network_id}')\n")
+    networks = {network_id: {'source_path': source_path, 'source_sha256': hash_file(source_path),
+                             'method': 'MSC'}}
+
+    capture_dir = str(tmp_path / 'capture')
+    capture_ts_artifacts([record], arc_dir, capture_dir, networks=networks,
+                         sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)})
+
+
+class TestAdoptPriorQM(object):
+
+    def test_no_projects_adopts_nothing(self):
+        assert adopt_prior_qm([], 'network1_1', 'wb97xd/def2tzvp') == {}
+
+    def test_a_missing_project_is_skipped_not_fatal(self, tmp_path):
+        """A stale path in a config must not kill a run that would otherwise work."""
+        assert adopt_prior_qm([str(tmp_path / 'gone')], 'network1_1', 'wb97xd/def2tzvp') == {}
+
+    def test_matching_level_of_theory_is_adopted(self, tmp_path):
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
+        adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp')
+        assert 'TS1' in adopted
+
+    def test_mismatched_level_of_theory_is_refused(self, tmp_path):
+        """Mixing levels inside one barrier makes the rate inconsistent, so a non-matching prior
+        result is not adopted even though it exists and converged."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2svp')
+        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp') == {}
+
+    def test_a_different_network_is_not_adopted(self, tmp_path):
+        """Labels are namespace-local: another network's TS1 is not this network's TS1."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
+                                network_id='network9_9')
+        assert adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp') == {}

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -205,6 +205,38 @@ _FROZEN_ENERGY_SETTINGS = {
 }
 
 
+def _write_prior_adopted_artifact(tmp_path, ts_label: str, subdir: str = 'prior_capture') -> str:
+    """
+    Write an adopted artifact where a real one lives: ``<capture_dir>/qm/<label>.py``, with the
+    log file its ``Log(...)`` argument references beside it.
+
+    The layout is not cosmetic. ``arc_qm_runner`` derives the artifact's originating capture
+    directory as two levels up from the artifact path -- that is a documented layout invariant of
+    ``t3.pdep.capture`` -- both to confine the vendoring and to read the energy settings the
+    artifact was computed under.
+
+    Returns:
+        str: The artifact path.
+    """
+    qm_dir = os.path.join(str(tmp_path), subdir, 'qm')
+    os.makedirs(qm_dir, exist_ok=True)
+    artifact_path = os.path.join(qm_dir, f'{ts_label}.py')
+    with open(artifact_path, 'w') as f:
+        f.write("geometry = Log('output.out')\n")
+    with open(os.path.join(qm_dir, 'output.out'), 'w') as f:
+        f.write('# stub ARC log output\n')
+    return artifact_path
+
+
+def _prior_verify_result(capture_dir: str, energy_settings: dict) -> VerifyResult:
+    """A verified prior capture carrying exactly ``energy_settings`` -- what ``verify_capture``
+    returns for the capture an adopted artifact came out of."""
+    return VerifyResult(capture_dir=capture_dir,
+                        manifest_path=os.path.join(capture_dir, CAPTURE_MANIFEST_FILE_NAME),
+                        record_count=1, captured_artifact_count=1, networks=dict(),
+                        energy_settings=energy_settings, ts_records=())
+
+
 class _FakeARC(object):
     """Records every construction's kwargs and every .execute()/.as_dict() call, class-wide."""
 
@@ -555,13 +587,14 @@ class TestArcQmRunner(object):
         # its OWN directory (SPs/), the same way a real captured artifact's is (see
         # t3.pdep.hybrid.write_hybrid_network_input_file's docstring) -- so the referenced log file
         # actually has to exist next to it for a real (non-mocked) vendoring pass to succeed.
-        prior_artifact_dir = str(tmp_path / 'prior_project' / 'output' / 'SPs')
-        os.makedirs(prior_artifact_dir)
-        prior_artifact_path = os.path.join(prior_artifact_dir, 'TS1.py')
-        with open(prior_artifact_path, 'w') as f:
-            f.write("geometry = Log('output.out')\n")
-        with open(os.path.join(prior_artifact_dir, 'output.out'), 'w') as f:
-            f.write('# stub ARC log output\n')
+        #
+        # The adopted artifact is placed at <prior capture>/qm/TS1.py, exactly where
+        # capture_ts_artifacts puts one, because arc_qm_runner now reads the prior capture's own
+        # manifest for the settings it was computed under (C4) and derives that capture directory
+        # as two levels up from the artifact.
+        prior_artifact_path = _write_prior_adopted_artifact(tmp_path, 'TS1')
+        monkeypatch.setattr('t3.pdep.pes_qm.verify_capture',
+                            lambda root: _prior_verify_result(root, _FROZEN_ENERGY_SETTINGS))
 
         converged, queued = arc_qm_runner(candidates, paths, _config(), _NETWORK_ID,
                                           adopted={'TS1': prior_artifact_path})
@@ -583,6 +616,81 @@ class TestArcQmRunner(object):
         vendored_log_path = os.path.join(capture_dir, 'adopted', 'logs', 'TS1', 'output.out')
         assert os.path.isfile(vendored_log_path)
         assert call['qm_artifacts_root'] == capture_dir
+
+    def test_adopted_settings_are_consulted_even_when_this_round_captured_new_qm(self, tmp_path,
+                                                                                  monkeypatch):
+        """C4: a hybrid network carries ONE energy_settings header, and Arkane applies it to every
+        artifact the file references -- adopted ones included. When a round both captures new QM
+        and folds in adopted artifacts, letting this round's capture settings win unexamined
+        renders the adopted barriers against an energy reference they were never computed under.
+        The adopted settings must therefore be loaded every time, not only as a fallback for a
+        round that captured nothing."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _usable_capture_result(None, capture_dir, network_path=''))
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1', 'TS2'),
+            ilt_ts_labels=(), vendored_files=(), warnings=())
+        prior_artifact_path = _write_prior_adopted_artifact(tmp_path, 'TS2')
+        verified = []
+
+        def _fake_verify_capture(root):
+            verified.append(root)
+            return _prior_verify_result(root, _FROZEN_ENERGY_SETTINGS)
+
+        monkeypatch.setattr('t3.pdep.pes_qm.verify_capture', _fake_verify_capture)
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID,
+                      adopted={'TS2': prior_artifact_path})
+        assert verified == [os.path.join(str(tmp_path), 'prior_capture')], \
+            "the adopted artifact's own prior capture must be read for its energy settings"
+
+    def test_adopted_settings_that_disagree_on_the_energy_reference_are_refused(self, tmp_path,
+                                                                               monkeypatch):
+        """Fail closed: there is no correct combined header, so a mismatch must refuse the round
+        rather than silently shift the adopted barriers."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _usable_capture_result(None, capture_dir, network_path=''))
+        prior_artifact_path = _write_prior_adopted_artifact(tmp_path, 'TS2')
+        # Same level of theory, DIFFERENT atom energies: an artifact rendered under the wrong one
+        # comes out with a wrong, silently plausible barrier.
+        other_settings = dict(_FROZEN_ENERGY_SETTINGS,
+                              atom_energies={'C': -37.8, 'H': -0.5, 'O': -75.0})
+        monkeypatch.setattr('t3.pdep.pes_qm.verify_capture',
+                            lambda root: _prior_verify_result(root, other_settings))
+        with pytest.raises(ValueError, match='energy reference'):
+            arc_qm_runner(candidates, paths, _config(), _NETWORK_ID,
+                          adopted={'TS2': prior_artifact_path})
+        assert recorder.write_hybrid_calls == [], \
+            'the hybrid must not be written under a settings header the adopted artifacts refuse'
+
+    def test_settings_differing_only_in_provenance_are_not_a_conflict(self, tmp_path, monkeypatch):
+        """Every round has its own ARC project directory by construction, so source_paths ALWAYS
+        differs between this round's capture and any adopted artifact's. Comparing raw dicts would
+        refuse every legitimate adoption while catching no real energy-reference conflict."""
+        capture_dir = os.path.join(str(tmp_path), 'capture')
+        os.makedirs(os.path.join(capture_dir, 'networks'))
+        shutil.copyfile(_FIXTURE_NETWORK_PATH,
+                        os.path.join(capture_dir, 'networks', f'{_NETWORK_ID}.py'))
+        paths, candidates, recorder, network_path = _arc_qm_runner_fixture(
+            tmp_path, monkeypatch, _usable_capture_result(None, capture_dir, network_path=''))
+        recorder.hybrid_result = HybridNetworkResult(
+            dest_path=hybrid_network_path(paths, _NETWORK_ID), qm_ts_labels=('TS1', 'TS2'),
+            ilt_ts_labels=(), vendored_files=(), warnings=())
+        prior_artifact_path = _write_prior_adopted_artifact(tmp_path, 'TS2')
+        prior_settings = dict(_FROZEN_ENERGY_SETTINGS,
+                              source_paths={'input_py': '/round_0/ARC/input.py'})
+        monkeypatch.setattr('t3.pdep.pes_qm.verify_capture',
+                            lambda root: _prior_verify_result(root, prior_settings))
+        arc_qm_runner(candidates, paths, _config(), _NETWORK_ID,
+                      adopted={'TS2': prior_artifact_path})
+        assert len(recorder.write_hybrid_calls) == 1
 
     def test_mutant_adopted_artifact_path_is_not_silently_accepted(self, tmp_path, monkeypatch):
         """Deliverable mutation: substituting an adopted artifact's path with a nonexistent path

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -1,7 +1,10 @@
 """Tests for t3.pdep.pes_qm."""
 
+import logging
 import os
 import shutil
+
+import pytest
 
 from arc.reaction.reaction import ARCReaction
 from arc.species.species import ARCSpecies
@@ -763,3 +766,76 @@ class TestAdoptPriorQM(object):
         adopted = adopt_prior_qm([str(tmp_path / 'proj_a'), str(tmp_path / 'proj_b')],
                                  'network1_1', 'wb97xd/def2tzvp', _TS1_PATH_REACTION_LABELS)
         assert adopted == {}
+
+
+class TestNormalizedModelChemistry(object):
+    """Direct coverage for _normalized_model_chemistry, which previously had none -- and whose
+    raise-instead-of-None defect (a ValueError out of ARC's get_arkane_model_chemistry for a level
+    with no tabulated frequency scale factor) killed the loop before round 0."""
+
+    def test_resolvable_level_returns_arcs_own_literal(self):
+        assert pes_qm._normalized_model_chemistry('wb97xd/def2tzvp') \
+            == _arc_model_chemistry_text('wb97xd/def2tzvp')
+
+    def test_year_suffixed_level_with_no_tabulated_scale_factor_returns_none_not_raise(self, caplog):
+        """'wb97xd2023/def2tzvp' is ARC's OWN normalized form -- exactly what a user copying a
+        level out of a prior capture manifest would write. ARC has no tabulated frequency scale
+        factor for the year-suffixed spelling, so get_arkane_model_chemistry raises 'freq_level
+        required when freq_scale_factor isn't provided'; this function must convert that raise
+        into its documented None answer rather than letting it kill the run."""
+        with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_qm'):
+            assert pes_qm._normalized_model_chemistry('wb97xd2023/def2tzvp') is None
+        assert 'could not normalize' in caplog.text
+
+    def test_adopt_prior_qm_survives_an_unresolvable_level(self, tmp_path, caplog):
+        """End to end through adopt_prior_qm: an unresolvable requested level must degrade to
+        'nothing adopted' with a warning, never to a crash before round 0."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
+        with caplog.at_level(logging.WARNING, logger='t3.pdep.pes_qm'):
+            adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd2023/def2tzvp',
+                                     _TS1_PATH_REACTION_LABELS)
+        assert adopted == {}
+        assert 'nothing will be adopted' in caplog.text
+
+
+class TestAdoptPriorQMRefusesRecordsWithoutStructuralEvidence(object):
+
+    def test_record_with_no_path_reaction_labels_is_refused_with_its_own_reason(self, tmp_path, caplog):
+        """A usable record that carries NO path_reaction_labels cannot be structurally matched at
+        all -- it must be refused with a log line saying exactly that, not fall through the match
+        loop to a misleading 'matches none of this run's candidates' message."""
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp',
+                                path_reaction_labels=())
+        with caplog.at_level(logging.INFO, logger='t3.pdep.pes_qm'):
+            adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
+                                     _TS1_PATH_REACTION_LABELS)
+        assert adopted == {}
+        assert 'records no path_reaction_labels' in caplog.text
+        assert 'match none of' not in caplog.text
+
+
+class TestAdoptedEnergySettings(object):
+    """Direct coverage for _adopted_energy_settings, which previously had none at all -- deleting
+    its whole fallback left the suite green."""
+
+    def test_empty_adopted_returns_none(self):
+        assert pes_qm._adopted_energy_settings(dict()) is None
+
+    def test_settings_come_from_the_adopted_artifacts_own_prior_manifest(self, tmp_path):
+        _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp')
+        adopted = adopt_prior_qm([str(tmp_path)], 'network1_1', 'wb97xd/def2tzvp',
+                                 _TS1_PATH_REACTION_LABELS)
+        settings = pes_qm._adopted_energy_settings(adopted)
+        assert settings['model_chemistry'] == _arc_model_chemistry_text('wb97xd/def2tzvp')
+        assert settings['use_hindered_rotors'] is True
+
+    def test_conflicting_prior_manifests_raise_rather_than_guess(self, tmp_path):
+        _write_capture_manifest(tmp_path / 'proj_a', ts_label='TS1', level='wb97xd/def2tzvp')
+        _write_capture_manifest(tmp_path / 'proj_b', ts_label='TS2', level='b3lyp/def2tzvp',
+                                path_reaction_labels=('reaction2',))
+        adopted_a = adopt_prior_qm([str(tmp_path / 'proj_a')], 'network1_1', 'wb97xd/def2tzvp',
+                                   _TS1_PATH_REACTION_LABELS)
+        adopted_b = adopt_prior_qm([str(tmp_path / 'proj_b')], 'network1_1', 'b3lyp/def2tzvp',
+                                   {'TS2': ('reaction2',)})
+        with pytest.raises(ValueError, match='conflicting'):
+            pes_qm._adopted_energy_settings(adopted_a | adopted_b)

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -897,8 +897,8 @@ class TestArcQmRunnerWithNothingQueued(object):
     the previous behaviour crashed a fully-adopted round 0 out of run_pes_loop -- and go straight
     to vendoring the adopted artifacts and writing the hybrid."""
 
-    def test_all_adopted_round_skips_arc_and_capture_and_still_writes_the_hybrid(self, tmp_path,
-                                                                                 monkeypatch):
+    def test_all_adopted_round_skips_arc_and_capture_and_still_calls_the_hybrid_writer(
+            self, tmp_path, monkeypatch):
         # A REAL prior capture (built by capture_ts_artifacts itself), adopted through the real
         # adopt_prior_qm, so the vendoring below and _adopted_energy_settings both run against the
         # exact artifact and manifest formats production writes -- no hand-rolled shapes.

--- a/tests/test_pdep/test_pes_qm.py
+++ b/tests/test_pdep/test_pes_qm.py
@@ -1,5 +1,6 @@
 """Tests for t3.pdep.pes_qm."""
 
+import glob
 import logging
 import os
 import shutil
@@ -19,8 +20,8 @@ from t3.pdep.parser import PDepPathReaction, parse_pdep_network_file
 from t3.pdep.pes_qm import (ARC_INPUT_FILE_NAME, _adopted_energy_settings,
                             _normalized_model_chemistries, _normalized_model_chemistry,
                             adopt_prior_qm, arc_qm_runner, build_arc_input)
-from t3.pdep.pes_rounds import (QMCandidate, channel_keys_by_ts_label, hybrid_network_path,
-                                round_paths)
+from t3.pdep.pes_rounds import (QMCandidate, adoption_channel_keys_by_ts_label,
+                                hybrid_network_path, round_paths)
 from t3.schema import PESLoopConfig
 
 
@@ -813,10 +814,14 @@ def _write_capture_manifest(tmp_path, ts_label='TS1', level='wb97xd/def2tzvp', f
                          sensitivity_by_ts={record.key: (record.coefficient, record.delta_ln_k)})
 
 
-# THIS run's own structural channel-key map, computed over the same real fixture the prior
-# captures vendor -- what run_pes_loop itself hands adopt_prior_qm (via channel_keys_by_ts_label
-# over the seed network).
-_FIXTURE_CHANNEL_KEYS = channel_keys_by_ts_label(parse_pdep_network_file(path=_FIXTURE_NETWORK_PATH))
+# THIS run's own ADOPTION channel-key map, computed over the same real fixture the prior captures
+# vendor -- what run_pes_loop itself hands adopt_prior_qm. Family-qualified, not endpoints-only:
+# adoption compares two unrelated files, where a different pathway between the same endpoints
+# would key identically. Of network799_1's three path reactions only reaction1 (TS1) names a
+# family, so this map holds TS1 alone -- TS2 and TS3 are refused rather than matched on their
+# endpoints, which is the point.
+_FIXTURE_CHANNEL_KEYS = adoption_channel_keys_by_ts_label(
+    parse_pdep_network_file(path=_FIXTURE_NETWORK_PATH))
 
 
 class TestAdoptPriorQM(object):
@@ -1052,8 +1057,13 @@ class TestAdoptedEnergySettings(object):
         _write_capture_manifest(tmp_path / 'proj_b', ts_label='TS2', level='b3lyp/def2tzvp')
         adopted_a = adopt_prior_qm([str(tmp_path / 'proj_a')], 'network1_1', 'wb97xd/def2tzvp',
                                    _FIXTURE_CHANNEL_KEYS)
-        adopted_b = adopt_prior_qm([str(tmp_path / 'proj_b')], 'network1_1', 'b3lyp/def2tzvp',
-                                   {'TS2': _FIXTURE_CHANNEL_KEYS['TS2']})
+        # proj_b's TS2 is deliberately NOT reached through adopt_prior_qm: reaction2 of the
+        # fixture network names no RMG family, so its channel is identified by its endpoints
+        # alone and adoption now refuses it outright (see adoption_channel_keys_by_ts_label).
+        # _adopted_energy_settings is the unit under test here, and it takes a label -> artifact
+        # map, so proj_b's captured artifact is taken straight off disk.
+        adopted_b = {'TS2': glob.glob(os.path.join(str(tmp_path), 'proj_b', '**', 'qm', '*TS2.py'),
+                                      recursive=True)[0]}
         with pytest.raises(ValueError, match='conflicting'):
             _adopted_energy_settings(adopted_a | adopted_b)
 

--- a/tests/test_pdep/test_pes_rounds.py
+++ b/tests/test_pdep/test_pes_rounds.py
@@ -315,12 +315,35 @@ class TestAdoptionChannelKeysAreNotEndpointsOnly(object):
         assert adoption_channel_keys_by_ts_label(prior)['TS0'] \
             != adoption_channel_keys_by_ts_label(current)['TS0']
 
-    def test_a_channel_naming_no_family_is_refused_not_matched_on_endpoints(self):
+    def test_a_channel_with_no_discriminator_at_all_is_refused(self):
         """A refused match costs quantum chemistry that was already paid for once; a false one
         costs the correctness of the barrier. No discriminator, no adoption."""
-        network = self._network(["Reaction library: 'primaryNitrogenLibrary'"])
+        network = self._network([''])
         assert 'TS0' in channel_keys_by_ts_label(network)
         assert adoption_channel_keys_by_ts_label(network) == {}
+
+    def test_a_library_sourced_channel_falls_back_to_its_kinetics_comment(self):
+        """network21_1's three path reactions all come from a reaction library and name no family
+        at all. Refusing them outright would make reuse dead for a whole class of real network --
+        the comment names the library, which is a pathway identity the endpoints are not."""
+        library = self._network(["Reaction library: 'primaryNitrogenLibrary'"])
+        node = self._network(['Estimated from node Root_N-1R!H->C'])
+        assert 'TS0' in adoption_channel_keys_by_ts_label(library)
+        assert adoption_channel_keys_by_ts_label(library)['TS0'] \
+            != adoption_channel_keys_by_ts_label(node)['TS0']
+
+    def test_the_family_wins_over_the_comment_when_one_is_named(self):
+        """The family is the coarser and more stable of the two -- it survives a degeneracy
+        multiplier or rate-rule retraining that rewords the comment around it, so a family-bearing
+        channel stays adoptable across RMG database versions."""
+        a = self._network(['Estimated using template [x] for rate rule [y]\n'
+                           'Multiplied by reaction path degeneracy 2.0\n'
+                           'family: H_Abstraction'])
+        b = self._network(['Estimated using template [x] for rate rule [y]\n'
+                           'Multiplied by reaction path degeneracy 3.0\n'
+                           'family: H_Abstraction'])
+        assert adoption_channel_keys_by_ts_label(a)['TS0'] \
+            == adoption_channel_keys_by_ts_label(b)['TS0']
 
     def test_the_same_pathway_still_matches_across_files(self):
         """The refusal must not be so broad that reuse can never fire at all."""

--- a/tests/test_pdep/test_pes_rounds.py
+++ b/tests/test_pdep/test_pes_rounds.py
@@ -8,8 +8,7 @@ import pytest
 from arc.molecule.molecule import Molecule
 
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
-from t3.pdep.pes_rounds import (CandidateSplit, PES_LOOP_DIAGRAM_FILENAME, QMCandidate,
-                                SkippedChannel, attach_sensitivity_evidence,
+from t3.pdep.pes_rounds import (CandidateSplit, PES_LOOP_DIAGRAM_FILENAME, attach_sensitivity_evidence,
                                 channel_keys_by_ts_label, round_paths, split_qm_candidates,
                                 structural_channel_key)
 

--- a/tests/test_pdep/test_pes_rounds.py
+++ b/tests/test_pdep/test_pes_rounds.py
@@ -199,7 +199,7 @@ class TestStructuralChannelKeys(object):
         backward = dataclasses.replace(forward, reactants=('B_r1',), products=('A_r1',))
         key_f = structural_channel_key(forward, network.species_structures)
         key_b = structural_channel_key(backward, network.species_structures)
-        assert key_f == key_b == (('C',), ('CC',))
+        assert key_f == key_b == (('CC|m1',), ('C|m1',))
 
     def test_key_is_label_and_atom_order_independent(self):
         """The same molecule written under a different species label and a permuted atom order
@@ -255,3 +255,29 @@ class TestStructuralChannelKeys(object):
         network = dataclasses.replace(
             _network([r1, r2]), species_structures={'A': adj_a, 'B': adj_b, 'C': adj_c})
         assert channel_keys_by_ts_label(network) == {}
+
+    def test_spin_states_do_not_collapse_onto_one_key(self):
+        """BLOCKING regression pin: SMILES does not encode spin state -- singlet and triplet CH2
+        both render '[CH2]' -- so without the explicit multiplicity suffix a prior
+        CH2(S) + CO <=> CH2CO barrier would be adopted onto the CH2(T) channel: a FALSE structural
+        match, i.e. exactly the wrong-saddle-point misattribution structural keying exists to
+        prevent."""
+        ch2_triplet = ('multiplicity 2\n'
+                       '1 C u2 p0 c0 {2,S} {3,S}\n'
+                       '2 H u0 p0 c0 {1,S}\n'
+                       '3 H u0 p0 c0 {1,S}\n').replace('multiplicity 2', 'multiplicity 3')
+        ch2_singlet = ('1 C u0 p1 c0 {2,S} {3,S}\n'
+                       '2 H u0 p0 c0 {1,S}\n'
+                       '3 H u0 p0 c0 {1,S}\n')
+        co = Molecule().from_smiles('[C-]#[O+]').to_adjacency_list()
+        ch2co = Molecule().from_smiles('C=C=O').to_adjacency_list()
+        rxn_triplet = dataclasses.replace(_rxn('t', 'family: x'), reactants=('CH2(T)', 'CO'),
+                                          products=('CH2CO',))
+        rxn_singlet = dataclasses.replace(_rxn('s', 'family: x'), reactants=('CH2(S)', 'CO'),
+                                          products=('CH2CO',))
+        key_triplet = structural_channel_key(
+            rxn_triplet, {'CH2(T)': ch2_triplet, 'CO': co, 'CH2CO': ch2co})
+        key_singlet = structural_channel_key(
+            rxn_singlet, {'CH2(S)': ch2_singlet, 'CO': co, 'CH2CO': ch2co})
+        assert key_triplet is not None and key_singlet is not None
+        assert key_triplet != key_singlet

--- a/tests/test_pdep/test_pes_rounds.py
+++ b/tests/test_pdep/test_pes_rounds.py
@@ -8,7 +8,8 @@ import pytest
 from arc.molecule.molecule import Molecule
 
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
-from t3.pdep.pes_rounds import (CandidateSplit, PES_LOOP_DIAGRAM_FILENAME, attach_sensitivity_evidence,
+from t3.pdep.pes_rounds import (CandidateSplit, PES_LOOP_DIAGRAM_FILENAME,
+                                adoption_channel_keys_by_ts_label, attach_sensitivity_evidence,
                                 channel_keys_by_ts_label, round_paths, split_qm_candidates,
                                 structural_channel_key)
 
@@ -280,3 +281,57 @@ class TestStructuralChannelKeys(object):
             rxn_singlet, {'CH2(S)': ch2_singlet, 'CO': co, 'CH2CO': ch2co})
         assert key_triplet is not None and key_singlet is not None
         assert key_triplet != key_singlet
+
+
+class TestAdoptionChannelKeysAreNotEndpointsOnly(object):
+    """The endpoints-only structural key identifies reactants and products, not a saddle point.
+    channel_keys_by_ts_label's duplicate guard covers two A<=>B pathways sitting in ONE file, but
+    cannot reach across two files: a prior capture holding one A<=>B pathway and this run holding
+    a DIFFERENT one key identically, no duplicate is present anywhere, and the prior artifact is
+    attached to a saddle point it was never computed for."""
+
+    @staticmethod
+    def _network(comments, network_id='network1_1'):
+        adjlists = {'A': Molecule().from_smiles('CC').to_adjacency_list(),
+                    'B': Molecule().from_smiles('C').to_adjacency_list()}
+        path_reactions = tuple(
+            PDepPathReaction(label=f'reaction{i}', reactants=('A',), products=('B',),
+                             transition_state=f'TS{i}', kinetics_type='Arrhenius',
+                             kinetics_comment=comment)
+            for i, comment in enumerate(comments))
+        return PDepNetwork(network_id=network_id, path=f'/abs/{network_id}.py', label=None,
+                           species_labels=('A', 'B'),
+                           transition_state_labels=tuple(f'TS{i}' for i in range(len(comments))),
+                           path_reactions=path_reactions, isomers=(), reactant_channels=(),
+                           product_channels=(), species_structures=adjlists)
+
+    def test_two_different_pathways_between_the_same_endpoints_key_differently(self):
+        """The whole defect in one assertion: endpoints-only, these two are indistinguishable."""
+        prior = self._network(['family: H_Abstraction'])
+        current = self._network(['family: Disproportionation'])
+        assert channel_keys_by_ts_label(prior)['TS0'] == channel_keys_by_ts_label(current)['TS0'], \
+            'the endpoints-only key cannot tell these apart -- that is why it is not what ' \
+            'adoption matches on'
+        assert adoption_channel_keys_by_ts_label(prior)['TS0'] \
+            != adoption_channel_keys_by_ts_label(current)['TS0']
+
+    def test_a_channel_naming_no_family_is_refused_not_matched_on_endpoints(self):
+        """A refused match costs quantum chemistry that was already paid for once; a false one
+        costs the correctness of the barrier. No discriminator, no adoption."""
+        network = self._network(["Reaction library: 'primaryNitrogenLibrary'"])
+        assert 'TS0' in channel_keys_by_ts_label(network)
+        assert adoption_channel_keys_by_ts_label(network) == {}
+
+    def test_the_same_pathway_still_matches_across_files(self):
+        """The refusal must not be so broad that reuse can never fire at all."""
+        prior = self._network(['family: H_Abstraction'], network_id='network9_9')
+        current = self._network(['family: H_Abstraction'])
+        assert adoption_channel_keys_by_ts_label(prior)['TS0'] \
+            == adoption_channel_keys_by_ts_label(current)['TS0']
+
+    def test_a_structurally_unkeyable_channel_is_still_refused(self):
+        """The family is an ADDITIONAL discriminator, never a replacement: a channel with no
+        parseable structure must not become adoptable just because it names a family."""
+        network = self._network(['family: H_Abstraction'])
+        network = dataclasses.replace(network, species_structures={'A': 'not an adjacency list'})
+        assert adoption_channel_keys_by_ts_label(network) == {}

--- a/tests/test_pdep/test_pes_rounds.py
+++ b/tests/test_pdep/test_pes_rounds.py
@@ -1,12 +1,17 @@
 """Tests for t3.pdep.pes_rounds."""
 
+import dataclasses
 import os
+
 import pytest
+
+from arc.molecule.molecule import Molecule
 
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
 from t3.pdep.pes_rounds import (CandidateSplit, PES_LOOP_DIAGRAM_FILENAME, QMCandidate,
-                                SkippedChannel, attach_sensitivity_evidence, round_paths,
-                                split_qm_candidates)
+                                SkippedChannel, attach_sensitivity_evidence,
+                                channel_keys_by_ts_label, round_paths, split_qm_candidates,
+                                structural_channel_key)
 
 
 def _rxn(label: str, comment: str, ts: str | None = None) -> PDepPathReaction:
@@ -176,3 +181,77 @@ class TestAttachSensitivityEvidence(object):
         at_floor = attach_sensitivity_evidence(split, {'TS_r1': (1.2e-7, 1e-3)},
                                                min_delta_ln_k=1e-3)
         assert [c.ts_label for c in at_floor.candidates] == ['TS_r1']
+
+
+class TestStructuralChannelKeys(object):
+    """The identity QM artifacts are carried across network-file writes on. Labels cannot be it:
+    every TS label Arkane writes is purely positional (rmgpy/rmg/pdep.py:854 replaces every path
+    reaction's transition state with a fresh, label-less object before each write), and reaction
+    labels are positional too."""
+
+    def test_keys_are_structural_and_direction_insensitive(self):
+        adj_a = Molecule().from_smiles('C').to_adjacency_list()
+        adj_b = Molecule().from_smiles('CC').to_adjacency_list()
+        network = _network([_rxn('r1', 'family: 1,2_Insertion_CO')])
+        network = dataclasses.replace(network, species_structures={'A_r1': adj_a, 'B_r1': adj_b})
+        forward = _rxn('f', 'family: x')
+        forward = dataclasses.replace(forward, reactants=('A_r1',), products=('B_r1',))
+        backward = dataclasses.replace(forward, reactants=('B_r1',), products=('A_r1',))
+        key_f = structural_channel_key(forward, network.species_structures)
+        key_b = structural_channel_key(backward, network.species_structures)
+        assert key_f == key_b == (('C',), ('CC',))
+
+    def test_key_is_label_and_atom_order_independent(self):
+        """The same molecule written under a different species label and a permuted atom order
+        keys identically -- this is what makes cross-project adoption structural."""
+        co2_a = ('1 O u0 p2 c0 {2,D}\n'
+                 '2 C u0 p0 c0 {1,D} {3,D}\n'
+                 '3 O u0 p2 c0 {2,D}\n')
+        co2_b = ('1 C u0 p0 c0 {2,D} {3,D}\n'
+                 '2 O u0 p2 c0 {1,D}\n'
+                 '3 O u0 p2 c0 {1,D}\n')
+        water = Molecule().from_smiles('O').to_adjacency_list()
+        rxn_a = dataclasses.replace(_rxn('a', 'family: x'), reactants=('CO2(11)',),
+                                    products=('W(1)',))
+        rxn_b = dataclasses.replace(_rxn('b', 'family: x'), reactants=('carbon dioxide(999)',),
+                                    products=('W(2)',))
+        key_a = structural_channel_key(rxn_a, {'CO2(11)': co2_a, 'W(1)': water})
+        key_b = structural_channel_key(rxn_b, {'carbon dioxide(999)': co2_b, 'W(2)': water})
+        assert key_a == key_b
+
+    def test_missing_or_unparseable_structure_yields_no_key(self):
+        rxn = dataclasses.replace(_rxn('r', 'family: x'), reactants=('A',), products=('B',))
+        assert structural_channel_key(rxn, {'A': Molecule().from_smiles('C').to_adjacency_list()}) \
+            is None
+        assert structural_channel_key(
+            rxn, {'A': 'not an adjacency list', 'B': 'nope'}) is None
+
+    def test_duplicate_channels_are_both_omitted_from_the_map(self):
+        """Two TSs connecting structurally identical channels cannot be told apart by this key;
+        carrying either would risk the wrong-saddle-point misattribution, so both are omitted."""
+        adj_a = Molecule().from_smiles('C').to_adjacency_list()
+        adj_b = Molecule().from_smiles('CC').to_adjacency_list()
+        adj_c = Molecule().from_smiles('CCC').to_adjacency_list()
+        r1 = dataclasses.replace(_rxn('r1', 'family: x', ts='TS1'), reactants=('A',),
+                                 products=('B',))
+        r2 = dataclasses.replace(_rxn('r2', 'family: x', ts='TS2'), reactants=('B',),
+                                 products=('A',))
+        r3 = dataclasses.replace(_rxn('r3', 'family: x', ts='TS3'), reactants=('B',),
+                                 products=('C',))
+        network = dataclasses.replace(
+            _network([r1, r2, r3]),
+            species_structures={'A': adj_a, 'B': adj_b, 'C': adj_c})
+        keys = channel_keys_by_ts_label(network)
+        assert set(keys) == {'TS3'}
+
+    def test_a_ts_shared_by_several_path_reactions_is_omitted(self):
+        adj_a = Molecule().from_smiles('C').to_adjacency_list()
+        adj_b = Molecule().from_smiles('CC').to_adjacency_list()
+        adj_c = Molecule().from_smiles('CCC').to_adjacency_list()
+        r1 = dataclasses.replace(_rxn('r1', 'family: x', ts='TS1'), reactants=('A',),
+                                 products=('B',))
+        r2 = dataclasses.replace(_rxn('r2', 'family: x', ts='TS1'), reactants=('B',),
+                                 products=('C',))
+        network = dataclasses.replace(
+            _network([r1, r2]), species_structures={'A': adj_a, 'B': adj_b, 'C': adj_c})
+        assert channel_keys_by_ts_label(network) == {}

--- a/tests/test_pdep/test_pes_rounds.py
+++ b/tests/test_pdep/test_pes_rounds.py
@@ -5,7 +5,8 @@ import pytest
 
 from t3.pdep.parser import PDepNetwork, PDepPathReaction
 from t3.pdep.pes_rounds import (CandidateSplit, PES_LOOP_DIAGRAM_FILENAME, QMCandidate,
-                                SkippedChannel, round_paths, split_qm_candidates)
+                                SkippedChannel, attach_sensitivity_evidence, round_paths,
+                                split_qm_candidates)
 
 
 def _rxn(label: str, comment: str, ts: str | None = None) -> PDepPathReaction:
@@ -110,3 +111,45 @@ class TestRoundLayout(object):
         """An absolute root is what makes the confinement checks downstream meaningful."""
         with pytest.raises(ValueError, match='absolute'):
             round_paths('proj', 0)
+
+
+class TestAttachSensitivityEvidence(object):
+    """attach_sensitivity_evidence is what stands between the loop and a fabricated coefficient:
+    real evidence is stamped, absent evidence removes the candidate (with its reason), and no
+    default ever fills the gap."""
+
+    def test_evidence_is_stamped_onto_candidates_in_order(self):
+        network = _network([_rxn('r1', 'family: 1,2_Insertion_CO'),
+                            _rxn('r2', 'family: 1,3_Insertion_CO2')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset())
+        stamped = attach_sensitivity_evidence(
+            split, {'TS_r1': (-2.0e-5, 0.17), 'TS_r2': (1.0e-6, 0.008)})
+        assert [c.ts_label for c in stamped.candidates] == ['TS_r1', 'TS_r2']
+        assert stamped.candidates[0].coefficient == -2.0e-5
+        assert stamped.candidates[0].delta_ln_k == 0.17
+        assert stamped.candidates[1].coefficient == 1.0e-6
+        assert stamped.skipped == ()
+
+    def test_candidate_without_evidence_is_skipped_with_its_reason_never_defaulted(self):
+        network = _network([_rxn('r1', 'family: 1,2_Insertion_CO'),
+                            _rxn('r2', 'family: 1,3_Insertion_CO2')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset())
+        stamped = attach_sensitivity_evidence(split, {'TS_r2': (1.0e-6, 0.008)})
+        assert [c.ts_label for c in stamped.candidates] == ['TS_r2']
+        assert len(stamped.skipped) == 1
+        assert stamped.skipped[0].label == 'r1'
+        assert 'no finite sensitivity evidence' in stamped.skipped[0].reason
+        assert 'inventing' in stamped.skipped[0].reason
+
+    def test_prior_skips_are_preserved(self):
+        network = _network([_rxn('r1', 'in family R_Recombination.'),
+                            _rxn('r2', 'family: 1,2_Insertion_CO')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset())
+        stamped = attach_sensitivity_evidence(split, {'TS_r2': (1.0e-6, 0.008)})
+        assert {s.label for s in stamped.skipped} == {'r1'}
+        assert [c.ts_label for c in stamped.candidates] == ['TS_r2']
+
+    def test_sa_dir_is_part_of_the_round_layout(self):
+        paths = round_paths('/proj', 1)
+        assert paths.sa == os.path.join('/proj', 'round_1', 'SA')
+        assert paths.sa.startswith(paths.root + os.sep)

--- a/tests/test_pdep/test_pes_rounds.py
+++ b/tests/test_pdep/test_pes_rounds.py
@@ -1,0 +1,112 @@
+"""Tests for t3.pdep.pes_rounds."""
+
+import os
+import pytest
+
+from t3.pdep.parser import PDepNetwork, PDepPathReaction
+from t3.pdep.pes_rounds import (CandidateSplit, PES_LOOP_DIAGRAM_FILENAME, QMCandidate,
+                                SkippedChannel, round_paths, split_qm_candidates)
+
+
+def _rxn(label: str, comment: str, ts: str | None = None) -> PDepPathReaction:
+    return PDepPathReaction(label=label, reactants=('A',), products=('B',),
+                            transition_state=ts if ts is not None else f'TS_{label}',
+                            kinetics_type='Arrhenius', kinetics_comment=comment)
+
+
+def _network(path_reactions) -> PDepNetwork:
+    return PDepNetwork(network_id='network1_1', path='/abs/network1_1.py', label=None,
+                       species_labels=(), transition_state_labels=(),
+                       path_reactions=tuple(path_reactions), isomers=(),
+                       reactant_channels=(), product_channels=())
+
+
+class TestSplitQMCandidates(object):
+
+    def test_barriered_reaction_without_qm_is_a_candidate(self):
+        network = _network([_rxn('r1', 'family: 1,2_Insertion_CO')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset())
+        assert len(split.candidates) == 1
+        assert split.candidates[0].ts_label == 'TS_r1'
+        assert split.candidates[0].family == '1,2_Insertion_CO'
+        assert split.skipped == ()
+
+    def test_barrierless_reaction_is_skipped_with_a_reason(self):
+        """The reason is recorded, never silently dropped."""
+        network = _network([_rxn('r1', 'in family R_Recombination.')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset())
+        assert split.candidates == ()
+        assert len(split.skipped) == 1
+        assert 'R_Recombination' in split.skipped[0].reason
+        assert 'no saddle point' in split.skipped[0].reason
+
+    def test_already_computed_ts_is_not_a_candidate_again(self):
+        """A TS with QM in hand is done; re-queueing it would spend the budget twice."""
+        network = _network([_rxn('r1', 'family: 1,2_Insertion_CO')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset({'TS_r1'}))
+        assert split.candidates == ()
+        assert len(split.skipped) == 1
+        assert 'already has QM' in split.skipped[0].reason
+
+    def test_reaction_without_a_transition_state_is_skipped(self):
+        """A path reaction declaring no TS has nothing to compute."""
+        network = _network([PDepPathReaction(label='r1', reactants=('A',), products=('B',),
+                                             transition_state=None, kinetics_type='Arrhenius',
+                                             kinetics_comment='family: 1,2_Insertion_CO')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset())
+        assert split.candidates == ()
+        assert 'declares no transition state' in split.skipped[0].reason
+
+    def test_mixed_network_splits_correctly(self):
+        network = _network([_rxn('r1', 'family: 1,2_Insertion_CO'),
+                            _rxn('r2', 'in family R_Recombination.'),
+                            _rxn('r3', 'family: 1,3_Insertion_CO2'),
+                            _rxn('r4', 'family: 1,2_Insertion_CO')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset({'TS_r4'}))
+        assert {c.ts_label for c in split.candidates} == {'TS_r1', 'TS_r3'}
+        assert {s.label for s in split.skipped} == {'r2', 'r4'}
+
+    def test_empty_network_yields_empty_split(self):
+        split = split_qm_candidates(_network([]), computed_ts_labels=frozenset())
+        assert split == CandidateSplit(candidates=(), skipped=())
+
+    def test_candidate_order_is_deterministic(self):
+        """Two runs over the same network must queue in the same order, or the budget admits a
+        different subset each time and results stop being reproducible."""
+        rxns = [_rxn(f'r{i}', 'family: 1,2_Insertion_CO') for i in range(6)]
+        first = split_qm_candidates(_network(rxns), computed_ts_labels=frozenset())
+        second = split_qm_candidates(_network(list(rxns)), computed_ts_labels=frozenset())
+        assert [c.ts_label for c in first.candidates] == [c.ts_label for c in second.candidates]
+
+
+class TestRoundLayout(object):
+    """Each round is fully self-contained on disk."""
+
+    def test_paths_are_under_the_round_root(self):
+        paths = round_paths('/proj', 0)
+        assert paths.root == os.path.join('/proj', 'round_0')
+        for attr in ('arc_project', 'explorer_output', 'capture', 'hybrid'):
+            assert getattr(paths, attr).startswith(paths.root + os.sep)
+
+    def test_each_round_gets_its_own_arc_project(self):
+        """This is what sidesteps capture's single-shot window: ARC wipes calcs/statmech/ on each
+        rate pass, so a second ARC run must not share a project directory with the first."""
+        assert round_paths('/proj', 0).arc_project != round_paths('/proj', 1).arc_project
+
+    def test_capture_is_not_inside_the_arc_project(self):
+        """capture_ts_artifacts refuses a capture_dir that resolves inside the ARC project."""
+        paths = round_paths('/proj', 0)
+        assert not paths.capture.startswith(paths.arc_project + os.sep)
+
+    def test_diagram_sits_at_the_round_root(self):
+        paths = round_paths('/proj', 2)
+        assert paths.diagram == os.path.join('/proj', 'round_2', PES_LOOP_DIAGRAM_FILENAME)
+
+    def test_negative_round_refused(self):
+        with pytest.raises(ValueError, match='non-negative'):
+            round_paths('/proj', -1)
+
+    def test_relative_project_directory_refused(self):
+        """An absolute root is what makes the confinement checks downstream meaningful."""
+        with pytest.raises(ValueError, match='absolute'):
+            round_paths('proj', 0)

--- a/tests/test_pdep/test_pes_rounds.py
+++ b/tests/test_pdep/test_pes_rounds.py
@@ -153,3 +153,26 @@ class TestAttachSensitivityEvidence(object):
         paths = round_paths('/proj', 1)
         assert paths.sa == os.path.join('/proj', 'round_1', 'SA')
         assert paths.sa.startswith(paths.root + os.sep)
+
+    def test_a_measured_response_below_the_floor_is_skipped_with_its_value(self):
+        """A measured zero (or any below-floor response) is real data saying 'not worth the
+        spend' -- the candidate is skipped with the measured value in its reason, never queued
+        and never defaulted past the floor."""
+        network = _network([_rxn('r1', 'family: 1,2_Insertion_CO'),
+                            _rxn('r2', 'family: 1,3_Insertion_CO2')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset())
+        stamped = attach_sensitivity_evidence(
+            split, {'TS_r1': (0.0, 0.0), 'TS_r2': (-2.0e-5, 0.17)}, min_delta_ln_k=1e-3)
+        assert [c.ts_label for c in stamped.candidates] == ['TS_r2']
+        assert len(stamped.skipped) == 1
+        assert stamped.skipped[0].label == 'r1'
+        assert 'below the min_delta_ln_k floor' in stamped.skipped[0].reason
+        assert '0.000e+00' in stamped.skipped[0].reason
+
+    def test_the_floor_defaults_off_and_an_at_floor_response_passes(self):
+        network = _network([_rxn('r1', 'family: 1,2_Insertion_CO')])
+        split = split_qm_candidates(network, computed_ts_labels=frozenset())
+        assert attach_sensitivity_evidence(split, {'TS_r1': (0.0, 0.0)}).candidates
+        at_floor = attach_sensitivity_evidence(split, {'TS_r1': (1.2e-7, 1e-3)},
+                                               min_delta_ln_k=1e-3)
+        assert [c.ts_label for c in at_floor.candidates] == ['TS_r1']

--- a/tests/test_pdep/test_pes_sa.py
+++ b/tests/test_pdep/test_pes_sa.py
@@ -1,0 +1,100 @@
+"""
+Tests for t3.pdep.pes_sa -- the standalone PES loop's own source of real sensitivity evidence.
+
+``test_run_round_me_sensitivity_runs_real_arkane`` runs the REAL Arkane master-equation SA (via
+the real ``write_arkane_network_input_file`` and the real ``run_arkane_job``) on the real
+``network799_1`` fixture -- deliberately no double at any seam, per the rule this branch keeps
+re-learning: mock the thing under test and you test the mock. It costs ~8 s and is the only test
+in the pdep suite that proves the loop's evidence pipeline end to end against Arkane itself.
+"""
+
+import math
+import os
+import shutil
+
+import pytest
+
+from t3.common import TEST_DATA_BASE_PATH
+from t3.pdep import pes_sa
+from t3.pdep.pes_sa import SA_COEFFICIENTS_RELPATH, run_round_me_sensitivity, ts_sensitivity_evidence
+from t3.pdep.selector import E0_PERTURBATION_J_PER_MOL
+from t3.pdep.yaml_safe import read_sa_yaml_file
+from t3.runners.rmg_runner import ArkaneJobResult
+
+_FIXTURE_DIR = os.path.join(TEST_DATA_BASE_PATH, 'pdep_real_networks', 'network799_1')
+_FIXTURE_NETWORK_PATH = os.path.join(_FIXTURE_DIR, 'network799_1.py')
+_FIXTURE_SA_PATH = os.path.join(_FIXTURE_DIR, 'sensitivity', 'sa_coefficients.yml')
+
+
+class TestTsSensitivityEvidence(object):
+
+    def test_real_recorded_sa_output_yields_max_abs_coefficient_per_ts(self):
+        """Against a REAL recorded Arkane SA output. The pinned TS3 value comes from the SECOND
+        direction key of the file (its first-key row is ~1.3e-08), so a mutant that only reads one
+        direction key -- or the first -- fails this test."""
+        evidence = ts_sensitivity_evidence(read_sa_yaml_file(_FIXTURE_SA_PATH))
+        assert set(evidence) == {'TS1', 'TS2', 'TS3'}
+        assert evidence['TS1'][0] == pytest.approx(-9.515582575266414e-05)
+        assert evidence['TS2'][0] == pytest.approx(-8.660634384118037e-05)
+        assert evidence['TS3'][0] == pytest.approx(-8.83268679433372e-05)
+        for coefficient, delta_ln_k in evidence.values():
+            assert delta_ln_k == pytest.approx(abs(coefficient) * E0_PERTURBATION_J_PER_MOL)
+
+    def test_non_dict_payload_is_refused_not_read_as_no_evidence(self):
+        with pytest.raises(ValueError, match='malformed'):
+            ts_sensitivity_evidence(['not', 'a', 'dict'])
+
+    def test_malformed_and_non_finite_pieces_are_skipped_never_guessed(self):
+        sa_dict = {
+            'structures': {'A': 'adjlist'},
+            'A <=> B': {
+                (300.0, 'K', 1.0, 'bar'): {'(TS) TS1': float('nan'),
+                                           '(TS) TS2': 2.0e-5,
+                                           'A': 1.0e-3},
+                (600.0, 'K', 1.0, 'bar'): 'not a dict',
+            },
+            'A <=> C': 'not a dict either',
+        }
+        evidence = ts_sensitivity_evidence(sa_dict)
+        assert evidence == {'TS2': (2.0e-5, pytest.approx(2.0e-5 * E0_PERTURBATION_J_PER_MOL))}
+
+    def test_a_zero_coefficient_is_real_evidence_not_a_missing_row(self):
+        """0.0 is a measured 'no leverage', which is finite, honest evidence -- distinct from a
+        missing or NaN row, which is no evidence at all."""
+        sa_dict = {'A <=> B': {(300.0, 'K', 1.0, 'bar'): {'(TS) TS1': 0.0}}}
+        assert ts_sensitivity_evidence(sa_dict) == {'TS1': (0.0, 0.0)}
+
+
+class TestRunRoundMeSensitivity(object):
+
+    def test_run_round_me_sensitivity_runs_real_arkane(self, tmp_path):
+        """The real pipeline, no double anywhere: real input rendering (sensitivity_conditions
+        injected into a copy of the real network799_1), real Arkane ME SA run, real YAML read,
+        real reduction. Every coefficient must be finite -- these are measured derivatives, and
+        capture_ts_artifacts downstream refuses anything else."""
+        network_path = os.path.join(str(tmp_path), 'network0_full.py')
+        shutil.copyfile(_FIXTURE_NETWORK_PATH, network_path)
+        sa_dir = os.path.join(str(tmp_path), 'SA')
+        evidence = run_round_me_sensitivity(network_path=network_path, sa_dir=sa_dir,
+                                            method='MSC', timeout=600)
+        assert set(evidence) == {'TS1', 'TS2', 'TS3'}
+        for coefficient, delta_ln_k in evidence.values():
+            assert math.isfinite(coefficient) and math.isfinite(delta_ln_k)
+            assert delta_ln_k == pytest.approx(abs(coefficient) * E0_PERTURBATION_J_PER_MOL)
+        # The rendered input really carried the SA directive, and Arkane really (re)wrote the
+        # coefficients artifact run_arkane_job requires.
+        with open(os.path.join(sa_dir, 'input.py')) as f:
+            assert 'sensitivity_conditions' in f.read()
+        assert os.path.isfile(os.path.join(sa_dir, SA_COEFFICIENTS_RELPATH))
+
+    def test_a_failed_arkane_job_raises_with_its_reason(self, tmp_path, monkeypatch):
+        network_path = os.path.join(str(tmp_path), 'network0_full.py')
+        shutil.copyfile(_FIXTURE_NETWORK_PATH, network_path)
+
+        def _fake_run_arkane_job(*, input_file, output_directory, logger, timeout):
+            return ArkaneJobResult(succeeded=False, reason='the solver exploded')
+
+        monkeypatch.setattr(pes_sa, 'run_arkane_job', _fake_run_arkane_job)
+        with pytest.raises(ValueError, match='the solver exploded'):
+            run_round_me_sensitivity(network_path=network_path,
+                                     sa_dir=os.path.join(str(tmp_path), 'SA'), method='MSC')

--- a/tests/test_pes_cli.py
+++ b/tests/test_pes_cli.py
@@ -91,7 +91,12 @@ class TestVerbosity(object):
     @pytest.mark.parametrize('flags, expected_verbose', [([], 20), (['-d'], 10), (['-q'], 30)])
     def test_the_flags_reach_the_logger(self, tmp_path, monkeypatch, flags, expected_verbose):
         input_path = tmp_path / 'input.yml'
-        input_path.write_text(yaml.dump({'pes': {'network': '/abs/n.py', 'source': ['HOCHO']}}))
+        # main() pre-flights the network file's existence, so this has to be a real file on disk
+        # even though the loop that would read it is stubbed out below.
+        network_path = tmp_path / 'n.py'
+        network_path.write_text('# a stand-in network file\n')
+        input_path.write_text(yaml.dump({'pes': {'network': str(network_path),
+                                                 'source': ['HOCHO']}}))
         _RecordingLogger.instances = []
         monkeypatch.setattr(PES, 'Logger', _RecordingLogger)
         # The loop itself is out of scope here -- it is driven for real, end to end, by
@@ -107,3 +112,69 @@ class TestVerbosity(object):
         (logger,) = _RecordingLogger.instances
         assert logger.kwargs['verbose'] == expected_verbose
         assert logger.kwargs['project_directory'] == os.path.abspath(str(tmp_path))
+
+
+class TestShippedExample(object):
+    """The example input is documentation that runs. A shipped input file nobody validates rots
+    silently: the schema moves, the example does not, and the first person to copy it as a
+    starting point pays for it."""
+
+    EXAMPLE_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                'examples', 'pes_loop', 'input.yml')
+
+    def test_the_shipped_example_validates(self):
+        config = read_pes_input(self.EXAMPLE_PATH)
+        assert config.pes.method == 'MSC'
+        assert len(config.pes.source) == 2, 'the example demonstrates a bimolecular entry channel'
+        assert config.qm.scope == 'sensitive'
+        assert config.termination.max_rounds == 5
+
+    def test_the_shipped_example_writes_levels_undashed(self):
+        """A dashed level makes ARC miss the cached frequency scale factor and makes Gaussian
+        reject the route line, so an example that shipped one would be actively harmful. The
+        schema's own validator refuses a dashed level at read time, so a bad example fails at
+        read_pes_input rather than at the assertion below -- these assertions are here to name
+        what the example must keep true, where someone editing it will read the reason."""
+        config = read_pes_input(self.EXAMPLE_PATH)
+        levels = (config.qm.opt_level, config.qm.freq_level, config.qm.sp_level,
+                  config.qm.irc_level, config.qm.scan_level)
+        assert all('-' not in level for level in levels), levels
+        assert config.qm.freq_level == config.qm.opt_level
+        assert config.qm.scan_level == config.qm.freq_level
+        assert config.qm.irc_level == config.qm.opt_level
+
+
+class TestNetworkPreflight(object):
+    """A missing network file must fail at the CLI, naming the resolved path, rather than deep
+    inside t3/pdep/parser.py after a project directory and a log file have been created. The
+    resolved path is the whole point of the message: the commonest cause is a relative path
+    anchored somewhere other than where the user assumed."""
+
+    def test_a_missing_network_file_names_the_resolved_path(self, tmp_path, monkeypatch):
+        input_path = tmp_path / 'input.yml'
+        input_path.write_text(yaml.dump({'pes': {'network': 'no_such_network.py',
+                                                 'source': ['HOCHO']}}))
+        monkeypatch.setattr(sys, 'argv', ['PES.py', str(input_path)])
+
+        with pytest.raises(FileNotFoundError) as exc_info:
+            PES.main()
+
+        assert str(tmp_path / 'no_such_network.py') in str(exc_info.value)
+
+    def test_the_preflight_runs_before_anything_is_created(self, tmp_path, monkeypatch):
+        """It fires before the Logger, so a mistyped path leaves no t3.log and no project
+        directory behind -- and before check_dependencies(), so the message a user sees is about
+        their input file rather than about their environment."""
+        input_path = tmp_path / 'runs' / 'input.yml'
+        input_path.parent.mkdir()
+        input_path.write_text(yaml.dump({'pes': {'network': 'no_such_network.py',
+                                                 'source': ['HOCHO']}}))
+        project_directory = tmp_path / 'elsewhere'
+        monkeypatch.setattr(sys, 'argv',
+                            ['PES.py', str(input_path), '-p', str(project_directory)])
+
+        with pytest.raises(FileNotFoundError):
+            PES.main()
+
+        assert not project_directory.exists()
+        assert not (input_path.parent / 't3.log').exists()

--- a/tests/test_pes_cli.py
+++ b/tests/test_pes_cli.py
@@ -9,6 +9,7 @@ import yaml
 
 import PES
 from PES import exit_code_for, parse_command_line_arguments, read_pes_input
+from t3.pdep.parser import parse_pdep_network_file
 from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_DIAGRAM_ONLY, PES_LOOP_FAILED,
                               PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES, PES_LOOP_STALLED)
 
@@ -138,6 +139,34 @@ class TestShippedExample(object):
         assert len(config.pes.source) == 2, 'the example demonstrates a bimolecular entry channel'
         assert config.qm.scope == 'sensitive'
         assert config.termination.max_rounds == 5
+
+    def test_the_example_names_a_network_file_that_exists(self):
+        """The header of the example says `python PES.py examples/pes_loop/input.yml`. It named
+        network1_full.py, which does not exist anywhere in this repository, so the command in the
+        example's own header failed at the CLI's pre-flight. Validating the schema alone cannot
+        catch that -- pes.network is just a non-empty string to pydantic."""
+        config = read_pes_input(self.EXAMPLE_PATH)
+        network_path = config.pes.network
+        if not os.path.isabs(network_path):
+            # Exactly how PES.main resolves it: against the input file's own directory.
+            network_path = os.path.join(os.path.dirname(self.EXAMPLE_PATH), network_path)
+        assert os.path.isfile(network_path), \
+            f'the example names a network file that does not exist: {network_path}'
+
+    def test_the_examples_source_and_bath_gas_appear_in_its_network(self):
+        """A network file that exists is not enough: Arkane's explorer resolves `source` and the
+        bath gas out of the network's own species dictionary, spelled exactly as that file spells
+        them (RMG labels carry their index). A mismatch fails deep inside an Arkane run, long
+        after the project directory and log file have been created."""
+        config = read_pes_input(self.EXAMPLE_PATH)
+        network_path = config.pes.network
+        if not os.path.isabs(network_path):
+            network_path = os.path.join(os.path.dirname(self.EXAMPLE_PATH), network_path)
+        species_labels = set(parse_pdep_network_file(path=network_path).species_labels)
+        assert set(config.pes.source) <= species_labels, \
+            f'{sorted(set(config.pes.source) - species_labels)} are not species of the network'
+        assert set(config.pes.bath_gas) <= species_labels, \
+            f'{sorted(set(config.pes.bath_gas) - species_labels)} are not species of the network'
 
     def test_the_shipped_example_writes_levels_undashed(self):
         """A dashed level makes ARC miss the cached frequency scale factor and makes Gaussian

--- a/tests/test_pes_cli.py
+++ b/tests/test_pes_cli.py
@@ -1,8 +1,13 @@
 """Tests for the PES.py CLI."""
 
+import os
+import sys
+from types import SimpleNamespace
+
 import pytest
 import yaml
 
+import PES
 from PES import exit_code_for, parse_command_line_arguments, read_pes_input
 from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_DIAGRAM_ONLY, PES_LOOP_FAILED,
                               PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES, PES_LOOP_STALLED)
@@ -37,8 +42,9 @@ class TestParseCommandLineArguments(object):
         assert args.file == 'input.yml'
 
     def test_project_directory_defaults_to_the_inputs_directory(self):
+        # Unset at the argparse level, resolved by main() -- the design the addendum settled on.
         args = parse_command_line_arguments(['/runs/pes/input.yml'])
-        assert args.project_directory in (None, '/runs/pes')
+        assert args.project_directory is None
 
     def test_project_directory_can_be_given_explicitly(self):
         args = parse_command_line_arguments(['/runs/pes/input.yml', '-p', '/scratch/run'])
@@ -59,3 +65,45 @@ class TestExitCodeFor(object):
 
     def test_a_failed_loop_exits_one(self):
         assert exit_code_for(PES_LOOP_FAILED) == 1
+
+
+class _RecordingLogger(object):
+    """Stands in for t3.logger.Logger at exactly the boundary main() constructs it, so the
+    verbosity flags can be checked against what the Logger was actually handed."""
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _RecordingLogger.instances.append(self)
+
+    def log(self, message, level='info'):
+        pass
+
+    def log_footer(self):
+        pass
+
+
+class TestVerbosity(object):
+    """``-d``/``-q`` are only worth anything if the level they map to reaches the Logger main()
+    builds; asserting the mapping in isolation would not notice main() ignoring it."""
+
+    @pytest.mark.parametrize('flags, expected_verbose', [([], 20), (['-d'], 10), (['-q'], 30)])
+    def test_the_flags_reach_the_logger(self, tmp_path, monkeypatch, flags, expected_verbose):
+        input_path = tmp_path / 'input.yml'
+        input_path.write_text(yaml.dump({'pes': {'network': '/abs/n.py', 'source': ['HOCHO']}}))
+        _RecordingLogger.instances = []
+        monkeypatch.setattr(PES, 'Logger', _RecordingLogger)
+        # The loop itself is out of scope here -- it is driven for real, end to end, by
+        # tests/test_pdep/test_pes_loop_integration.py.
+        monkeypatch.setattr(PES, 'run_pes_loop',
+                            lambda *args, **kwargs: SimpleNamespace(
+                                status=PES_LOOP_CONVERGED, reason='', rounds=(),
+                                final_network_path=None, final_diagram_path=None))
+        monkeypatch.setattr(sys, 'argv', ['PES.py', str(input_path)] + flags)
+
+        PES.main()
+
+        (logger,) = _RecordingLogger.instances
+        assert logger.kwargs['verbose'] == expected_verbose
+        assert logger.kwargs['project_directory'] == os.path.abspath(str(tmp_path))

--- a/tests/test_pes_cli.py
+++ b/tests/test_pes_cli.py
@@ -1,0 +1,61 @@
+"""Tests for the PES.py CLI."""
+
+import pytest
+import yaml
+
+from PES import exit_code_for, parse_command_line_arguments, read_pes_input
+from t3.pdep.pes_loop import (PES_LOOP_CONVERGED, PES_LOOP_DIAGRAM_ONLY, PES_LOOP_FAILED,
+                              PES_LOOP_MAX_ROUNDS, PES_LOOP_NO_CANDIDATES, PES_LOOP_STALLED)
+
+
+class TestReadPESInput(object):
+
+    def test_reads_a_valid_input_file(self, tmp_path):
+        path = tmp_path / 'input.yml'
+        path.write_text(yaml.dump({'pes': {'network': '/abs/n.py', 'source': ['HOCHO']}}))
+        config = read_pes_input(str(path))
+        assert config.pes.source == ['HOCHO']
+
+    def test_an_unknown_top_level_key_is_refused(self, tmp_path):
+        """extra='forbid': a typo'd key must fail loudly, not be silently ignored, or a user
+        thinks they configured something they did not."""
+        path = tmp_path / 'input.yml'
+        path.write_text(yaml.dump({'pes': {'network': '/abs/n.py', 'source': ['A']},
+                                   'termnation': {'max_rounds': 2}}))
+        with pytest.raises(Exception):
+            read_pes_input(str(path))
+
+    def test_a_missing_file_raises_a_clear_error(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_pes_input(str(tmp_path / 'nope.yml'))
+
+
+class TestParseCommandLineArguments(object):
+
+    def test_input_file_is_positional(self):
+        args = parse_command_line_arguments(['input.yml'])
+        assert args.file == 'input.yml'
+
+    def test_project_directory_defaults_to_the_inputs_directory(self):
+        args = parse_command_line_arguments(['/runs/pes/input.yml'])
+        assert args.project_directory in (None, '/runs/pes')
+
+    def test_project_directory_can_be_given_explicitly(self):
+        args = parse_command_line_arguments(['/runs/pes/input.yml', '-p', '/scratch/run'])
+        assert args.project_directory == '/scratch/run'
+
+
+class TestExitCodeFor(object):
+    """A stall or a max_rounds stop is a finding to read in the log, not a crash: only an
+    outright failure is worth a non-zero exit code."""
+
+    @pytest.mark.parametrize('status', [PES_LOOP_CONVERGED,
+                                        PES_LOOP_MAX_ROUNDS,
+                                        PES_LOOP_NO_CANDIDATES,
+                                        PES_LOOP_STALLED,
+                                        PES_LOOP_DIAGRAM_ONLY])
+    def test_every_non_failure_status_exits_zero(self, status):
+        assert exit_code_for(status) == 0
+
+    def test_a_failed_loop_exits_one(self):
+        assert exit_code_for(PES_LOOP_FAILED) == 1

--- a/tests/test_pes_cli.py
+++ b/tests/test_pes_cli.py
@@ -17,7 +17,8 @@ class TestReadPESInput(object):
 
     def test_reads_a_valid_input_file(self, tmp_path):
         path = tmp_path / 'input.yml'
-        path.write_text(yaml.dump({'pes': {'network': '/abs/n.py', 'source': ['HOCHO']}}))
+        path.write_text(yaml.dump({'pes': {'network': '/abs/n.py', 'source': ['HOCHO'],
+                                          'bath_gas': {'N2': 1.0}}}))
         config = read_pes_input(str(path))
         assert config.pes.source == ['HOCHO']
 
@@ -25,7 +26,7 @@ class TestReadPESInput(object):
         """extra='forbid': a typo'd key must fail loudly, not be silently ignored, or a user
         thinks they configured something they did not."""
         path = tmp_path / 'input.yml'
-        path.write_text(yaml.dump({'pes': {'network': '/abs/n.py', 'source': ['A']},
+        path.write_text(yaml.dump({'pes': {'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}},
                                    'termnation': {'max_rounds': 2}}))
         with pytest.raises(Exception):
             read_pes_input(str(path))
@@ -96,7 +97,8 @@ class TestVerbosity(object):
         network_path = tmp_path / 'n.py'
         network_path.write_text('# a stand-in network file\n')
         input_path.write_text(yaml.dump({'pes': {'network': str(network_path),
-                                                 'source': ['HOCHO']}}))
+                                                 'source': ['HOCHO'],
+                                                 'bath_gas': {'N2': 1.0}}}))
         _RecordingLogger.instances = []
         monkeypatch.setattr(PES, 'Logger', _RecordingLogger)
         # The loop itself is out of scope here -- it is driven for real, end to end, by
@@ -153,7 +155,8 @@ class TestNetworkPreflight(object):
     def test_a_missing_network_file_names_the_resolved_path(self, tmp_path, monkeypatch):
         input_path = tmp_path / 'input.yml'
         input_path.write_text(yaml.dump({'pes': {'network': 'no_such_network.py',
-                                                 'source': ['HOCHO']}}))
+                                                 'source': ['HOCHO'],
+                                                 'bath_gas': {'N2': 1.0}}}))
         monkeypatch.setattr(sys, 'argv', ['PES.py', str(input_path)])
 
         with pytest.raises(FileNotFoundError) as exc_info:
@@ -168,7 +171,8 @@ class TestNetworkPreflight(object):
         input_path = tmp_path / 'runs' / 'input.yml'
         input_path.parent.mkdir()
         input_path.write_text(yaml.dump({'pes': {'network': 'no_such_network.py',
-                                                 'source': ['HOCHO']}}))
+                                                 'source': ['HOCHO'],
+                                                 'bath_gas': {'N2': 1.0}}}))
         project_directory = tmp_path / 'elsewhere'
         monkeypatch.setattr(sys, 'argv',
                             ['PES.py', str(input_path), '-p', str(project_directory)])

--- a/tests/test_pes_cli.py
+++ b/tests/test_pes_cli.py
@@ -51,6 +51,14 @@ class TestParseCommandLineArguments(object):
         args = parse_command_line_arguments(['/runs/pes/input.yml', '-p', '/scratch/run'])
         assert args.project_directory == '/scratch/run'
 
+    def test_diagram_only_is_off_by_default(self):
+        args = parse_command_line_arguments(['input.yml'])
+        assert args.diagram_only is False
+
+    def test_diagram_only_can_be_asked_for(self):
+        args = parse_command_line_arguments(['input.yml', '--diagram-only'])
+        assert args.diagram_only is True
+
 
 class TestExitCodeFor(object):
     """A stall or a max_rounds stop is a finding to read in the log, not a crash: only an

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,6 +29,7 @@ from t3.schema import (IDTCriterionEnum,
                        QM,
                        InputBase,
                        PESLoopConfig,
+                       PESSection,
                        PESQMSection,
                        )
 
@@ -1242,3 +1243,67 @@ class TestPESQMSectionMinDeltaLnK(object):
         with pytest.raises(ValidationError):
             PESQMSection(min_delta_ln_k=1.0)
         assert PESQMSection(min_delta_ln_k=1e-6).min_delta_ln_k == 1e-6
+
+
+class TestPESSectionsForbidExtras(object):
+    """``extra = "forbid"`` on PESLoopConfig alone only rejects an unknown TOP-LEVEL key --
+    pydantic does not propagate a model's config into the nested models its fields declare. A typo
+    inside a section was silently discarded and the run proceeded on the schema default, so a user
+    who wrote ``qm.max_transition_state_per_round`` (singular) got 10 transition states per round
+    and was never told their setting did nothing."""
+
+    _PES = {'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}}
+
+    def test_the_singular_typo_that_motivated_this_is_refused(self):
+        with pytest.raises(ValidationError, match='max_transition_state_per_round'):
+            PESLoopConfig(pes=self._PES, qm={'max_transition_state_per_round': 3})
+
+    def test_an_unknown_pes_key_is_refused(self):
+        with pytest.raises(ValidationError):
+            PESLoopConfig(pes=dict(self._PES, bath_gass={'N2': 1.0}))
+
+    def test_an_unknown_qm_key_is_refused(self):
+        with pytest.raises(ValidationError):
+            PESLoopConfig(pes=self._PES, qm={'sp_levl': 'wb97xd/def2tzvp'})
+
+    def test_an_unknown_termination_key_is_refused(self):
+        with pytest.raises(ValidationError):
+            PESLoopConfig(pes=self._PES, termination={'max_round': 2})
+
+    def test_an_unknown_reuse_key_is_refused(self):
+        with pytest.raises(ValidationError):
+            PESLoopConfig(pes=self._PES, reuse={'from_t3_project': ['/p']})
+
+    def test_a_valid_config_is_still_accepted(self):
+        """The refusal must not be so broad that a correct input file stops validating."""
+        config = PESLoopConfig(pes=self._PES, qm={'max_transition_states_per_round': 3},
+                               termination={'max_rounds': 2},
+                               reuse={'from_t3_projects': ['/p']})
+        assert config.qm.max_transition_states_per_round == 3
+
+
+class TestPESTimeoutIsStrictAndFinite(object):
+    """PDepExplorerConfig refuses a bool or a non-finite timeout explicitly -- but only from
+    INSIDE run_pes_loop, after the CLI has created the project directory, the log file and
+    round_0/. max_rounds already uses strict=True for exactly this reason."""
+
+    _PES = {'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}}
+
+    def test_true_is_not_a_one_second_budget(self):
+        """bool is a subclass of int: ``timeout: true`` otherwise validates as 1.0, a one-second
+        explorer budget that fails every network, arrived at by a typo."""
+        with pytest.raises(ValidationError):
+            PESSection(**dict(self._PES, timeout=True))
+
+    def test_positive_infinity_is_refused(self):
+        """+inf passes gt=0 and reinstates exactly the unbounded runtime this field bounds."""
+        with pytest.raises(ValidationError):
+            PESSection(**dict(self._PES, timeout=float('inf')))
+
+    def test_nan_is_refused(self):
+        with pytest.raises(ValidationError):
+            PESSection(**dict(self._PES, timeout=float('nan')))
+
+    def test_a_plain_yaml_integer_is_still_accepted(self):
+        """``timeout: 3600`` is what a user actually writes; strictness must not refuse it."""
+        assert PESSection(**dict(self._PES, timeout=3600)).timeout == 3600.0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1211,3 +1211,17 @@ class TestPESLoopConfig(object):
     def test_reuse_defaults_to_empty(self):
         config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']})
         assert config.reuse.from_t3_projects == []
+
+
+class TestPESQMSectionMinDeltaLnK(object):
+    """qm.min_delta_ln_k mirrors t3.sensitivity.pdep_min_delta_ln_k: same default, same bounds."""
+
+    def test_default_matches_t3s_in_run_floor(self):
+        assert PESQMSection().min_delta_ln_k == 1e-3
+
+    def test_bounds_are_exclusive(self):
+        with pytest.raises(ValidationError):
+            PESQMSection(min_delta_ln_k=0.0)
+        with pytest.raises(ValidationError):
+            PESQMSection(min_delta_ln_k=1.0)
+        assert PESQMSection(min_delta_ln_k=1e-6).min_delta_ln_k == 1e-6

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1126,7 +1126,8 @@ class TestPESLoopConfig(object):
 
     def test_minimal_valid_config(self):
         """Only pes.network and pes.source are required; everything else has a default."""
-        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO']})
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO'],
+                                'bath_gas': {'N2': 1.0}})
         assert config.pes.method == 'MSC'
         assert config.qm.opt_level == 'wb97xd/def2tzvp'
         assert config.termination.max_rounds == 5
@@ -1134,82 +1135,101 @@ class TestPESLoopConfig(object):
 
     def test_bimolecular_entry_channel_is_accepted(self):
         """An entry channel A + B, not just an isomer source. Arkane's explorer takes both."""
-        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['HO', 'CHO']})
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['HO', 'CHO'], 'bath_gas': {'N2': 1.0}})
         assert config.pes.source == ['HO', 'CHO']
 
     def test_three_source_species_refused(self):
         """Arkane's explorer accepts a unimolecular or bimolecular source and nothing more, so
         this is refused at validation rather than deep inside Arkane."""
         with pytest.raises(ValidationError, match='1 or 2'):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A', 'B', 'C']})
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A', 'B', 'C'], 'bath_gas': {'N2': 1.0}})
 
     def test_zero_source_species_refused(self):
         with pytest.raises(ValidationError, match='1 or 2'):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': []})
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': [], 'bath_gas': {'N2': 1.0}})
+
+    def test_a_missing_bath_gas_is_refused(self):
+        """There is no bath gas that is right by default. Left optional, a missing one surfaces
+        only when PDepExplorerConfig refuses it -- inside run_pes_loop, after the project
+        directory, the log file and round_0/ have already been created."""
+        with pytest.raises(ValidationError, match='bath_gas'):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']})
+
+    def test_an_empty_bath_gas_is_refused(self):
+        """An empty mapping passes the type check and is exactly as useless as a missing one."""
+        with pytest.raises(ValidationError, match='non-empty'):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {}})
 
     def test_dashed_level_of_theory_refused(self):
         """A dashed level makes ARC miss the cached frequency scale factor and makes Gaussian
         reject the route line. Refuse it here rather than debug it on a cluster."""
         with pytest.raises(ValidationError, match='undashed'):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}},
                           qm={'opt_level': 'wb97x-d/def2-tzvp', 'freq_level': 'wb97x-d/def2-tzvp'})
 
     def test_genuine_dunning_dashes_are_allowed(self):
         """cc-pvtz-f12 keeps its dashes -- only def2 and wb97xd must be hyphen-free."""
-        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}},
                                qm={'sp_level': 'dlpno-ccsd(t)-f12/cc-pvtz-f12'})
         assert config.qm.sp_level == 'dlpno-ccsd(t)-f12/cc-pvtz-f12'
 
     def test_freq_level_must_equal_opt_level(self):
-        """Frequencies must be evaluated at a real minimum of the same surface."""
-        with pytest.raises(ValidationError, match='freq_level'):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
-                          qm={'opt_level': 'wb97xd/def2tzvp', 'freq_level': 'wb97xd/def2svp'})
+        """Frequencies must be evaluated at a real minimum of the same surface.
+
+        ``scan_level`` is moved WITH ``freq_level`` deliberately: left at its default it disagrees
+        with the mutated ``freq_level``, so the SCAN guard fires instead -- and that message
+        contains the substring 'freq_level=', which satisfied a ``match='freq_level'`` even with
+        the freq/opt guard deleted. Hence the exact phrase matched below.
+        """
+        with pytest.raises(ValidationError, match="'freq_level' must equal 'opt_level'"):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}},
+                          qm={'opt_level': 'wb97xd/def2tzvp', 'freq_level': 'wb97xd/def2svp',
+                              'scan_level': 'wb97xd/def2svp'})
 
     def test_scan_level_must_equal_freq_level(self):
         """So rotors project out correctly."""
-        with pytest.raises(ValidationError, match='scan_level'):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+        with pytest.raises(ValidationError, match="'scan_level' must equal 'freq_level'"):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}},
                           qm={'freq_level': 'wb97xd/def2tzvp', 'scan_level': 'wb97xd/def2svp'})
 
     def test_irc_level_must_equal_opt_level(self):
         """#10: irc must be evaluated at the same level as opt -- had zero coverage."""
-        with pytest.raises(ValidationError, match='irc_level'):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+        with pytest.raises(ValidationError, match="'irc_level' must equal 'opt_level'"):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}},
                           qm={'opt_level': 'wb97xd/def2tzvp', 'irc_level': 'wb97xd/def2svp'})
 
     def test_scope_must_be_all_or_sensitive(self):
         with pytest.raises(ValidationError):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']}, qm={'scope': 'some'})
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}}, qm={'scope': 'some'})
 
     def test_scope_all_is_accepted(self):
-        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']}, qm={'scope': 'all'})
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}}, qm={'scope': 'all'})
         assert config.qm.scope == 'all'
 
     def test_max_rounds_must_be_positive(self):
         with pytest.raises(ValidationError):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}},
                           termination={'max_rounds': 0})
 
     def test_max_rounds_rejects_bool(self):
         """bool is a subclass of int, so without strict=True `max_rounds: true` silently means 1."""
         with pytest.raises(ValidationError):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}},
                           termination={'max_rounds': True})
 
     def test_timeout_is_required_to_be_positive(self):
         """Explorer runtime is unbounded; the timeout is load-bearing, not decorative."""
         with pytest.raises(ValidationError):
-            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'timeout': -1})
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}, 'timeout': -1})
 
     def test_rotors_and_irc_default_off(self):
         """Cost knobs, off by default, turned on per campaign."""
-        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']})
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}})
         assert config.qm.rotors is False
         assert config.qm.irc is False
 
     def test_reuse_defaults_to_empty(self):
-        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']})
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'bath_gas': {'N2': 1.0}})
         assert config.reuse.from_t3_projects == []
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -28,6 +28,11 @@ from t3.schema import (IDTCriterionEnum,
                        RMGSpeciesConstraints,
                        QM,
                        InputBase,
+                       PESLoopConfig,
+                       PESSection,
+                       PESQMSection,
+                       PESTerminationSection,
+                       PESReuseSection,
                        )
 
 # define a long quote of length 444 characters to test constraints on string length
@@ -1114,3 +1119,89 @@ def test_qm_schema():
     qm = QM(**qm)
     assert qm.adapter == 'ARC'
     assert qm.species == qm.reactions == list()
+
+
+class TestPESLoopConfig(object):
+    """The standalone PES exploration loop's input schema."""
+
+    def test_minimal_valid_config(self):
+        """Only pes.network and pes.source are required; everything else has a default."""
+        config = PESLoopConfig(pes={'network': '/abs/network1_1.py', 'source': ['HOCHO']})
+        assert config.pes.method == 'MSC'
+        assert config.qm.opt_level == 'wb97xd/def2tzvp'
+        assert config.termination.max_rounds == 5
+        assert config.qm.scope == 'sensitive'
+
+    def test_bimolecular_entry_channel_is_accepted(self):
+        """An entry channel A + B, not just an isomer source. Arkane's explorer takes both."""
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['HO', 'CHO']})
+        assert config.pes.source == ['HO', 'CHO']
+
+    def test_three_source_species_refused(self):
+        """Arkane's explorer accepts a unimolecular or bimolecular source and nothing more, so
+        this is refused at validation rather than deep inside Arkane."""
+        with pytest.raises(ValidationError, match='1 or 2'):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A', 'B', 'C']})
+
+    def test_zero_source_species_refused(self):
+        with pytest.raises(ValidationError, match='1 or 2'):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': []})
+
+    def test_dashed_level_of_theory_refused(self):
+        """A dashed level makes ARC miss the cached frequency scale factor and makes Gaussian
+        reject the route line. Refuse it here rather than debug it on a cluster."""
+        with pytest.raises(ValidationError, match='undashed'):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+                          qm={'opt_level': 'wb97x-d/def2-tzvp', 'freq_level': 'wb97x-d/def2-tzvp'})
+
+    def test_genuine_dunning_dashes_are_allowed(self):
+        """cc-pvtz-f12 keeps its dashes -- only def2 and wb97xd must be hyphen-free."""
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+                               qm={'sp_level': 'dlpno-ccsd(t)-f12/cc-pvtz-f12'})
+        assert config.qm.sp_level == 'dlpno-ccsd(t)-f12/cc-pvtz-f12'
+
+    def test_freq_level_must_equal_opt_level(self):
+        """Frequencies must be evaluated at a real minimum of the same surface."""
+        with pytest.raises(ValidationError, match='freq_level'):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+                          qm={'opt_level': 'wb97xd/def2tzvp', 'freq_level': 'wb97xd/def2svp'})
+
+    def test_scan_level_must_equal_freq_level(self):
+        """So rotors project out correctly."""
+        with pytest.raises(ValidationError, match='scan_level'):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+                          qm={'freq_level': 'wb97xd/def2tzvp', 'scan_level': 'wb97xd/def2svp'})
+
+    def test_scope_must_be_all_or_sensitive(self):
+        with pytest.raises(ValidationError):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']}, qm={'scope': 'some'})
+
+    def test_scope_all_is_accepted(self):
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']}, qm={'scope': 'all'})
+        assert config.qm.scope == 'all'
+
+    def test_max_rounds_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+                          termination={'max_rounds': 0})
+
+    def test_max_rounds_rejects_bool(self):
+        """bool is a subclass of int, so without strict=True `max_rounds: true` silently means 1."""
+        with pytest.raises(ValidationError):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+                          termination={'max_rounds': True})
+
+    def test_timeout_is_required_to_be_positive(self):
+        """Explorer runtime is unbounded; the timeout is load-bearing, not decorative."""
+        with pytest.raises(ValidationError):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A'], 'timeout': -1})
+
+    def test_rotors_and_irc_default_off(self):
+        """Cost knobs, off by default, turned on per campaign."""
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']})
+        assert config.qm.rotors is False
+        assert config.qm.irc is False
+
+    def test_reuse_defaults_to_empty(self):
+        config = PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']})
+        assert config.reuse.from_t3_projects == []

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,10 +29,7 @@ from t3.schema import (IDTCriterionEnum,
                        QM,
                        InputBase,
                        PESLoopConfig,
-                       PESSection,
                        PESQMSection,
-                       PESTerminationSection,
-                       PESReuseSection,
                        )
 
 # define a long quote of length 444 characters to test constraints on string length

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1172,6 +1172,12 @@ class TestPESLoopConfig(object):
             PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
                           qm={'freq_level': 'wb97xd/def2tzvp', 'scan_level': 'wb97xd/def2svp'})
 
+    def test_irc_level_must_equal_opt_level(self):
+        """#10: irc must be evaluated at the same level as opt -- had zero coverage."""
+        with pytest.raises(ValidationError, match='irc_level'):
+            PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']},
+                          qm={'opt_level': 'wb97xd/def2tzvp', 'irc_level': 'wb97xd/def2svp'})
+
     def test_scope_must_be_all_or_sensitive(self):
         with pytest.raises(ValidationError):
             PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['A']}, qm={'scope': 'some'})


### PR DESCRIPTION
## Why

T3 draws its pressure-dependent PES diagram during network *assessment* — before the master-equation sensitivity analysis, and long before anything is queued to ARC. Nothing redraws it afterwards. So every PES diagram T3 emits carries RMG's rate-rule estimates, and a computed barrier structurally cannot reach one. (Recorded as finding F19 of the CHO2/CH2O2 campaign.)

This PR adds the missing half: a **PES exploration loop** that explores, computes, and re-explores, so the diagram at the end carries barriers that were actually calculated.

Each round:

1. runs Arkane's explorer on the network, discovering new isomers and channels from the source;
2. runs a master-equation sensitivity analysis on the explored network (`t3/pdep/pes_sa.py`);
3. sends the transition states the rate coefficients actually depend on to ARC, and captures the resulting statistical-mechanics artifacts;
4. writes a hybrid network carrying those computed barriers, and explores again from it.

It stops when a round finds no new transition state worth computing, when the round budget runs out, or when nothing measurable remains above the sensitivity floor. The diagram is drawn from the **last** round.

The loop is **standalone** — driven by `PES.py`, a sibling to `T3.py`, not wired into T3's iteration. That is deliberate: it can be corroborated against a real surface first, used externally to T3's legacy loop, or invoked directly, and connected into a T3 iteration later once it has earned it.

## What's here

| File | |
|---|---|
| `PES.py` | the CLI |
| `t3/pdep/pes_loop.py` | the round driver and its six terminal statuses |
| `t3/pdep/pes_qm.py` | builds the ARC input, runs it, captures artifacts, adopts prior QM |
| `t3/pdep/pes_rounds.py` | round directory layout and the structural channel identity |
| `t3/pdep/pes_sa.py` | the per-round master-equation sensitivity analysis |
| `t3/pdep/barrierless.py` | classifies channels that have no saddle point |
| `t3/schema.py` | `PESLoopConfig` and its four sections |
| `examples/pes_loop/input.yml` | a documented example, validated by tests |

Additive elsewhere: `capture.py`, `discovery.py` and `parser.py` gain fields and a fix; no existing behaviour changes, and `verify_capture` was never weakened.

## Notes for review

Four things are worth knowing, because each cost a round to find.

**Arkane's TS labels are purely positional.** `rmgpy/rmg/pdep.py:854` replaces every path reaction's `transition_state` with a fresh empty-labelled object sixteen lines before the only `save_input_file` call site, so the preserving guard at `arkane/pdep.py:668` never fires. Every TS label in every network file Arkane writes is an index, not an identity. Carrying QM across rounds by label can therefore attach a computed barrier to the wrong saddle point — so channels are keyed structurally instead, and the integration test's explorer deliberately renumbers TS1↔TS2 between rounds to prove it.

**Canonical SMILES is not spin-state-canonical.** The structural key first used plain canonical SMILES, under which CH2 singlet and CH2 triplet key identically — so the singlet's barrier would have been adopted onto the triplet channel. Keys now carry a `|m<multiplicity>` suffix. Charge and lone-pair differences separate on their own; resonance forms key in a form-dependent way, whose consequence is a *refused* match, which is fail-closed and fine.

**A measured zero is not evidence of importance.** The sensitivity analysis can measure `coefficient = 0.0` for a transition state, which would then be queued and written into the capture manifest under a field documented as "the evidence that justified selecting this transition state". Real measurement, false justification. `qm.min_delta_ln_k` (default 1e-3) mirrors T3's own `pdep_min_delta_ln_k` and applies under both `scope: sensitive` and `scope: all`.

**Barrierless channels are never queued.** R_Recombination has no saddle point; queueing one aborts the whole run.

## Testing

`tests/test_pes_cli.py` + `tests/test_pdep`: **1864 passed**, 0 failed (46m31s). Baseline before this branch was 1635.

The integration tests drive the **real** `run_pes_loop`, the **real** `arc_qm_runner` and the **real** `capture_ts_artifacts`, faking only the two external engines (Arkane's explorer and ARC), and assert on what lands on disk — down to which barrier bytes ended up on which channel after a renumber. That shape is deliberate: this subsystem has previously shipped features that were dead at runtime while their unit tests passed, including one where every test mocked the callee, so at least one test per external seam drives the real thing.

## Base

Stacked on **#184** (`pdep-bathgas-timeout`), not `main`, because it consumes `t3/pdep/diagram.py`, which lives there — #185 has already been merged into that branch. Merge order: #184 → this.

One note from the rebase onto the current #184: that branch dropped the `plot` parameter from `run_arkane_job`, and `t3/pdep/pes_sa.py` was passing it. The rebase applied all 31 commits without a single textual conflict, and the break surfaced only when the tests ran — caught by the one `test_pes_sa.py` test that drives the real `run_arkane_job` rather than a double. Fixed here and squashed into the commit that introduced the module.
