### PR TITLE
fix(pdep): make the PES loop run end to end from a source-only seed

### DIFF
--- a/examples/pes_loop_cho2/.gitignore
+++ b/examples/pes_loop_cho2/.gitignore
@@ -1,0 +1,5 @@
+# PES.py run outputs (Arkane explorer artifacts, logs, diagrams) are reproducible from the seed
+# and input.yml here; do not track them.
+run/
+run2/
+run*/

--- a/examples/pes_loop_cho2/input.yml
+++ b/examples/pes_loop_cho2/input.yml
@@ -1,0 +1,46 @@
+# SOURCE-ONLY CHO2 PES exploration loop input.
+#
+# This drives the standalone PES loop from a source-only seed -- the [O]C=O well, a bath gas, and
+# no hand-written reactions (network_cho2_source.py). The loop runs Arkane's own explorer to grow
+# the surface, then draws its diagram. Run it as a no-QM smoke test with:
+#
+#     python PES.py examples/pes_loop_cho2/input.yml --diagram-only \
+#         --project-directory examples/pes_loop_cho2/run
+#
+# A UNIMOLECULAR source ([O]C=O) is used on purpose: a bimolecular source makes Arkane discover
+# more than one network, which the adapter refuses (seed from a well instead).
+
+pes:
+  network: network_cho2_source.py
+  source:
+    - '[O]C=O'
+  method: MSC
+  bath_gas:
+    Ar: 1.0
+  explore_tol: 0.01
+  energy_tol: 1.0e+01
+  flux_tol: 1.0e-06
+  maximum_radical_electrons: 2
+  timeout: 7200.0
+
+qm:
+  opt_level: wb97xd/def2tzvp
+  freq_level: wb97xd/def2tzvp
+  sp_level: dlpno-ccsd(t)-f12/cc-pvtz-f12
+  irc_level: wb97xd/def2tzvp
+  scan_level: wb97xd/def2tzvp
+  ts_adapters:
+    - heuristics
+    - linear
+  rotors: false
+  irc: false
+  scope: sensitive
+  max_transition_states_per_round: 10
+  min_delta_ln_k: 1.0e-03
+
+termination:
+  max_rounds: 5
+  stop_when_no_new_ts: true
+
+reuse:
+  from_t3_projects: []

