### PR TITLE
feat(logger): record ARC's git provenance in the run header

### DIFF
--- a/t3/logger.py
+++ b/t3/logger.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import time
 
+import arc
 from arc.common import get_git_branch, get_git_commit
 
 from t3.common import dict_to_str, t3_path, time_lapse
@@ -143,6 +144,32 @@ class Logger(object):
                      level='always')
         else:
             self.log('\n', level='always')
+
+        # Extract HEAD git commit from ARC, derived from the ARC package actually imported
+        # (arc.__file__ and up), so the log records the ARC that ran. Every step here is
+        # non-fatal by construction: the helpers return empty strings and never raise, so an ARC
+        # installed as a wheel, a missing .git, or an absent git binary logs a note and lets the
+        # run continue rather than aborting it. ``__file__`` is read with getattr because a
+        # namespace package leaves it None, and os.path.abspath(None) raises a TypeError that
+        # would abort the whole run from inside a logging line.
+        arc_file = getattr(arc, '__file__', None)
+        arc_path = os.path.dirname(os.path.dirname(os.path.abspath(arc_file))) if arc_file else ''
+        arc_head, arc_date = get_git_commit(path=arc_path) if arc_path else ('', '')
+        arc_branch = get_git_branch(path=arc_path) if arc_path else ''
+        if arc_head != '' and arc_date != '':
+            self.log(f'The current git HEAD for ARC is:\n'
+                     f'    {arc_head}\n    {arc_date}',
+                     level='always')
+            if arc_branch and arc_branch != 'main':
+                self.log(f'    (running on the {arc_branch} branch)\n',
+                         level='always')
+            else:
+                self.log('\n', level='always')
+        else:
+            self.log(f'Could not determine the git provenance of ARC at '
+                     f'{arc_path or "an undeterminable path (arc.__file__ is not set)"}\n',
+                     level='always')
+
         self.log(f'Starting project {self.project}', level='always')
 
     def log_max_time_reached(self, max_time: str):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -9,7 +9,9 @@ import datetime
 import os
 import shutil
 
-from t3.common import TEST_DATA_BASE_PATH
+import arc
+
+from t3.common import TEST_DATA_BASE_PATH, t3_path
 import t3.logger as logger
 
 
@@ -111,6 +113,75 @@ def test_log():
                  ]:
         assert line not in lines
     shutil.rmtree(log_project_directory, ignore_errors=True)
+
+
+def test_log_header(monkeypatch):
+    """The header must report ARC's provenance in the ARC block and T3's in the T3 block.
+
+    The provenance helpers are stubbed to return values keyed on the ``path`` they are called with,
+    so the test pins that the ARC block is derived from the imported ARC's path (arc.__file__ and up)
+    and the T3 block from T3's path, and that the two cannot be silently swapped. This holds
+    regardless of the machine's checkout state, so it survives CI where ARC is a fresh clone.
+    """
+    arc_path = os.path.dirname(os.path.dirname(os.path.abspath(arc.__file__)))
+    commit_by_path = {arc_path: ('arc_head_sha', 'arc_commit_date'),
+                      t3_path: ('t3_head_sha', 't3_commit_date')}
+    branch_by_path = {arc_path: 'arc_branch', t3_path: 't3_branch'}
+
+    def fake_get_git_commit(path=None):
+        return commit_by_path.get(path, ('', ''))
+
+    def fake_get_git_branch(path=None):
+        return branch_by_path.get(path, '')
+
+    monkeypatch.setattr(logger, 'get_git_commit', fake_get_git_commit)
+    monkeypatch.setattr(logger, 'get_git_branch', fake_get_git_branch)
+
+    try:
+        # Logger.__init__ writes the header, so the stubs above must already be in place.
+        init_logger(verbose=10)
+        with open(os.path.join(log_project_directory, 't3.log')) as f:
+            content = f.read()
+        # Both blocks are present, in order (T3 first, then ARC).
+        assert 'The current git HEAD for T3 is:' in content
+        assert 'The current git HEAD for ARC is:' in content
+        t3_start = content.index('The current git HEAD for T3 is:')
+        arc_start = content.index('The current git HEAD for ARC is:')
+        block_end = content.index('Starting project', arc_start)
+        t3_block = content[t3_start:arc_start]
+        arc_block = content[arc_start:block_end]
+        # Each block carries all three of its own fields and none of the other's. Asserting the
+        # whole triple both ways is the point: checking only the SHAs would still pass a partial
+        # mix-up that got the SHA right and the date or branch wrong.
+        for field in ('t3_head_sha', 't3_commit_date', 't3_branch'):
+            assert field in t3_block
+            assert field not in arc_block
+        for field in ('arc_head_sha', 'arc_commit_date', 'arc_branch'):
+            assert field in arc_block
+            assert field not in t3_block
+    finally:
+        shutil.rmtree(log_project_directory, ignore_errors=True)
+
+
+def test_log_header_survives_an_arc_without_a_file(monkeypatch):
+    """A missing ``arc.__file__`` must degrade to a note, never abort the run.
+
+    ARC imported as a namespace package has ``__file__`` set to None, and ``os.path.abspath(None)``
+    raises a TypeError. Raising it from inside the header would kill a multi-hour run over a log
+    line, so the header must fall through to its "could not determine" branch instead.
+    """
+    monkeypatch.setattr(logger.arc, '__file__', None)
+
+    try:
+        init_logger(verbose=10)
+        with open(os.path.join(log_project_directory, 't3.log')) as f:
+            content = f.read()
+        assert 'Could not determine the git provenance of ARC' in content
+        assert 'arc.__file__ is not set' in content
+        # The run carried on: the header still reached its final line.
+        assert 'Starting project' in content
+    finally:
+        shutil.rmtree(log_project_directory, ignore_errors=True)
 
 
 def test_log_max_time_reached():


### PR DESCRIPTION
## Why

Every T3 run logs its own git commit and branch. It logs nothing about **ARC** — the package that
actually runs the quantum chemistry.

That was survivable while the local ARC checkout tracked a stable branch. It no longer does: it sits
on an integration branch carrying approved-but-unmerged ARC PRs, **rebuilt onto latest main as those
PRs land**. T3 imports `arc` from that checkout, so a run silently takes whatever the branch happened
to be that hour and the log cannot say which. Observed live while this ticket was open: ARC's tip
moved between two checks an hour apart.

A result nobody can attribute to a specific ARC is not a reproducible result.

## What

The header now carries an ARC block beside the T3 one, e.g.

```
The current git HEAD for ARC is:
    b76160faf5419ae4659e29205d862b5dd433a42d
    Sat Aug 22 16:13:53 2026 +0300
    (running on the future branch)
```

The path is derived from **the ARC package actually imported** (`arc.__file__` and up) rather than
from a configured location — the point is to record what ran, not what was meant to run.

## Non-fatal by construction

`get_git_commit` / `get_git_branch` return empty strings and never raise, so an ARC installed as a
wheel, a missing `.git`, or an absent `git` binary logs a "could not determine" line and the run
continues. A logging improvement that can abort a six-hour run would be a worse defect than the one
it fixes.

## Tests

`tests/test_logger.py` monkeypatches the two helpers to return **distinguishable values per path**
and asserts each block carries its own — including that neither block contains the other's, so the
two cannot be silently swapped.

This matters: an earlier revision asserted only that an ARC block *appeared*, and that version passed
with `arc_path` pointed back at `t3_path` — i.e. with the original bug reinstated under an "ARC"
heading. The current test fails against that mutation.