### PR TITLE
ci: cut CI wall-clock ~35x (memoise the pdep fixture, cache the Cython build, event-aware concurrency, killpg on timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# The group is event-aware on purpose: with a ref-only group, the nightly `schedule` run and a
+# push to `main` share a group (both are refs/heads/main) and cancel each other, which is what
+# killed several nightly runs mid-flight (one at 2 h 25 m). cancel-in-progress is kept for what it
+# is actually for -- a superseded push or PR update on the same ref -- and disabled for the
+# scheduled run, which has nothing to supersede.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,44 @@ jobs:
             python=3.11
             --channel-priority strict
 
+      # 8a. Cache key for the compiled RMG-Py Cython extensions.
+      # The build is only valid for the exact RMG-Py source it was built from AND the exact
+      # rmg_env it was built against (the extensions link against that env's Python, numpy and
+      # Cython ABIs), so the key is the RMG-Py commit SHA plus a hash of the resolved package
+      # list of rmg_env (name + version + build string of every package), not just
+      # environment.yml -- environment.yml is not a lock file and can re-solve to a different
+      # numpy while hashing the same.
+      - name: Compute RMG-Py build cache key
+        id: rmg-build-key
+        shell: bash -el {0}
+        run: |
+          rmg_sha="$(git -C RMG-Py rev-parse HEAD)"
+          env_hash="$(micromamba list -n rmg_env | sort | sha256sum | cut -c1-16)"
+          echo "key=rmgpy-build-${{ runner.os }}-${{ runner.arch }}-${rmg_sha}-${env_hash}" >> "$GITHUB_OUTPUT"
+
+      # 8b. Restore the compiled extensions if this exact (source, environment) pair was built
+      # before. There are deliberately no restore-keys: a partial match would serve a build made
+      # from different sources or against a different ABI, which is the stale-cache failure mode
+      # nobody can reproduce locally. A miss just means the build runs, as it does today.
+      - name: Cache RMG-Py Cython build
+        id: rmg-build-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            RMG-Py/**/*.so
+            RMG-Py/build
+          key: ${{ steps.rmg-build-key.outputs.key }}
+
       # 8. Compile RMG-Py (Cython extensions, in rmg_env)
       - name: Compile RMG-Py
         shell: bash -el {0}
         working-directory: RMG-Py
         run: |
-          micromamba run -n rmg_env make
+          if [ "${{ steps.rmg-build-cache.outputs.cache-hit }}" == "true" ]; then
+            echo "Reusing the cached RMG-Py Cython build (${{ steps.rmg-build-key.outputs.key }})."
+          else
+            micromamba run -n rmg_env make
+          fi
           echo "PYTHONPATH=${{ github.workspace }}/RMG-Py" >> $GITHUB_ENV
 
       # 9. Install & Compile ARC (Dependency, into t3_env)

--- a/t3/runners/rmg_runner.py
+++ b/t3/runners/rmg_runner.py
@@ -3,6 +3,7 @@ A "keep alive" runner tool for RMG on a server.
 Should be executed locally on the head node using the t3 environment.
 """
 
+import contextlib
 import datetime
 import logging
 import math
@@ -169,8 +170,65 @@ def rmg_job_converged(project_directory: str) -> tuple[bool, str | None]:
 
 
 _DEFAULT_RMG_TIMEOUT_S = 6 * 3600  # 6 hours
+_KILL_GRACE_PERIOD_S = 10  # seconds to wait after SIGTERM before sending SIGKILL
 
 logger = logging.getLogger(__name__)
+
+
+def _kill_process_group(process: 'subprocess.Popen') -> None:
+    """Kill a process and every descendant it spawned.
+
+    The RMG incore command is a shell pipeline (``bash`` -> ``micromamba run`` -> ``python`` ->
+    ``tee``), so killing only the direct child leaves the actual RMG process orphaned and still
+    running. The child is started with ``start_new_session=True``, which makes it the leader of
+    its own process group, so signalling that group reaches the whole tree.
+
+    Args:
+        process (subprocess.Popen): The process to kill, started with ``start_new_session=True``.
+    """
+    try:
+        pgid = os.getpgid(process.pid)
+    except ProcessLookupError:
+        # The child is already gone. Reap it anyway: without a wait() it stays a zombie until
+        # the Popen object is collected, and there is nothing left to signal.
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=_KILL_GRACE_PERIOD_S)
+        return
+    except PermissionError:
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGTERM)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        # The grace period expiring is the normal path to SIGKILL below, not an error.
+        process.wait(timeout=_KILL_GRACE_PERIOD_S)
+    if _process_group_is_alive(pgid):
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, signal.SIGKILL)
+
+
+def _process_group_is_alive(pgid: int) -> bool:
+    """Whether any process remains in the given process group.
+
+    Signal 0 performs the permission and existence checks without delivering anything. This is
+    checked against the whole *group* rather than against the direct child, because the child is
+    a shell wrapper: it can exit while the RMG process it spawned is still running, which is the
+    orphan this module exists to prevent. Escalating to ``SIGKILL`` unconditionally would instead
+    risk signalling an unrelated group, should the PGID have been recycled in the meantime.
+
+    Args:
+        pgid (int): The process group id to probe.
+
+    Returns:
+        bool: Whether the group still has at least one member.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The group exists but is not ours to signal -- alive, and SIGKILL will fail harmlessly.
+        return True
+    return True
 
 
 def _parse_walltime_to_seconds(walltime: str) -> int:
@@ -221,15 +279,20 @@ else
     echo "Micromamba/Mamba/Conda required" >&2
     exit 1
 fi' '''
+    process = subprocess.Popen(shell_script, shell=True, executable='/bin/bash',
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                               start_new_session=True)
     try:
-        result = subprocess.run(shell_script, shell=True, executable='/bin/bash',
-                                capture_output=True, text=True, timeout=timeout_s)
-        stderr_text = result.stderr or ''
+        _, stderr_text = process.communicate(timeout=timeout_s)
+        stderr_text = stderr_text or ''
     except subprocess.TimeoutExpired:
+        _kill_process_group(process)
+        with contextlib.suppress(Exception):
+            process.communicate(timeout=_KILL_GRACE_PERIOD_S)
         logger.error(f'RMG incore timed out after {timeout_s}s')
         return True
-    if result.returncode != 0:
-        logger.error(f'RMG incore exited with code {result.returncode}')
+    if process.returncode != 0:
+        logger.error(f'RMG incore exited with code {process.returncode}')
         return True
     if 'RMG threw an exception and did not converge.' in stderr_text:
         return True

--- a/tests/test_pdep/_wiring_helpers.py
+++ b/tests/test_pdep/_wiring_helpers.py
@@ -16,7 +16,9 @@ apart and stop actually testing the same thing.
 Not itself a test module (no ``test_*`` functions), so pytest does not collect it directly.
 """
 
+import copy
 import os
+import shutil
 
 from t3.chem import T3Reaction
 from t3.common import TEST_DATA_BASE_PATH
@@ -50,15 +52,41 @@ TS2_COEFFICIENT = 0.05
 TS1_COEFFICIENT = 0.04
 
 
-def build_t3(tmp_path):
+# The parsed model, memoised across ``build_t3()`` calls. Parsing the 1.55 MB chem_annotated.yaml
+# and building its 1461 reactions takes ~30 s and is the single dominant cost of the pdep test
+# suite (~100 calls, ~50 min); the fixture tree is byte-identical on every call, so the parse is
+# done once and each caller is handed a deepcopy (~0.06 s). Keyed on the size and mtime of the
+# two fixture files that determine the result, so editing a fixture invalidates the cache.
+_MODEL_CACHE: dict[tuple, tuple[list, list]] = {}
+
+
+def _fixture_model_stamp() -> tuple:
+    """Identify the fixture files whose content determines the parsed model.
+
+    Returns:
+        tuple: (path, size, mtime) triplets for the Cantera model and the species dictionary.
+    """
+    paths = (os.path.join(FIXTURE_ITERATION_1, 'RMG', 'cantera_from_ck', 'chem_annotated.yaml'),
+             os.path.join(FIXTURE_ITERATION_1, 'RMG', 'chemkin', 'species_dictionary.txt'))
+    return tuple((path, os.path.getsize(path), os.path.getmtime(path)) for path in paths)
+
+
+def build_t3(tmp_path, use_cache: bool = True):
     """Build a real T3 instance against a tmp_path copy of the iteration_1 fixture tree.
 
     Also stages the network4_2/MSC sensitivity sidecar fixture (which lives outside
     pdep_network/, see ``SA_FIXTURE_PATH`` above) into the tmp_path copy, at the exact
     location it would occupy in a real run.
-    """
-    import shutil
 
+    Args:
+        tmp_path: The pytest tmp_path to build the project in.
+        use_cache (bool, optional): Whether to reuse a memoised parse of the Cantera model
+                                    (handing out a deepcopy) instead of re-parsing it. Pass
+                                    ``False`` to exercise the real end-to-end parse.
+
+    Returns:
+        T3: A T3 instance with ``rmg_species`` and ``rmg_reactions`` loaded.
+    """
     project_directory = str(tmp_path)
     shutil.copytree(FIXTURE_ITERATION_1, os.path.join(project_directory, 'iteration_1'))
     msc_sensitivity_dir = os.path.join(project_directory, 'iteration_1', 'PDep_SA', 'network4_2',
@@ -66,7 +94,14 @@ def build_t3(tmp_path):
     os.makedirs(msc_sensitivity_dir, exist_ok=True)
     shutil.copy(SA_FIXTURE_PATH, os.path.join(msc_sensitivity_dir, 'sa_coefficients.yml'))
     t3 = run_minimal(project_directory=project_directory, iteration=1, set_paths=True)
-    t3.rmg_species, t3.rmg_reactions = t3.load_species_and_reactions_from_yaml_file()
+    if not use_cache:
+        t3.rmg_species, t3.rmg_reactions = t3.load_species_and_reactions_from_yaml_file()
+        return t3
+    key = _fixture_model_stamp()
+    if key not in _MODEL_CACHE:
+        _MODEL_CACHE.clear()
+        _MODEL_CACHE[key] = t3.load_species_and_reactions_from_yaml_file()
+    t3.rmg_species, t3.rmg_reactions = copy.deepcopy(_MODEL_CACHE[key])
     return t3
 
 

--- a/tests/test_pdep/test_api.py
+++ b/tests/test_pdep/test_api.py
@@ -127,7 +127,10 @@ def test_select_pdep_network_matches_t3_in_run_decision(tmp_path, monkeypatch):
     run on the same inputs -- not merely with select_from_sa_dict() called directly (that would
     only prove api.py calls the core function, not that it produces the same decision T3's actual
     in-run path produces for a live run, which is the guarantee this module exists to provide)."""
-    t3 = _build_t3(tmp_path)
+    # use_cache=False deliberately: the other ~100 callers of build_t3() share a memoised parse of
+    # chem_annotated.yaml, so this parity test is kept on the real end-to-end parse, ensuring at
+    # least one test still exercises the actual Cantera model loading path.
+    t3 = _build_t3(tmp_path, use_cache=False)
     pdep_rxns_to_explore = _build_pdep_rxns_to_explore(t3)
     sa_dict_value = _build_sa_dict(t3)
     sa_path = _candidate_sa_path(t3, method='CSE')

--- a/tests/test_pdep/test_wiring_helpers.py
+++ b/tests/test_pdep/test_wiring_helpers.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+t3 tests test_pdep test_wiring_helpers module
+
+Guards the memoisation in ``_wiring_helpers.build_t3()``. That helper is called by ~100 tests in
+this directory, each of which used to re-parse the same 1.55 MB chem_annotated.yaml; the parse is
+now done once and every caller is handed a ``deepcopy``. The entire correctness of that trade
+rests on two properties, which are what this module tests:
+
+1. Fidelity -- the cached build is indistinguishable from a real end-to-end parse.
+2. Isolation -- a caller that mutates what it was handed cannot affect the next caller.
+
+Without (2), tests in this directory would start passing or failing for reasons unrelated to what
+they assert, which is far worse than a slow suite.
+"""
+
+from tests.test_pdep._wiring_helpers import (C4ENE_INDEX,
+                                             C4RAD_INDEX,
+                                             H_INDEX,
+                                             build_t3)
+
+
+def _labels(t3):
+    return [species.label for species in t3.rmg_species]
+
+
+def _adjacency_lists(t3):
+    return [species.mol.to_adjacency_list() if species.mol is not None else None
+            for species in t3.rmg_species]
+
+
+def _reaction_signatures(t3):
+    """A cheap structural fingerprint of every reaction.
+
+    ``str(T3Reaction)`` costs ~0.15 s per reaction (~230 s over the 1461 reactions of this
+    fixture), so comparing reactant/product labels and the pressure-dependence flag is used
+    instead of stringifying the whole set.
+    """
+    return [(tuple(species.label for species in reaction.r_species),
+             tuple(species.label for species in reaction.p_species),
+             reaction.is_pressure_dependent)
+            for reaction in t3.rmg_reactions]
+
+
+class TestBuildT3Cache(object):
+    """Test that the memoised build_t3() is faithful to, and isolated from, a real parse."""
+
+    def test_cached_build_matches_a_real_parse(self, tmp_path):
+        """The cached model is identical to one parsed end-to-end from the fixture file."""
+        uncached = build_t3(tmp_path / 'uncached', use_cache=False)
+        cached = build_t3(tmp_path / 'cached', use_cache=True)
+
+        assert len(cached.rmg_species) == len(uncached.rmg_species)
+        assert len(cached.rmg_reactions) == len(uncached.rmg_reactions)
+        assert _labels(cached) == _labels(uncached)
+        assert _adjacency_lists(cached) == _adjacency_lists(uncached)
+        assert _reaction_signatures(cached) == _reaction_signatures(uncached)
+
+    def test_each_caller_gets_distinct_objects(self, tmp_path):
+        """Two builds share no species, reaction, molecule or atom objects."""
+        first = build_t3(tmp_path / 'first')
+        second = build_t3(tmp_path / 'second')
+
+        assert first.rmg_species is not second.rmg_species
+        assert first.rmg_reactions is not second.rmg_reactions
+        for index in (H_INDEX, C4ENE_INDEX, C4RAD_INDEX):
+            assert first.rmg_species[index] is not second.rmg_species[index]
+            assert first.rmg_species[index].mol is not second.rmg_species[index].mol
+            first_atoms = {id(atom) for atom in first.rmg_species[index].mol.atoms}
+            second_atoms = {id(atom) for atom in second.rmg_species[index].mol.atoms}
+            assert not first_atoms & second_atoms
+        assert first.rmg_reactions[0] is not second.rmg_reactions[0]
+
+    def test_object_sharing_within_a_build_is_preserved(self, tmp_path):
+        """A species referenced by a reaction is the same object as the one in rmg_species.
+
+        deepcopy of the (species, reactions) pair in one call preserves the internal aliasing a
+        real parse produces; copying the two lists separately would not, and would silently
+        change what these tests exercise.
+        """
+        t3 = build_t3(tmp_path)
+        by_label = {species.label: species for species in t3.rmg_species}
+        checked = 0
+        for reaction in t3.rmg_reactions:
+            for species in list(reaction.r_species) + list(reaction.p_species):
+                if species.label in by_label:
+                    assert species is by_label[species.label]
+                    checked += 1
+        assert checked, 'no reaction species were matched against the species list'
+
+    def test_mutating_a_species_does_not_leak_to_the_next_caller(self, tmp_path):
+        """Mutating labels, attributes and molecules of one build leaves the next build pristine."""
+        first = build_t3(tmp_path / 'first')
+        original_label = first.rmg_species[H_INDEX].label
+        original_adjacency_list = first.rmg_species[H_INDEX].mol.to_adjacency_list()
+        original_species_count = len(first.rmg_species)
+        original_reaction_count = len(first.rmg_reactions)
+
+        first.rmg_species[H_INDEX].label = 'MUTATED'
+        first.rmg_species[H_INDEX].reasons = ['mutated reason']
+        first.rmg_species[H_INDEX].thermo = 'mutated thermo'
+        first.rmg_species[H_INDEX].mol.atoms[0].element = \
+            first.rmg_species[C4ENE_INDEX].mol.atoms[0].element
+        first.rmg_species.pop()
+        first.rmg_reactions.pop()
+
+        second = build_t3(tmp_path / 'second')
+        assert second.rmg_species[H_INDEX].label == original_label
+        assert second.rmg_species[H_INDEX].reasons != ['mutated reason']
+        assert second.rmg_species[H_INDEX].thermo != 'mutated thermo'
+        assert second.rmg_species[H_INDEX].mol.to_adjacency_list() == original_adjacency_list
+        assert len(second.rmg_species) == original_species_count
+        assert len(second.rmg_reactions) == original_reaction_count
+
+    def test_mutating_a_reaction_does_not_leak_to_the_next_caller(self, tmp_path):
+        """Mutating a reaction of one build leaves the next build's reactions pristine."""
+        first = build_t3(tmp_path / 'first')
+        original_signature = _reaction_signatures(first)[0]
+
+        first.rmg_reactions[0].r_species = []
+        first.rmg_reactions[0].is_pressure_dependent = not first.rmg_reactions[0].is_pressure_dependent
+
+        second = build_t3(tmp_path / 'second')
+        assert _reaction_signatures(second)[0] == original_signature

--- a/tests/test_runners/test_rmg_runner.py
+++ b/tests/test_runners/test_rmg_runner.py
@@ -6,13 +6,20 @@ t3 tests test_rmg_runner module
 """
 
 import os
+import shutil
+import signal
 import subprocess
 import time
 
 import pytest
 
 from t3.common import TEST_DATA_BASE_PATH, EXAMPLES_BASE_PATH
-from t3.runners.rmg_runner import rmg_job_converged, run_arkane_job, write_submit_script
+from t3.runners import rmg_runner
+from t3.runners.rmg_runner import (_kill_process_group,
+                                   rmg_job_converged,
+                                   run_arkane_job,
+                                   run_rmg_incore,
+                                   write_submit_script)
 
 
 class TestWriteSubmitScript(object):
@@ -411,3 +418,144 @@ def teardown_module():
     for file_path in file_paths:
         if os.path.isfile(file_path):
             os.remove(file_path)
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Whether a process with the given PID currently exists.
+
+    Args:
+        pid (int): The PID to check.
+
+    Returns:
+        bool: Whether the process exists.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The process exists but is not signalable by this user. That is alive, not dead --
+        # reporting it dead here would let _wait_for_death() succeed against a running process,
+        # which is the one way these tests could pass while the bug they guard is present.
+        pass
+    return True
+
+
+def _wait_for_death(pid: int, timeout: float = 20.0) -> bool:
+    """Wait for a PID to disappear.
+
+    Args:
+        pid (int): The PID to wait for.
+        timeout (float, optional): Max seconds to wait.
+
+    Returns:
+        bool: Whether the process is gone.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _pid_is_alive(pid):
+            return True
+        time.sleep(0.1)
+    return not _pid_is_alive(pid)
+
+
+def _wait_for_pid_file(pid_file: str, timeout: float = 20.0) -> int:
+    """Wait for a spawned grandchild to write its PID to a file, and return that PID.
+
+    Args:
+        pid_file (str): The path of the file the grandchild writes its PID into.
+        timeout (float, optional): Max seconds to wait.
+
+    Returns:
+        int: The grandchild PID.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.isfile(pid_file):
+            with open(pid_file) as f:
+                content = f.read().strip()
+            if content.isdigit():
+                return int(content)
+        time.sleep(0.05)
+    raise AssertionError(f'The grandchild process never wrote its PID to {pid_file}')
+
+
+# A shell one-liner that backgrounds a long-lived grandchild, records its PID, and then blocks.
+# This mimics the RMG incore command shape (bash -> micromamba run -> python -> tee), where the
+# process that must be killed is not the direct child of the runner.
+_GRANDCHILD_SCRIPT = 'sleep 600 & echo $! > "{pid_file}"; wait'
+
+
+@pytest.mark.skipif(os.name != 'posix' or shutil.which('bash') is None,
+                    reason='needs POSIX process groups, signals and bash')
+class TestKillProcessGroup(object):
+    """Test that a timed-out RMG run is killed rather than orphaned."""
+
+    def test_kill_process_group_kills_the_grandchild(self, tmp_path):
+        """The whole process group dies, not just the direct child.
+
+        Killing only the direct child (the old ``subprocess.run`` behavior) leaves the real RMG
+        process running, which is what showed up in CI logs as
+        ``Terminate orphan process: pid (20994) (python3.14)``.
+        """
+        pid_file = str(tmp_path / 'grandchild.pid')
+        process = subprocess.Popen(_GRANDCHILD_SCRIPT.format(pid_file=pid_file),
+                                   shell=True, executable='/bin/bash', start_new_session=True)
+        try:
+            grandchild_pid = _wait_for_pid_file(pid_file)
+            assert _pid_is_alive(grandchild_pid)
+            _kill_process_group(process)
+            assert _wait_for_death(process.pid), 'the direct child survived'
+            assert _wait_for_death(grandchild_pid), 'the grandchild was orphaned instead of killed'
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+    def test_process_group_is_alive_tracks_the_group_not_the_child(self):
+        """The SIGKILL guard reports a group alive while any member remains, and dead after.
+
+        ``_kill_process_group()`` escalates to SIGKILL only when this returns True, so that it
+        never signals a PGID that has already been recycled. It deliberately probes the whole
+        group rather than the direct child: the child is a shell wrapper and can exit while the
+        process that matters is still running, which is the orphan this module exists to prevent.
+        """
+        process = subprocess.Popen('sleep 600', shell=True, executable='/bin/bash',
+                                   start_new_session=True)
+        pgid = os.getpgid(process.pid)
+        try:
+            assert rmg_runner._process_group_is_alive(pgid)
+        finally:
+            os.killpg(pgid, signal.SIGKILL)
+            process.wait()
+        assert not rmg_runner._process_group_is_alive(pgid), 'an empty group reported alive'
+
+    def test_run_rmg_incore_timeout_kills_the_grandchild(self, tmp_path, monkeypatch):
+        """``run_rmg_incore()``'s timeout path kills the whole process tree it spawned.
+
+        The command is replaced with a stand-in that backgrounds a grandchild, but every
+        ``Popen`` keyword argument the production code passes is preserved, so this exercises the
+        real timeout handling rather than a re-implementation of it.
+        """
+        pid_file = str(tmp_path / 'grandchild.pid')
+        recorded_kwargs, spawned = {}, []
+        real_popen = subprocess.Popen
+
+        def fake_popen(cmd, **kwargs):
+            recorded_kwargs.update(kwargs)
+            process = real_popen(_GRANDCHILD_SCRIPT.format(pid_file=pid_file), **kwargs)
+            spawned.append(process)
+            return process
+
+        monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+        # '00:00:00:02' is a 2 second walltime, so the timeout fires while the grandchild lives.
+        exception_raised = run_rmg_incore(rmg_input_file_path=str(tmp_path / 'input.py'),
+                                          walltime='00:00:00:02')
+        monkeypatch.undo()
+
+        assert exception_raised is True
+        assert recorded_kwargs.get('start_new_session') is True, \
+            'the child must lead its own process group for os.killpg() to reach the whole tree'
+        grandchild_pid = _wait_for_pid_file(pid_file)
+        assert _wait_for_death(spawned[0].pid), 'the direct child survived the timeout'
+        assert _wait_for_death(grandchild_pid), 'the grandchild was orphaned instead of killed'

--- a/tests/test_utils/test_flux.py
+++ b/tests/test_utils/test_flux.py
@@ -218,18 +218,18 @@ def test_generate_top_rop_bar_figs_1():
         assert os.path.isfile(os.path.join(folder_path, 'bar_ROPs', fig))
 
 
-def test_generate_top_rop_bar_figs_2():
-    """Test generating ROP bar figures for formic acid pyrolysis"""
+def test_generate_top_rop_bar_figs_2(hocho_simulation_data):
+    """Test generating ROP bar figures for formic acid pyrolysis.
+
+    Reuses the module-level fixture rather than re-running the same JSR simulation (~300 s in CI):
+    the fixture is the identical simulation over the superset of times, and its t=0.001 profile
+    was verified bit-for-bit equal (T, P, X and every ROP) to one obtained by simulating t=0.001
+    alone.
+    """
     observables = ['HOCHO(1)', 'CO2(9)']
-    times = [0.001]
-    profiles = flux.get_profiles_from_simulation(model_path=os.path.join(TEST_DATA_BASE_PATH, 'models', 'HOCHO.yaml'),
-                                                 reactor_type='JSR',
-                                                 times=times,
-                                                 composition={'HOCHO(1)': 1.0},
-                                                 T=1000,
-                                                 P=1,
-                                                 V=100,
-                                                 )
+    profiles = {time: profile for time, profile in hocho_simulation_data.items()
+                if abs(time - 0.001) < 1e-6}
+    assert profiles, 'the hocho_simulation_data fixture does not contain the t=0.001 point'
     folder_path = os.path.join(SCRATCH_BASE_PATH, 'test_generate_top_rop_bar_figs_HOCHO_pyrolysis')
     flux.generate_top_rop_bar_figs(profiles=profiles, observables=observables, folder_path=folder_path)
     for fig in ['HOCHO(1)_0.001_s.png', 'CO2(9)_0.001_s.png']:


### PR DESCRIPTION
Cuts T3's CI wall-clock by memoising the expensive test fixture, caching the RMG-Py Cython build,
reusing an existing simulation fixture, making the nightly cron's concurrency group event-aware,
and killing the whole process group when a timed-out RMG run is reaped.

The branch predates #184/#186/#188/#189; it has been rebased onto current `main` (`ff49c50`), all
five commits replaying with zero conflicts. Pre-rebase tip preserved at
`refs/backup/ci-speedup-prerebase` (`e6ce16b7`).

## Measured on today's `main`, not inherited

**2889 s → 83 s on the same 265 tests (~35×)** for
`tests/test_pdep/test_main_wiring.py test_main_funnel.py test_api.py`.
`tests/test_utils/test_flux.py`: 1071 s → 836 s, 28 passed both sides.

The saving is larger than the ~3× (2h32m → 50m) this work was originally credited with; that
figure was measured against a base that no longer exists, so it has been re-measured here rather
than carried forward.

## The memoisation does not cost coverage

The central change makes ~102 tests share one `build_t3()` object by `deepcopy`, which raises two
questions. Both were answered empirically.

**Order dependence — none found.** Four explicit `pytest-randomly` seeds, each run and reported
individually:

| seed | result | wall | files |
|---|---|---|---|
| 20260821 | 265 passed, RC=0 | 82 s | 3 |
| 424242 | 298 passed, RC=0 | 1003 s | 5 |
| 7 | 298 passed, RC=0 | 1066 s | 5 |
| 999983 | 298 passed, RC=0 | 1393 s | 5 |

The plugin was verified to actually reorder — `--collect-only` diffed across two seeds gives
different leading tests — since four identical orderings would have looked exactly like four green
passes of an order-independent suite. It was installed to a private `--target` on `PYTHONPATH`
rather than into the shared conda env, where it auto-activates and would have silently randomized
every other session's test runs on the same box.

**Fixture sensitivity — set-identical.** Rotating `rmg_species` by one at every point `build_t3()`
returns, applied on both sides:

```
base   55 failed, 210 passed, 2991 s
head   55 failed, 210 passed,   66 s
common 55 · only-on-base 0 · only-on-head 0   -- SET-IDENTICAL
```

The same tests detect a broken fixture at the same strength, 35× faster. Caveat stated plainly:
base has one return path in `build_t3()`, head has two, and both of head's were mutated — so the
invariant is identical on each side, but from two insertion points against one.

## Full suite

`pytest tests/ -p no:cacheprovider -q` on head: **4 failed, 2612 passed, 1567 s**. All four
reproduce identically on an unmodified `main` worktree and are environmental, not this branch's:
3 × `TestWriteSubmitScript` (`LOCAL_CLUSTER_SOFTWARE` is absent from `arc.settings.settings` on the
test box, so `SUBMIT_FILENAME` is `''` and `open()` receives a directory), and
`test_functional.py::test_computing_thermo` (RMG incore produces no `chem_annotated.yaml`; fails in
27 s on base with the same `CanteraError`).

## One note for review

The rebase was textually clean over 189 changed lines in `rmg_runner.py` — which is where semantic
breakage hides rather than where it announces itself — so `run_rmg_incore` was checked by hand
afterwards: `main`'s changes landed elsewhere in the file and the process-group rewrite sits
intact.