--- a/examples/pes_loop_cho2/network_cho2_source.py
+++ b/examples/pes_loop_cho2/network_cho2_source.py
@@ -1,0 +1,77 @@
+# Minimal SOURCE-ONLY CHO2 seed for the standalone PES exploration loop.
+#
+# This file carries ONLY the source well [O]C=O (formyloxy), the Ar bath gas, one network()
+# block naming the well as the sole isomer, and one pressureDependence() block -- the minimum
+# t3.pdep.explorer.input_file.write_arkane_explorer_input_file needs. There is NO reaction(),
+# NO transitionState(), and NO adduct isomer: Arkane's explorer grows the CHO2 surface from this
+# seed using the RMG database. Requiring reactions here would invert the data flow -- the explorer
+# is what creates them (see t3/pdep/parser.py's require_reactions and t3/pdep/api.py).
+#
+# A UNIMOLECULAR source is deliberate: a bimolecular H + CO2 source makes Arkane's explorer
+# discover TWO disjoint CHO2 networks, which ArkaneExplorerAdapter refuses (there is no single
+# unambiguous result). A single well explores one connected network the loop can resolve and draw.
+#
+# The [O]C=O and Ar statmech blocks are lifted verbatim from a real RMG-explored CHO2 network
+# (examples/pes_loop_cho2/t3_seed_run/network_cho2_clean.py in the I-006/I-007 worktree), so no
+# energy is invented.
+
+species(
+    label = '[O]C=O',
+    structure = adjacencyList("""multiplicity 2
+1 O u1 p2 c0 {3,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+"""),
+    E0 = (-169.935,'kJ/mol'),
+    modes = [
+        HarmonicOscillator(frequencies=([2782.5,750,1395,475,1775,1000],'cm^-1')),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    molecularWeight = (45.0174,'amu'),
+    collisionModel = TransportData(shapeIndex=2, epsilon=(4140.61,'J/mol'), sigma=(3.59,'angstroms'), dipoleMoment=(0,'De'), polarizability=(0,'angstroms^3'), rotrelaxcollnum=2.0, comment="""NOx2018"""),
+    energyTransferModel = SingleExponentialDown(alpha0=(3.5886,'kJ/mol'), T0=(300,'K'), n=0.85),
+    thermo = NASA(polynomials=[NASAPolynomial(coeffs=[3.9649,-0.00518829,3.73952e-05,-4.21919e-08,1.47224e-11,-20431.8,7.33591], Tmin=(100,'K'), Tmax=(994.515,'K')), NASAPolynomial(coeffs=[5.26528,0.00541264,-2.4716e-06,5.38764e-10,-4.28526e-14,-21473.4,-2.86661], Tmin=(994.515,'K'), Tmax=(5000,'K'))], Tmin=(100,'K'), Tmax=(5000,'K'), E0=(-169.935,'kJ/mol'), Cp0=(33.2579,'J/(mol*K)'), CpInf=(83.1447,'J/(mol*K)'), comment="""Thermo group additivity estimation: group(O2s-(Cds-O2d)H) + group(Cds-OdOsH) + radical(OJC=O)"""),
+)
+
+species(
+    label = 'Ar',
+    structure = adjacencyList("""1 Ar u0 p4 c0
+"""),
+    molecularWeight = (39.8775,'amu'),
+    collisionModel = TransportData(shapeIndex=0, epsilon=(1134.93,'J/mol'), sigma=(3.33,'angstroms'), dipoleMoment=(0,'De'), polarizability=(0,'angstroms^3'), rotrelaxcollnum=0.0, comment="""NOx2018"""),
+    energyTransferModel = SingleExponentialDown(alpha0=(3.5886,'kJ/mol'), T0=(300,'K'), n=0.85),
+    thermo = NASA(polynomials=[NASAPolynomial(coeffs=[2.5,0,0,0,0,-745.375,4.37967], Tmin=(200,'K'), Tmax=(1000,'K')), NASAPolynomial(coeffs=[2.5,0,0,0,0,-745.375,4.37967], Tmin=(1000,'K'), Tmax=(6000,'K'))], Tmin=(200,'K'), Tmax=(6000,'K'), E0=(-6.19738,'kJ/mol'), Cp0=(20.7862,'J/(mol*K)'), CpInf=(20.7862,'J/(mol*K)'), label="""Ar""", comment="""Thermo library: primaryThermoLibrary"""),
+)
+
+network(
+    label = 'PDepNetwork CHO2 source',
+    isomers = [
+        '[O]C=O',
+    ],
+    reactants = [
+    ],
+    bathGas = {
+        'Ar': 1.0,
+    },
+)
+
+pressureDependence(
+    label = 'PDepNetwork CHO2 source',
+    Tmin = (700,'K'),
+    Tmax = (3200,'K'),
+    Tcount = 10,
+    Tlist = ([3200,2290.91,1784.07,1460.87,1236.81,1072.34,946.479,847.059,766.54,700],'K'),
+    Pmin = (0.1,'bar'),
+    Pmax = (100,'bar'),
+    Pcount = 10,
+    Plist = ([0.1,0.215443,0.464159,1,2.15443,4.64159,10,21.5443,46.4159,100],'bar'),
+    maximumGrainSize = (2,'kJ/mol'),
+    minimumGrainCount = 250,
+    method = 'modified strong collision',
+    interpolationModel = ('pdeparrhenius',),
+    activeKRotor = True,
+    activeJRotor = True,
+    rmgmode = True,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,8 @@ filterwarnings = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # unused imports in __init__.py are re-exports
 "t3/runners/rmg_incore_sa.py" = ["E701"]  # subprocess script, compact one-liners are fine
+# RMG/Arkane network files are data in Python syntax: `species()`, `network()` and
+# `pressureDependence()` are injected by the parser's exec namespace, never imported, so every
+# call site reads as an undefined name. The copies under tests/data are covered by `exclude`
+# above; these are the ones that ship as runnable examples.
+"examples/**/network_*.py" = ["F821"]

--- a/t3/pdep/api.py
+++ b/t3/pdep/api.py
@@ -421,7 +421,12 @@ def explore_pdep_network(network_path: str,
     # claim, and precisely the one an auditor of an expensive QM run would lean on.
     recorded_admission_policy = admission_policy if selection is not None else ADMISSION_POLICY_UNGATED
 
-    parsed_network = parse_pdep_network_file(path=network_path)
+    # require_reactions=False: this is the network to be EXPLORED. On round 0 it is the seed, which
+    # is legitimately source-only (species + bath gas, no reaction(...) -- the explorer is what
+    # creates the reactions), so refusing a reaction-less file here would invert the data flow and
+    # demand the reactions before the run that produces them. A round-N hybrid network does carry
+    # reactions; passing False there simply does not re-assert what is already true.
+    parsed_network = parse_pdep_network_file(path=network_path, require_reactions=False)
 
     if selection is not None:
         # method, network_id, the hash diagnosis (no-hash vs. hash-mismatch), and the evaluation-

--- a/t3/pdep/explorer/arkane.py
+++ b/t3/pdep/explorer/arkane.py
@@ -25,8 +25,8 @@ from t3.pdep.diagram import T3_PES_DIAGRAM_FILENAME, draw_pes_diagram
 from t3.pdep.explorer.adapter import PESExplorerAdapter
 from t3.pdep.explorer.factory import register_explorer_adapter
 from t3.pdep.explorer.input_file import write_arkane_explorer_input_file
-from t3.pdep.me_success import IGNORABLE_STDERR_PHRASES, check_arkane_me_success
-from t3.pdep.parser import canonical_channel_pair, parse_pdep_network_file
+from t3.pdep.me_success import check_arkane_me_success, real_stderr_lines
+from t3.pdep.parser import canonical_channel_pair, parse_pdep_network_file, strip_rmg_index_suffix
 from t3.runners.rmg_runner import run_arkane_job
 
 if TYPE_CHECKING:
@@ -440,12 +440,9 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
             with open(stderr_path, 'r') as f:
                 stderr_text = f.read()
         if stderr_text:
-            real_stderr_lines = [
-                line.strip() for line in stderr_text.splitlines()
-                if line.strip() and not any(phrase in line for phrase in IGNORABLE_STDERR_PHRASES)
-            ]
-            if real_stderr_lines:
-                reasons.append('Arkane reported stderr output: ' + ' | '.join(real_stderr_lines))
+            real_lines = real_stderr_lines(stderr_text)
+            if real_lines:
+                reasons.append('Arkane reported stderr output: ' + ' | '.join(real_lines))
 
         # Failure signal 3 of 4: a fatal marker in stdout OR Arkane's own log. This is the ONLY
         # signal that catches Arkane's soft-CSE-failure archetype at the process level: exit 0,
@@ -595,12 +592,19 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
                     f"(arkane/pdep.py:741-755); its absence means the file is truncated, or is "
                     f"not a network file at all.",)
 
-        declared = set(network.species_labels)
+        # Compare on the INDEX-STRIPPED base label, never the raw one: RMG names the same species
+        # differently in the two artifacts it writes from one in-memory network -- output.py by base
+        # label ('[O]C=O'), the network file by base + a per-file disambiguation index ('[O]C=O(1)').
+        # A raw-label containment test reports every species as "undeclared" and discards a
+        # genuinely single-run exploration (this is the defect this normalization fixes). Stripping
+        # the index is safe: distinct species have distinct base labels, so it never merges two real
+        # species. See t3.pdep.parser.strip_rmg_index_suffix.
+        declared = {strip_rmg_index_suffix(label) for label in network.species_labels}
         undeclared = set()
         for result in me_success_results:
             for reaction in result.reactions:
-                undeclared.update(set(reaction.reactants) - declared)
-                undeclared.update(set(reaction.products) - declared)
+                undeclared.update({strip_rmg_index_suffix(s) for s in reaction.reactants} - declared)
+                undeclared.update({strip_rmg_index_suffix(s) for s in reaction.products} - declared)
         if undeclared:
             return (f"The output file(s) and the final network file '{file_name}' do not describe "
                     f"the same network: the output names species {sorted(undeclared)} which the "
@@ -641,8 +645,19 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
         # Compared as MULTISETS, so that a repeated pair is reported as a surplus rather than
         # silently collapsing into the expected set: Arkane's duplicate suppression never writes the
         # same pair live twice, so a repeat is evidence in its own right.
-        expected_pairs = Counter(network.expected_net_reaction_channel_pairs())
-        actual_pairs = Counter(canonical_channel_pair(reaction.reactants, reaction.products)
+        # Both sides are keyed on index-stripped base labels, for the same reason the species
+        # containment check above is: the two artifacts label the same channel differently, so a
+        # raw comparison reports every pair as mismatched. Each side is re-canonicalized AFTER
+        # stripping (canonical_channel_pair sorts, and stripping can change sort order), so the two
+        # multisets are built the same shape and only genuine topology differences survive.
+        def _strip_pair(pair):
+            return canonical_channel_pair([strip_rmg_index_suffix(s) for s in pair[0]],
+                                          [strip_rmg_index_suffix(s) for s in pair[1]])
+        expected_pairs = Counter(_strip_pair(pair)
+                                 for pair in network.expected_net_reaction_channel_pairs())
+        actual_pairs = Counter(canonical_channel_pair(
+                                   [strip_rmg_index_suffix(s) for s in reaction.reactants],
+                                   [strip_rmg_index_suffix(s) for s in reaction.products])
                                for reaction in parsed_reactions)
         missing_pairs = sorted((expected_pairs - actual_pairs).elements())
         surplus_pairs = sorted((actual_pairs - expected_pairs).elements())
@@ -695,9 +710,13 @@ class ArkaneExplorerAdapter(PESExplorerAdapter):
             # Detection (network_indices, above) happens regardless -- refusal rides atop
             # resolution, it does not replace it.
             reasons.append(f"Arkane explored {len(network_indices)} distinct networks "
-                           f"(indices {network_indices}) from seed {self.seed_species}; "
-                           f"multi-network exploration is refused in this increment, since there is "
-                           f"no single unambiguous result to resolve.")
+                           f"(indices {network_indices}) from seed {self.seed_species}, so there is "
+                           f"no single unambiguous network to resolve, and this increment does not "
+                           f"pick one. This happens when the source is a BIMOLECULAR channel "
+                           f"(A + B): the explorer grows a separate network per reachable well. To "
+                           f"run the loop on this surface, seed from a single UNIMOLECULAR well "
+                           f"instead (one of the isomers this run found), which explores one "
+                           f"connected network the loop can resolve and draw.")
             return tuple(reasons), tuple(), tuple()
 
         index = network_indices[0]

--- a/t3/pdep/explorer/input_file.py
+++ b/t3/pdep/explorer/input_file.py
@@ -20,6 +20,7 @@ import io
 import keyword
 import math
 import os
+import re
 import tempfile
 import tokenize
 import warnings
@@ -165,6 +166,13 @@ class ExplorerInputSummary:
                                         the source's behalf).
         warnings (tuple): Human-readable warnings (e.g. that a multi-species bath gas's fractions
                           are recorded here but will not be honored by Arkane; see P16).
+        spin_multiplicity_corrected (tuple): One ``(label, old, new)`` per species whose
+                          ``spinMultiplicity`` contradicted its own adjacency-list ``multiplicity``
+                          header and was rewritten to match it (see the correction block below).
+                          RMG's explorer emits ``spinMultiplicity = 1`` for triplet atomic O
+                          (adjacency ``multiplicity 3``, u2, thermo label ``O(T)``); re-feeding that
+                          file makes Arkane round-trip an inconsistent species and crash, so any
+                          RMG-explored network carrying O(3P) is otherwise un-re-feedable.
     """
     dest_path: str
     seed_species: tuple
@@ -172,6 +180,7 @@ class ExplorerInputSummary:
     kinetics_labels_emitted: tuple = field(default_factory=tuple)
     reactive_false_injected: tuple = field(default_factory=tuple)
     warnings: tuple = field(default_factory=tuple)
+    spin_multiplicity_corrected: tuple = field(default_factory=tuple)
 
 
 def write_arkane_explorer_input_file(source_path: str,
@@ -300,6 +309,8 @@ def write_arkane_explorer_input_file(source_path: str,
 
     species_nodes = dict()
     species_reactive = dict()
+    species_structure_nodes = dict()
+    species_spin_mult_nodes = dict()
     ts_nodes = dict()
     network_nodes = list()
     pdep_nodes = list()
@@ -322,6 +333,8 @@ def write_arkane_explorer_input_file(source_path: str,
                 reactive_node = kwargs.get('reactive')
                 species_reactive[label] = _REACTIVE_ABSENT if reactive_node is None \
                     else _literal_or_none(reactive_node)
+                species_structure_nodes[label] = kwargs.get('structure')
+                species_spin_mult_nodes[label] = kwargs.get('spinMultiplicity')
 
         elif call_name == 'transitionState':
             label = _literal_or_none(kwargs.get('label'))
@@ -388,6 +401,40 @@ def write_arkane_explorer_input_file(source_path: str,
         first_kw = species_call.keywords[0]
         insert_pos = _pos(text, line_starts, first_kw.lineno, first_kw.col_offset)
         edits.append((insert_pos, insert_pos, f"reactive = False,\n{' ' * first_kw.col_offset}"))
+
+    # Correct any spinMultiplicity that contradicts its species' own adjacency-list multiplicity.
+    # RMG's explorer writes triplet atomic O ('[O]', thermo label "O(T)") with spinMultiplicity = 1
+    # while its adjacency-list header says 'multiplicity 3' (u2, two unpaired electrons). Splicing
+    # that block verbatim into the next round's explorer input makes Arkane re-read an
+    # internally-inconsistent species and crash on Hund's rule -- so any RMG-explored network
+    # carrying O(3P) is un-re-feedable until this is fixed. This is a CONSISTENCY correction, not
+    # invented statmech: the adjacency list is the species' authoritative electronic structure, so
+    # when an explicit 'multiplicity N' header disagrees with spinMultiplicity, the header wins and
+    # spinMultiplicity is rewritten to N (energies/frequencies untouched). SMILES-only structures
+    # carry no explicit header and are left alone (Arkane derives their multiplicity itself). Placed
+    # in T3 rather than in RMG-Py deliberately: T3 must be robust to the network files stock RMG
+    # already writes, and cannot assume a patched RMG on every box -- see the ticket's placement
+    # argument. The correction is recorded (and warned) so it is never silent.
+    spin_multiplicity_corrected = list()
+    for label, structure_node in species_structure_nodes.items():
+        adj_multiplicity = _adjacency_list_multiplicity(structure_node)
+        if adj_multiplicity is None:
+            continue
+        spin_mult_node = species_spin_mult_nodes.get(label)
+        spin_mult_value = _literal_or_none(spin_mult_node) if spin_mult_node is not None else None
+        if not isinstance(spin_mult_value, int) or isinstance(spin_mult_value, bool):
+            continue
+        if spin_mult_value == adj_multiplicity:
+            continue
+        start = _pos(text, line_starts, spin_mult_node.lineno, spin_mult_node.col_offset)
+        end = _pos(text, line_starts, spin_mult_node.end_lineno, spin_mult_node.end_col_offset)
+        edits.append((start, end, str(adj_multiplicity)))
+        spin_multiplicity_corrected.append((label, spin_mult_value, adj_multiplicity))
+        message = (f"Species {label!r}: spinMultiplicity {spin_mult_value} contradicts its "
+                   f"adjacency-list 'multiplicity {adj_multiplicity}' header; corrected to "
+                   f"{adj_multiplicity} so Arkane can re-read the species (RMG's explorer writes "
+                   f"triplet atomic O as a singlet). Energies and frequencies are untouched.")
+        warnings_list.append(message)
 
     # Remove every network(...) block: Arkane's explorer input parser does not recognize it, and
     # keeping it would (at best) be dead text and (at worst) confuse a human re-reading the file.
@@ -500,6 +547,7 @@ def write_arkane_explorer_input_file(source_path: str,
         kinetics_labels_emitted=tuple(kinetics_labels_emitted),
         reactive_false_injected=tuple(reactive_injection_labels),
         warnings=tuple(warnings_list),
+        spin_multiplicity_corrected=tuple(spin_multiplicity_corrected),
     )
 
 
@@ -1603,3 +1651,37 @@ def _literal_or_none(node):
         return ast.literal_eval(node)
     except (ValueError, TypeError):
         return None
+
+
+# The 'multiplicity N' header a species' adjacencyList string carries, e.g. the first line of
+# 'multiplicity 3\n1 O u2 p2 c0\n'. Anchored to a line start so it never matches the word inside a
+# comment or a species label.
+_ADJ_MULTIPLICITY_RE = re.compile(r'^\s*multiplicity\s+(\d+)\s*$', re.MULTILINE)
+
+
+def _adjacency_list_multiplicity(structure_node) -> int | None:
+    """
+    The explicit ``multiplicity`` a species' ``adjacencyList(...)`` structure declares.
+
+    Returns ``None`` -- meaning "no correction to make here" -- when the structure is not an
+    ``adjacencyList(...)`` call (e.g. ``SMILES(...)``, whose multiplicity Arkane derives itself),
+    when its argument is not a plain string literal, or when the adjacency string carries no
+    explicit ``multiplicity`` header (a closed-shell species omits it, defaulting to 1, which needs
+    no correction).
+
+    Args:
+        structure_node: The AST node of the species' ``structure`` keyword value, or ``None``.
+
+    Returns:
+        Optional[int]: The declared multiplicity, or ``None`` if there is nothing to correct.
+    """
+    if not isinstance(structure_node, ast.Call) or _get_call_name(structure_node) != 'adjacencyList':
+        return None
+    if not structure_node.args:
+        return None
+    arg = structure_node.args[0]
+    adj_text = arg.value if isinstance(arg, ast.Constant) and isinstance(arg.value, str) else None
+    if adj_text is None:
+        return None
+    match = _ADJ_MULTIPLICITY_RE.search(adj_text)
+    return int(match.group(1)) if match else None

--- a/t3/pdep/me_success.py
+++ b/t3/pdep/me_success.py
@@ -13,6 +13,7 @@ reasons documented in ``t3/pdep/parser.py``.
 
 import math
 import os
+import re
 from dataclasses import dataclass
 
 from t3.pdep.parser import parse_arkane_pdep_output_file
@@ -26,6 +27,56 @@ IGNORABLE_STDERR_PHRASES = (
     '==============================',
     'pjrt_executable.cc',
 )
+
+# A Python ``warnings``-module emission looks like ``<file>:<lineno>: SomeWarning: <message>``,
+# optionally followed by an indented echo of the offending source line. The explorer's ME solve
+# routinely prints scipy ``LinAlgWarning: Ill-conditioned matrix`` and RMG ``thermoengine``
+# ``LinAlgWarning`` this way on a run that otherwise succeeds and writes a valid, count-consistent
+# ``output.py``. A warning is non-fatal BY CONSTRUCTION (the warnings module never raises), so it is
+# not evidence a run failed -- and the real failure signals remain untouched: a non-zero exit, a
+# missing required artifact, a fatal ``Error:``/``Critical:`` log marker, and the payload checks. A
+# traceback line (``Traceback (most recent call last):``, ``ValueError: ...``) does NOT match this
+# pattern and still fails the run, so this filters noise without deleting the guard.
+_WARNING_LINE_RE = re.compile(r':\d+:\s+\w*Warning:\s')
+
+
+def real_stderr_lines(stderr_text: str) -> list:
+    """
+    Return the stderr lines that are genuine failure evidence, dropping ignorable noise.
+
+    Drops blank lines, every ``IGNORABLE_STDERR_PHRASES`` line, and Python ``warnings``-module
+    output -- both the ``file:line: SomeWarning: message`` line and the single indented source-echo
+    line the warnings module prints after it. Everything else (tracebacks, error text) is kept,
+    stripped, in order.
+
+    Args:
+        stderr_text (str): The raw stderr content.
+
+    Returns:
+        list: The real (non-ignorable) stderr lines, each stripped of surrounding whitespace.
+    """
+    real = []
+    prev_was_warning = False
+    for line in stderr_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            prev_was_warning = False
+            continue
+        if any(phrase in line for phrase in IGNORABLE_STDERR_PHRASES):
+            prev_was_warning = False
+            continue
+        if _WARNING_LINE_RE.search(line):
+            prev_was_warning = True
+            continue
+        # The warnings module echoes the offending source line, indented, immediately after the
+        # warning itself. Drop that echo, but only when it directly follows a warning line -- an
+        # indented line elsewhere (e.g. inside a traceback) is left as real evidence.
+        if prev_was_warning and line[:1].isspace():
+            prev_was_warning = False
+            continue
+        prev_was_warning = False
+        real.append(stripped)
+    return real
 
 
 @dataclass(frozen=True)
@@ -100,10 +151,7 @@ def check_arkane_me_success(output_path: str,
     if exit_code is not None and exit_code != 0:
         reasons.append(f'Arkane exited with a non-zero status ({exit_code}).')
     if stderr:
-        real_errors = [
-            line.strip() for line in stderr.splitlines()
-            if line.strip() and not any(phrase in line for phrase in IGNORABLE_STDERR_PHRASES)
-        ]
+        real_errors = real_stderr_lines(stderr)
         if real_errors:
             reasons.append('Arkane reported stderr output: ' + ' | '.join(real_errors))
 

--- a/t3/pdep/parser.py
+++ b/t3/pdep/parser.py
@@ -11,6 +11,7 @@ This module therefore parses the file into a syntax tree with ``ast.parse`` only
 
 import ast
 import io
+import re
 import tokenize
 import warnings
 from dataclasses import dataclass, field
@@ -54,6 +55,7 @@ __all__ = [
     'parse_pdep_network_e0_text',
     'parse_pdep_network_file',
     'parse_pdep_network_text',
+    'strip_rmg_index_suffix',
     'to_json_safe',
 ]
 
@@ -173,6 +175,34 @@ def canonical_channel_pair(reactant_labels, product_labels) -> tuple:
         tuple: A 2-tuple of canonical channels, itself in a canonical order.
     """
     return tuple(sorted((_canonical_channel(reactant_labels), _canonical_channel(product_labels))))
+
+
+# A trailing ``(<int>)`` is RMG's per-file disambiguation index, appended to a species' base
+# (SMILES-derived) label to keep labels unique within one file. It is NOT part of the species'
+# identity, and RMG does NOT write it consistently across the two artifacts of one explorer run:
+# the ME ``output.py`` names species by their base label (``[O]C=O``, ``O=C=O``) while the final
+# ``network<i>_(full|reduced).py`` names the SAME species with the index (``[O]C=O(1)``,
+# ``O=C=O(5)``). Any cross-artifact label comparison must strip the index first or it reports a
+# genuinely single-run pairing as "did not come from one run". Distinct species have distinct base
+# labels (the base is the SMILES), so stripping never merges two real species -- the index only
+# ever disambiguates a base from itself.
+_RMG_INDEX_SUFFIX_RE = re.compile(r'\(\d+\)$')
+
+
+def strip_rmg_index_suffix(label: str) -> str:
+    """
+    Strip RMG's trailing ``(<int>)`` disambiguation index from a species label.
+
+    ``'[O]C=O(1)' -> '[O]C=O'``; ``'O=C=O(5)' -> 'O=C=O'``; a label with no such suffix
+    (``'[C-]#[O+]'``, ``'[O]C=O'``) is returned unchanged.
+
+    Args:
+        label (str): A species label as written in an RMG network or Arkane output file.
+
+    Returns:
+        str: The label with a single trailing ``(<int>)`` index removed, if present.
+    """
+    return _RMG_INDEX_SUFFIX_RE.sub('', label)
 
 
 def _derive_product_channels(path_reactions: tuple,
@@ -709,15 +739,23 @@ def _extract_numeric_leaves(value) -> list:
     return leaves
 
 
-def parse_pdep_network_file(path: str) -> PDepNetwork:
+def parse_pdep_network_file(path: str, require_reactions: bool = True) -> PDepNetwork:
     """
     Parse an RMG pdep network file from disk.
 
     Args:
         path (str): The path to the RMG pdep network file (e.g., ``.../pdep/network4_2.py``).
+        require_reactions (bool): Whether a file declaring no ``reaction(...)`` entry is refused
+            (the default) or accepted as a valid reaction-less network. Explored/hybrid network
+            files and the explorer's own artifact validation require reactions -- their absence
+            means a truncated or wrong file. A SEED network handed to the explorer, by contrast,
+            legitimately carries source species and a bath gas with NO reactions (the explorer is
+            what creates them), so its callers pass ``require_reactions=False``. See
+            ``parse_pdep_network_text`` for the full rationale.
 
     Raises:
-        ValueError: If the file cannot be parsed as Python, or contains no path reactions.
+        ValueError: If the file cannot be parsed as Python, or (when ``require_reactions``)
+            contains no path reactions.
 
     Returns:
         PDepNetwork: The parsed network, with ``source_hash`` set to the content hash of the exact
@@ -740,11 +778,12 @@ def parse_pdep_network_file(path: str) -> PDepNetwork:
     text = data.decode(encoding)
     network_id = Path(path).stem
     return parse_pdep_network_text(text=text, network_id=network_id, path=path,
-                                   source_hash=hash_bytes(data))
+                                   source_hash=hash_bytes(data), require_reactions=require_reactions)
 
 
 def parse_pdep_network_text(text: str, network_id: str, path: str = '',
-                            source_hash: str | None = None) -> PDepNetwork:
+                            source_hash: str | None = None,
+                            require_reactions: bool = True) -> PDepNetwork:
     """
     Parse RMG pdep network file text into a ``PDepNetwork``.
 
@@ -758,9 +797,17 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
             whose bytes differ from its decoded form (CRLF line endings, a BOM, a non-UTF-8 encoding
             cookie), and a provenance hash that silently disagrees with the one the SA cache sidecar
             records is worse than no hash at all. Callers with no file leave it ``None``.
+        require_reactions (bool): Whether a text declaring no ``reaction(...)`` entry is refused
+            (the default) or accepted as a valid reaction-less network. A SEED handed to the
+            explorer legitimately has no reactions -- the explorer creates them -- so the
+            explore path parses it with ``require_reactions=False``. Everywhere the file is
+            supposed to already carry a solved surface (an explored/hybrid network, the explorer's
+            own final-artifact validation) keeps the default, so a truncated or wrong file is still
+            refused loudly.
 
     Raises:
-        ValueError: If the text cannot be parsed as Python, or contains no path reactions.
+        ValueError: If the text cannot be parsed as Python, or (when ``require_reactions``)
+            contains no path reactions.
 
     Returns:
         PDepNetwork: The parsed network.
@@ -845,7 +892,7 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
         # ``pressureDependence(...)`` data is not part of the public API here; it is
         # recognized (so it is not silently ignored as "unrecognized") but otherwise unused.
 
-    if not path_reactions:
+    if require_reactions and not path_reactions:
         raise ValueError(f"The pdep network file at '{path}' contains no reaction(...) entries; nothing to parse.")
 
     if not product_channels_declared:

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -167,7 +167,7 @@ def _build_explorer_config(config: PESLoopConfig, project_directory: str,
                            paths: RoundPaths) -> PDepExplorerConfig:
     """Build this round's ``PDepExplorerConfig`` from ``config.pes``."""
     return PDepExplorerConfig(
-        explorer='arkane',
+        explorer='Arkane',
         trusted_output_root=project_directory,
         output_directory=paths.explorer_output,
         seed_species=tuple(config.pes.source),
@@ -337,7 +337,10 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
     seed_channel_keys = dict()
     seed_adoption_keys = dict()
     if adopted_ts_labels or config.reuse.from_t3_projects:
-        seed_network = parse_pdep_network_file(path=config.pes.network)
+        # require_reactions=False: config.pes.network is the seed, which is legitimately
+        # source-only on round 0 (no reaction(...) yet -- the explorer creates them). This parse
+        # only needs the seed's species/channel keys for adoption matching, never its reactions.
+        seed_network = parse_pdep_network_file(path=config.pes.network, require_reactions=False)
         seed_channel_keys = channel_keys_by_ts_label(seed_network)
         seed_adoption_keys = adoption_channel_keys_by_ts_label(seed_network)
     if adopted_ts_labels:

--- a/tests/data/pdep_source_seeds/cho2_source/network_cho2_source.py
+++ b/tests/data/pdep_source_seeds/cho2_source/network_cho2_source.py
@@ -1,0 +1,77 @@
+# Minimal SOURCE-ONLY CHO2 seed for the standalone PES exploration loop.
+#
+# This file carries ONLY the source well [O]C=O (formyloxy), the Ar bath gas, one network()
+# block naming the well as the sole isomer, and one pressureDependence() block -- the minimum
+# t3.pdep.explorer.input_file.write_arkane_explorer_input_file needs. There is NO reaction(),
+# NO transitionState(), and NO adduct isomer: Arkane's explorer grows the CHO2 surface from this
+# seed using the RMG database. Requiring reactions here would invert the data flow -- the explorer
+# is what creates them (see t3/pdep/parser.py's require_reactions and t3/pdep/api.py).
+#
+# A UNIMOLECULAR source is deliberate: a bimolecular H + CO2 source makes Arkane's explorer
+# discover TWO disjoint CHO2 networks, which ArkaneExplorerAdapter refuses (there is no single
+# unambiguous result). A single well explores one connected network the loop can resolve and draw.
+#
+# The [O]C=O and Ar statmech blocks are lifted verbatim from a real RMG-explored CHO2 network
+# (examples/pes_loop_cho2/t3_seed_run/network_cho2_clean.py in the I-006/I-007 worktree), so no
+# energy is invented.
+
+species(
+    label = '[O]C=O',
+    structure = adjacencyList("""multiplicity 2
+1 O u1 p2 c0 {3,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+"""),
+    E0 = (-169.935,'kJ/mol'),
+    modes = [
+        HarmonicOscillator(frequencies=([2782.5,750,1395,475,1775,1000],'cm^-1')),
+    ],
+    spinMultiplicity = 2,
+    opticalIsomers = 1,
+    molecularWeight = (45.0174,'amu'),
+    collisionModel = TransportData(shapeIndex=2, epsilon=(4140.61,'J/mol'), sigma=(3.59,'angstroms'), dipoleMoment=(0,'De'), polarizability=(0,'angstroms^3'), rotrelaxcollnum=2.0, comment="""NOx2018"""),
+    energyTransferModel = SingleExponentialDown(alpha0=(3.5886,'kJ/mol'), T0=(300,'K'), n=0.85),
+    thermo = NASA(polynomials=[NASAPolynomial(coeffs=[3.9649,-0.00518829,3.73952e-05,-4.21919e-08,1.47224e-11,-20431.8,7.33591], Tmin=(100,'K'), Tmax=(994.515,'K')), NASAPolynomial(coeffs=[5.26528,0.00541264,-2.4716e-06,5.38764e-10,-4.28526e-14,-21473.4,-2.86661], Tmin=(994.515,'K'), Tmax=(5000,'K'))], Tmin=(100,'K'), Tmax=(5000,'K'), E0=(-169.935,'kJ/mol'), Cp0=(33.2579,'J/(mol*K)'), CpInf=(83.1447,'J/(mol*K)'), comment="""Thermo group additivity estimation: group(O2s-(Cds-O2d)H) + group(Cds-OdOsH) + radical(OJC=O)"""),
+)
+
+species(
+    label = 'Ar',
+    structure = adjacencyList("""1 Ar u0 p4 c0
+"""),
+    molecularWeight = (39.8775,'amu'),
+    collisionModel = TransportData(shapeIndex=0, epsilon=(1134.93,'J/mol'), sigma=(3.33,'angstroms'), dipoleMoment=(0,'De'), polarizability=(0,'angstroms^3'), rotrelaxcollnum=0.0, comment="""NOx2018"""),
+    energyTransferModel = SingleExponentialDown(alpha0=(3.5886,'kJ/mol'), T0=(300,'K'), n=0.85),
+    thermo = NASA(polynomials=[NASAPolynomial(coeffs=[2.5,0,0,0,0,-745.375,4.37967], Tmin=(200,'K'), Tmax=(1000,'K')), NASAPolynomial(coeffs=[2.5,0,0,0,0,-745.375,4.37967], Tmin=(1000,'K'), Tmax=(6000,'K'))], Tmin=(200,'K'), Tmax=(6000,'K'), E0=(-6.19738,'kJ/mol'), Cp0=(20.7862,'J/(mol*K)'), CpInf=(20.7862,'J/(mol*K)'), label="""Ar""", comment="""Thermo library: primaryThermoLibrary"""),
+)
+
+network(
+    label = 'PDepNetwork CHO2 source',
+    isomers = [
+        '[O]C=O',
+    ],
+    reactants = [
+    ],
+    bathGas = {
+        'Ar': 1.0,
+    },
+)
+
+pressureDependence(
+    label = 'PDepNetwork CHO2 source',
+    Tmin = (700,'K'),
+    Tmax = (3200,'K'),
+    Tcount = 10,
+    Tlist = ([3200,2290.91,1784.07,1460.87,1236.81,1072.34,946.479,847.059,766.54,700],'K'),
+    Pmin = (0.1,'bar'),
+    Pmax = (100,'bar'),
+    Pcount = 10,
+    Plist = ([0.1,0.215443,0.464159,1,2.15443,4.64159,10,21.5443,46.4159,100],'bar'),
+    maximumGrainSize = (2,'kJ/mol'),
+    minimumGrainCount = 250,
+    method = 'modified strong collision',
+    interpolationModel = ('pdeparrhenius',),
+    activeKRotor = True,
+    activeJRotor = True,
+    rmgmode = True,
+)

--- a/tests/test_pdep/test_explorer_arkane.py
+++ b/tests/test_pdep/test_explorer_arkane.py
@@ -991,6 +991,21 @@ class TestArkaneExplorerAdapterFinalNetworkPayload:
         assert adapter.explore() is True, adapter.reasons
         assert adapter.get_networks()[0].endswith('network0_full.py')
 
+    def test_index_suffixed_network_labels_still_match_base_labelled_output(self, tmp_path, monkeypatch):
+        """Defect 5: RMG names the same species by base label in output.py ('CH2O') and by
+        base + index in the network file ('CH2O(1)'). The payload check must compare on the stripped
+        base label, or it discards a genuinely single-run exploration as "not from one run". This is
+        the real divergence that stopped the loop; without the normalization this assertion fails."""
+        indexed_network = (VALID_NETWORK_PY
+                           .replace("'methoxy'", "'methoxy(3)'")
+                           .replace("'CH2O'", "'CH2O(1)'")
+                           .replace("'H'", "'H(2)'"))
+        # Sanity: the fixture really did diverge (indexed on the network side, base on the output).
+        assert "'CH2O(1)'" in indexed_network and "'CH2O'" in VALID_OUTPUT_PY
+        adapter = self._explore_with_final(tmp_path, monkeypatch, final_content=indexed_network,
+                                           output_content=VALID_OUTPUT_PY)
+        assert adapter.explore() is True, adapter.reasons
+
     def test_output_and_final_network_must_describe_the_same_network(self, tmp_path, monkeypatch):
         """
         Codex's P2, which is this same gap seen from the other side.
@@ -1285,6 +1300,23 @@ class TestArkaneExplorerAdapterReductionPredicate:
         assert any('methoxy' in reason for reason in adapter.reasons), \
             'The refusal reason must name the seed.'
         assert any('multi' in reason.lower() or '2' in reason for reason in adapter.reasons)
+
+    def test_multi_network_refusal_tells_the_user_to_seed_from_a_well(self, tmp_path, monkeypatch):
+        """Defect 4: refusing a bimolecular-source multi-network run is acceptable, but the message
+        must not be a dead end -- it must tell the user what to do (seed from a unimolecular well)."""
+        adapter = _build_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            't3.pdep.explorer.arkane.run_arkane_job',
+            _make_fake_run_arkane_job(
+                success=True,
+                output_files={'output.py': VALID_OUTPUT_PY, 'output0.py': VALID_OUTPUT_PY,
+                             'output1.py': VALID_OUTPUT_PY},
+                final_files={'network0_full.py': VALID_NETWORK_PY,
+                            'network1_full.py': VALID_NETWORK_PY},
+            ))
+        assert adapter.explore() is False
+        reasons = ' '.join(adapter.reasons).lower()
+        assert 'unimolecular' in reasons and 'well' in reasons, adapter.reasons
 
 
 class TestArkaneExplorerAdapterFailureSignals:

--- a/tests/test_pdep/test_explorer_input_file.py
+++ b/tests/test_pdep/test_explorer_input_file.py
@@ -301,6 +301,98 @@ def test_rewrites_method_line_for_msc(tmp_path):
     assert 'modified strong collision' not in text
 
 
+# A source whose atomic-O species is written the way RMG's explorer writes triplet O(3P):
+# spinMultiplicity=1 contradicting its own 'multiplicity 3' adjacency header. [OH] beside it is
+# self-consistent (multiplicity 2 / spinMultiplicity 2) and must be left untouched. Outer ''' with
+# inner """ so the adjacency-list triple-quoted strings nest cleanly.
+SOURCE_TRIPLET_O_INCONSISTENT = '''species(
+    label='[O]',
+    structure=adjacencyList("""multiplicity 3
+1 O u2 p2 c0
+"""),
+    E0=(243.034, 'kJ/mol'),
+    spinMultiplicity=1,
+)
+species(
+    label='[OH]',
+    structure=adjacencyList("""multiplicity 2
+1 O u1 p2 c0 {2,S}
+2 H u0 p0 c0 {1,S}
+"""),
+    E0=(28.0, 'kJ/mol'),
+    spinMultiplicity=2,
+)
+species(
+    label='He',
+    structure=SMILES('[He]'),
+    E0=(0, 'kJ/mol'),
+    reactive=False,
+)
+pressureDependence(
+    label='PDepNetwork #1',
+    Tmin=(300, 'K'),
+    Tmax=(2000, 'K'),
+    Tcount=8,
+    Pmin=(0.01, 'bar'),
+    Pmax=(100, 'bar'),
+    Pcount=5,
+    maximumGrainSize=(0.5, 'kcal/mol'),
+    maximumGrainCount=250,
+    method = 'modified strong collision',
+    activeKRotor=True,
+    activeJRotor=True,
+    rmgmode=False,
+)
+'''
+
+
+def _species_spin_multiplicity(text, label):
+    """The spinMultiplicity literal written for ``label`` in a generated explorer input file."""
+    tree = ast.parse(text)
+    for node in tree.body:
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call) \
+                or not isinstance(node.value.func, ast.Name) or node.value.func.id != 'species':
+            continue
+        kwargs = {kw.arg: kw.value for kw in node.value.keywords if kw.arg is not None}
+        if 'label' in kwargs and ast.literal_eval(kwargs['label']) == label:
+            return ast.literal_eval(kwargs['spinMultiplicity'])
+    raise AssertionError(f'no species {label!r} with a spinMultiplicity in the generated file')
+
+
+def test_corrects_triplet_o_spin_multiplicity_that_contradicts_its_adjacency_header(tmp_path):
+    """Defect 3: RMG's explorer writes triplet atomic O with spinMultiplicity=1 while its adjacency
+    header says 'multiplicity 3'. Splicing that verbatim makes the next round's Arkane crash, so the
+    writer rewrites spinMultiplicity to match the (authoritative) adjacency list. The self-consistent
+    [OH] beside it is left untouched -- this corrects a contradiction, it does not rewrite spins."""
+    source_path = _write_source(tmp_path, SOURCE_TRIPLET_O_INCONSISTENT)
+    dest_path = str(tmp_path / 'input.py')
+
+    result = write_arkane_explorer_input_file(
+        source_path=source_path, dest_path=dest_path,
+        **{**DEFAULT_KWARGS, 'seed_species': ('[O]',), 'maximum_radical_electrons': 2})
+
+    assert result.spin_multiplicity_corrected == (('[O]', 1, 3),)
+    with open(dest_path) as f:
+        text = f.read()
+    assert _species_spin_multiplicity(text, '[O]') == 3      # corrected
+    assert _species_spin_multiplicity(text, '[OH]') == 2     # consistent -> untouched
+    # The correction is surfaced, never silent.
+    assert any('[O]' in w and 'spinMultiplicity' in w for w in result.warnings)
+
+
+def test_does_not_touch_a_consistent_spin_multiplicity(tmp_path):
+    """A source whose spinMultiplicity already matches its adjacency header triggers no correction --
+    the over-correction guard, so the fix cannot start rewriting good files."""
+    consistent = SOURCE_TRIPLET_O_INCONSISTENT.replace('    spinMultiplicity=1,\n',
+                                                       '    spinMultiplicity=3,\n')
+    source_path = _write_source(tmp_path, consistent)
+    dest_path = str(tmp_path / 'input.py')
+    result = write_arkane_explorer_input_file(
+        source_path=source_path, dest_path=dest_path,
+        **{**DEFAULT_KWARGS, 'seed_species': ('[O]',), 'maximum_radical_electrons': 2})
+    assert result.spin_multiplicity_corrected == ()
+
+
 def test_does_not_emit_kinetics_directive_when_reaction_has_explicit_kinetics(tmp_path):
     """Behavior: a reaction() with an explicit kinetics= keyword gets no kinetics(...) directive."""
     source_path = _write_source(tmp_path, SOURCE_WITH_KINETICS)

--- a/tests/test_pdep/test_me_success.py
+++ b/tests/test_pdep/test_me_success.py
@@ -16,10 +16,45 @@ import math
 import os
 
 from t3.common import TEST_DATA_BASE_PATH
-from t3.pdep.me_success import MESuccessResult, check_arkane_me_success
+from t3.pdep.me_success import MESuccessResult, check_arkane_me_success, real_stderr_lines
 from t3.pdep.parser import parse_pdep_network_file
 
 PDEP_ME_DIR = os.path.join(TEST_DATA_BASE_PATH, 'pdep_me')
+
+
+# A verbatim excerpt of the stderr a real explorer ME solve prints on a run that otherwise succeeds
+# and writes a valid, count-consistent output.py: scipy and RMG numerical-conditioning warnings,
+# each followed by the warnings module's echo of the offending source line.
+_EXPLORER_WARNING_STDERR = (
+    "/home/x/envs/rmg_env/lib/python3.9/site-packages/scipy/optimize/_optimize.py:2322: "
+    "LinAlgWarning: Ill-conditioned matrix (rcond=9.78829e-18): result may not be accurate.\n"
+    "  fu = func(x, *args)\n"
+    "/home/x/Code/RMG-Py/rmgpy/thermo/thermoengine.py:100: LinAlgWarning: Ill-conditioned matrix "
+    "(rcond=3.18757e-21): result may not be accurate.\n"
+    "  thermo = wilhoit.to_nasa(Tmin=100.0, Tmax=5000.0, Tint=1000.0)\n"
+)
+
+
+def test_real_stderr_lines_drops_python_warnings_and_their_source_echo():
+    """A run that only printed scipy/RMG LinAlgWarnings to stderr succeeded; the warnings module's
+    output (the warning line AND the indented source-echo after it) is non-fatal by construction and
+    must not be read as failure evidence."""
+    assert real_stderr_lines(_EXPLORER_WARNING_STDERR) == []
+
+
+def test_real_stderr_lines_keeps_a_traceback():
+    """A genuine error is not a warning: a traceback and its exception line are kept, even when they
+    sit beside ignorable warnings, so filtering noise never blinds the guard to a real failure."""
+    text = (_EXPLORER_WARNING_STDERR
+            + "Traceback (most recent call last):\n"
+            + "  File \"arkane/main.py\", line 286, in execute\n"
+            + "ValueError: Impossible multiplicity for molecule\n")
+    real = real_stderr_lines(text)
+    assert 'Traceback (most recent call last):' in real
+    assert 'ValueError: Impossible multiplicity for molecule' in real
+    # The indented file-location line inside the traceback is kept too: it only drops when it
+    # directly follows a warning line, not when it follows a traceback header.
+    assert any('File "arkane/main.py"' in line for line in real)
 SUCCESS_OUTPUT = os.path.join(PDEP_ME_DIR, 'success', 'output.py')
 SOFT_FAILURE_CSE_OUTPUT = os.path.join(PDEP_ME_DIR, 'soft_failure_cse', 'output.py')
 HARD_FAILURE_OUTPUT = os.path.join(PDEP_ME_DIR, 'hard_failure', 'output.py')

--- a/tests/test_pdep/test_parser.py
+++ b/tests/test_pdep/test_parser.py
@@ -221,6 +221,34 @@ def test_empty_network_raises_value_error():
         parse_pdep_network_text(text=text, network_id='synthetic_empty')
 
 
+def test_reaction_less_seed_is_accepted_when_reactions_not_required():
+    """A source-only seed (species + bath gas, no reaction()) is legitimate input to the explorer,
+    which is what CREATES the reactions -- so require_reactions=False must accept it rather than
+    invert the data flow by demanding the reactions before the run that produces them."""
+    text = ("species(label = '[O]C=O', structure = SMILES('[O]C=O'))\n"
+            "species(label = 'Ar', structure = SMILES('[Ar]'))\n")
+    network = parse_pdep_network_text(text=text, network_id='cho2_seed', require_reactions=False)
+    assert network.species_labels == ('[O]C=O', 'Ar')
+    assert network.path_reactions == ()
+    # The default still refuses it -- the strictness is right for explored/hybrid networks and the
+    # explorer's own artifact validation, only wrong for a seed.
+    with pytest.raises(ValueError):
+        parse_pdep_network_text(text=text, network_id='cho2_seed')
+
+
+@pytest.mark.parametrize('label, expected', [
+    ('[O]C=O(1)', '[O]C=O'),
+    ('O=C=O(5)', 'O=C=O'),
+    ('H(2)', 'H'),
+    ('[C-]#[O+]', '[C-]#[O+]'),   # no suffix -> unchanged
+    ('[O]C=O', '[O]C=O'),         # no suffix -> unchanged
+    ('Ar', 'Ar'),
+])
+def test_strip_rmg_index_suffix(label, expected):
+    from t3.pdep.parser import strip_rmg_index_suffix
+    assert strip_rmg_index_suffix(label) == expected
+
+
 # FIX5: no in-repo fixture (network1_1/network4_1/network4_2) contains a MultiArrhenius
 # (or other composite) kinetics call, so this case is necessarily covered with a synthetic,
 # hand-written fixture rather than a real one.

--- a/tests/test_pdep/test_pes_loop.py
+++ b/tests/test_pdep/test_pes_loop.py
@@ -135,7 +135,7 @@ def _stub_explorer(monkeypatch, tmp_path, families, fail=False, fail_from=None):
                                      status=EXPLORATION_STATUS_SUCCEEDED,
                                      network_paths=(output_path,))
 
-    def _fake_parse(path):
+    def _fake_parse(path, require_reactions=True):
         network_id = os.path.splitext(os.path.basename(path))[0]
         return dataclasses.replace(base_network, network_id=network_id, path=path)
 
@@ -560,7 +560,7 @@ class TestRunPESLoop(object):
                                          status=EXPLORATION_STATUS_SUCCEEDED,
                                          network_paths=(output_path,))
 
-        def _fake_parse(path):
+        def _fake_parse(path, require_reactions=True):
             network_id = os.path.splitext(os.path.basename(path))[0]
             return dataclasses.replace(base_network, network_id=network_id, path=path)
 
@@ -954,7 +954,7 @@ class TestRenumberedNetworksKeepQMOnTheRightChannel(object):
                                          status=EXPLORATION_STATUS_SUCCEEDED,
                                          network_paths=(output_path,))
 
-        def _fake_parse(path):
+        def _fake_parse(path, require_reactions=True):
             # The loop parses each round's freshly explored network right after exploring it, so
             # the round currently being parsed is simply the latest explore call.
             network = networks[min(len(calls) - 1, 2)] if calls else networks[0]
@@ -1023,7 +1023,7 @@ class TestUnkeyableNetworks(object):
 
         monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
         monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file',
-                            lambda path: dataclasses.replace(base_network, path=path))
+                            lambda path, require_reactions=True: dataclasses.replace(base_network, path=path))
         monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram',
                             lambda network_path, output_path: open(output_path, 'w').close())
         runner_calls = []
@@ -1074,7 +1074,7 @@ class TestUnkeyableNetworks(object):
 
         monkeypatch.setattr('t3.pdep.pes_loop.explore_pdep_network', _fake_explore)
         monkeypatch.setattr('t3.pdep.pes_loop.parse_pdep_network_file',
-                            lambda path: dataclasses.replace(base_network, path=path))
+                            lambda path, require_reactions=True: dataclasses.replace(base_network, path=path))
         monkeypatch.setattr('t3.pdep.pes_loop.draw_pes_diagram',
                             lambda network_path, output_path: open(output_path, 'w').close())
         adopted_per_round = []

--- a/tests/test_pdep/test_pes_loop_source_seed.py
+++ b/tests/test_pdep/test_pes_loop_source_seed.py
@@ -1,0 +1,60 @@
+"""
+End-to-end PES-loop test from a SOURCE-ONLY seed, driving the REAL Arkane explorer.
+
+This is the test the I-009 Verifier asks for: no double at the explorer seam. It drives the real
+``t3.pdep.pes_loop.run_pes_loop`` with ``qm_runner=None`` (the ``PES.py --diagram-only`` path) on a
+source-only CHO2 seed -- one well, a bath gas, no hand-written ``reaction()`` -- and asserts the
+loop runs Arkane's own explorer, accepts the genuinely-explored network, and writes its own PES
+diagram. It exercises, through the real callee, four of the defects this ticket cleared: the seed
+parser accepting a reaction-less seed, the ``explorer='Arkane'`` case fix, the ``_check_final_network_payload``
+label normalization, and the scipy/RMG ``LinAlgWarning`` stderr false-positive. A fully-mocked seam
+hid every one of them, which is exactly why this test refuses a double.
+
+It runs Arkane under ``rmg_env`` via ``run_arkane_job`` (same as ``test_pes_sa.py``'s real-Arkane
+test) and costs ~30 s; it is the single end-to-end explorer test in the suite.
+"""
+
+import os
+
+from t3.pdep.pes_loop import PES_LOOP_DIAGRAM_ONLY, run_pes_loop
+from t3.schema import PESLoopConfig
+
+_SOURCE_SEED_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'data', 'pdep_source_seeds', 'cho2_source',
+    'network_cho2_source.py')
+
+
+def _source_only_config(network_path):
+    """A PES-loop config seeded from the source-only CHO2 well, mirroring examples/pes_loop_cho2."""
+    return PESLoopConfig(
+        pes={'network': network_path,
+             'source': ['[O]C=O'],
+             'method': 'MSC',
+             'bath_gas': {'Ar': 1.0},
+             'explore_tol': 0.01,
+             'energy_tol': 1.0e1,
+             'flux_tol': 1.0e-6,
+             'maximum_radical_electrons': 2,
+             'timeout': 1200.0},
+        termination={'max_rounds': 1, 'stop_when_no_new_ts': True},
+    )
+
+
+def test_diagram_only_runs_end_to_end_from_a_source_only_seed(tmp_path):
+    """The real loop, real explorer, no double: a source-only seed explores to a genuine network,
+    the payload check accepts it, and the loop writes its own diagram."""
+    result = run_pes_loop(_source_only_config(os.path.abspath(_SOURCE_SEED_PATH)),
+                          str(tmp_path), qm_runner=None)
+
+    assert result.status == PES_LOOP_DIAGRAM_ONLY, (result.status, result.reason)
+    assert len(result.rounds) == 1
+
+    # The loop drew its OWN diagram (t3.pdep.pes_loop._draw_round_diagram), not merely the adapter's.
+    assert result.final_diagram_path is not None, result.reason
+    assert os.path.isfile(result.final_diagram_path)
+    assert os.path.getsize(result.final_diagram_path) > 0
+
+    # The accepted final network is the real explored artifact Arkane wrote.
+    assert result.final_network_path is not None
+    assert os.path.isfile(result.final_network_path)
+    assert os.path.getsize(result.final_network_path) > 0


### PR DESCRIPTION
## What

`PES.py --diagram-only` → `run_pes_loop` had **never run end to end**. A source-only
seed — one well, a bath gas, no hand-written `reaction()` — hit five defects stacked
behind one another, each invisible until the previous was cleared, plus a sixth found
behind those. This clears all six, so the loop completes a round through Arkane's own
explorer and writes its own diagram.

They are fixed together on purpose: fixing only the outermost moves the failure four
steps downstream rather than removing it.

## The six

1. **Seed parser refused a reaction-less seed.** `parse_pdep_network_{file,text}` now take
   `require_reactions` (default `True`); the explore path passes `False`. The seed
   legitimately has no reactions — the explorer creates them — so requiring them inverts
   the data flow. The default keeps the guard for explored/hybrid networks.
2. **The loop could not reach its own explorer.** `pes_loop` hardcoded `explorer='arkane'`;
   the adapter registers as `'Arkane'`. One-character case fix.
3. **Triplet atomic O written as a singlet.** RMG's explorer emits `spinMultiplicity = 1`
   for O(³P) whose adjacency header says `multiplicity 3`, so any re-fed network crashed
   Arkane on Hund's rule. Corrected at T3's re-feed boundary rather than in RMG-Py, so T3
   tolerates the network files stock RMG already writes.
4. **A bimolecular source yields multiple networks**, which the adapter refuses. The
   refusal now tells the user to seed from a unimolecular well instead of being a dead end.
5. **`_check_final_network_payload` discarded a successful exploration.** It compared
   `output.py`'s base labels (`[O]C=O`) against the final network file's indexed ones
   (`[O]C=O(1)`). Now compares index-stripped labels — the invariant across the two
   artifacts. **The guard is kept, not relaxed.**
6. **(behind #5) The stderr failure signal flagged warnings as errors.** scipy/RMG
   `LinAlgWarning` output failed runs that had succeeded. `real_stderr_lines` now drops
   Python `warnings`-module output; tracebacks and error text still fail the run.

## Tests

Adds a **real-Arkane** end-to-end test — no double at the explorer seam — because
fully-mocked seams hid every one of these six. `tests/test_pdep`: **1886 passed**.

Also adds a source-only CHO2 example under `examples/pes_loop_cho2/`.