### PR TITLE
fix(explorer): let the outbound self-check accept the modelChemistry line the inbound guard admits

### DIFF
--- a/t3/pdep/explorer/input_file.py
+++ b/t3/pdep/explorer/input_file.py
@@ -1566,6 +1566,47 @@ def _validate_source_expression(node: ast.AST, text: str, source_path: str) -> N
 _GENERATED_CALL_NAMES = tuple(_TOP_LEVEL_CALL_NAMES) + ('database', 'explorer', 'kinetics')
 
 
+def _is_model_chemistry_call_assignment(target: str, value: ast.expr) -> bool:
+    """
+    Decide whether a single-target assignment is the one non-literal shape both guards accept:
+    ``modelChemistry = LevelOfTheory(...)`` / ``CompositeLevelOfTheory(...)``, whose real ARC/hybrid
+    value is a bare call Arkane exec's at load time rather than an ``ast.literal_eval``-able literal.
+
+    This is the SHARED accept-test for that one directive, called from BOTH the inbound source guard
+    (``_validate_source_statements``) and the outbound self-check (``_validate_generated_statements``).
+    The line is spliced verbatim from source to generated file, so what the inbound guard admits the
+    outbound guard must re-admit; keeping the decision in one place is what stops the two from drifting
+    apart again -- the drift that let this exact line pass on the way in and fail on the way out.
+
+    The call is routed through the SAME structural checker T3 uses when it EMITS this directive
+    (``t3.pdep.hybrid._validate_model_chemistry_expression``): validating the ``ast.unparse``
+    round-tripped node -- which that string-taking checker re-parses -- is equivalent to validating
+    the spliced text, because the AST is what decides exec semantics and the verbatim splice
+    reproduces it. The gate is deliberately on a genuine call node to one of the two known names: a
+    ``modelChemistry`` bound to some OTHER value returns False and falls through to the caller's
+    literal test, so a computed value stays refused.
+
+    Args:
+        target (str): The single assignment target's name.
+        value (ast.expr): The assignment's value node.
+
+    Returns:
+        bool: True if this is a structurally valid ``modelChemistry`` call assignment; False if the
+              value is not a ``modelChemistry`` call at all (leave it to the caller's literal test).
+
+    Raises:
+        ValueError: If it IS a ``modelChemistry`` call to a known name but fails structural
+                    validation. Each caller wraps this in its own error (a source ValueError inbound,
+                    a self-check RuntimeError outbound).
+    """
+    if not (target == 'modelChemistry' and isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id in _MODEL_CHEMISTRY_CALL_NAMES):
+        return False
+    _validate_model_chemistry_expression(target, ast.unparse(value))
+    return True
+
+
 def _validate_generated_statements(tree: ast.Module, text: str, dest_path: str) -> None:
     """
     Self-check the top-level statement list of the file this module is about to WRITE.
@@ -1598,7 +1639,15 @@ def _validate_generated_statements(tree: ast.Module, text: str, dest_path: str) 
                 and _get_call_name(node.value) in _GENERATED_CALL_NAMES):
             continue
         if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            target = node.targets[0].id
+            # Accept exactly what the inbound guard accepts for an assignment, via the shared helper:
+            # the one non-literal shape is ``modelChemistry = LevelOfTheory(...)``, spliced verbatim
+            # from an already-validated source. A malformed such call (helper raises) cannot reach here
+            # -- the inbound guard refuses it with the same checker -- so it correctly falls through to
+            # the RuntimeError below, which is the right response to this module emitting a bad one.
             try:
+                if _is_model_chemistry_call_assignment(target, node.value):
+                    continue
                 ast.literal_eval(node.value)
             except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
                 pass
@@ -1608,10 +1657,11 @@ def _validate_generated_statements(tree: ast.Module, text: str, dest_path: str) 
             f"Refusing to write '{dest_path}': the generated explorer input file text failed its own "
             f"self-check. Line {node.lineno} is a top-level {type(node).__name__} statement "
             f"({_source_snippet(node, text)!r}) that this module never emits and no validated source "
-            f"statement can become -- only calls to {sorted(_GENERATED_CALL_NAMES)}, bare literals and "
-            f"literal assignments belong here. Something spliced or rendered a statement into this file, "
-            f"which is a defect in this module (or an injection through one of its arguments), not a "
-            f"problem with the source file.")
+            f"statement can become -- only calls to {sorted(_GENERATED_CALL_NAMES)}, bare literals, "
+            f"literal assignments, and a validated 'modelChemistry = "
+            f"{'/'.join(_MODEL_CHEMISTRY_CALL_NAMES)}(...)' directive belong here. Something spliced or "
+            f"rendered a statement into this file, which is a defect in this module (or an injection "
+            f"through one of its arguments), not a problem with the source file.")
 
 
 def _validate_source_statements(tree: ast.Module, text: str, source_path: str) -> None:
@@ -1698,27 +1748,21 @@ def _validate_source_statements(tree: ast.Module, text: str, source_path: str) -
                     f"generates and appends -- so a source may not assign to it, however harmless the value.")
             # ``modelChemistry`` is the one directive whose real ARC/hybrid value is a bare
             # ``LevelOfTheory(...)``/``CompositeLevelOfTheory(...)`` call (which Arkane exec's at load
-            # time), not an ``ast.literal_eval``-able literal. Rather than grow a second model-chemistry
-            # allowlist here, route it through the SAME structural checker T3 uses when it EMITS this
-            # directive (``t3.pdep.hybrid._validate_model_chemistry_expression``); the AST is what
-            # decides exec semantics and the verbatim splice reproduces it, so validating the
-            # ``ast.unparse``-round-tripped node -- which that string-taking checker re-parses -- is
-            # equivalent to validating the spliced text. The gate is deliberately on a genuine call
-            # node to one of the two known names: the checker accepts any NON-call string as a plain
-            # label (injection-char check only), so a computed ``modelChemistry`` value must keep
-            # falling through to the refusal below rather than being handed over as a bare label.
-            if (target == 'modelChemistry' and isinstance(node.value, ast.Call)
-                    and isinstance(node.value.func, ast.Name)
-                    and node.value.func.id in _MODEL_CHEMISTRY_CALL_NAMES):
-                try:
-                    _validate_model_chemistry_expression(target, ast.unparse(node.value))
-                except ValueError as e:
-                    raise ValueError(
-                        f"Refusing to use '{source_path}' as an Arkane explorer/network source: line "
-                        f"{node.lineno} assigns a 'modelChemistry' value that fails structural validation "
-                        f"({_source_snippet(node, text)!r}): {e}. This source's text is spliced verbatim into "
-                        f"a NEW file Arkane will exec, so a malformed model-chemistry call is refused.") from e
-                continue
+            # time), not an ``ast.literal_eval``-able literal. It is accepted via the SAME shared
+            # helper the outbound self-check uses, so the inbound and outbound rules for this one
+            # non-literal shape cannot drift apart (the drift that let a spliced ``modelChemistry``
+            # line pass here and then fail its own self-check on the way out). The helper returns False
+            # for a ``modelChemistry`` bound to some OTHER value, which then keeps falling through to
+            # the literal refusal below rather than being handed over as a bare label.
+            try:
+                if _is_model_chemistry_call_assignment(target, node.value):
+                    continue
+            except ValueError as e:
+                raise ValueError(
+                    f"Refusing to use '{source_path}' as an Arkane explorer/network source: line "
+                    f"{node.lineno} assigns a 'modelChemistry' value that fails structural validation "
+                    f"({_source_snippet(node, text)!r}): {e}. This source's text is spliced verbatim into "
+                    f"a NEW file Arkane will exec, so a malformed model-chemistry call is refused.") from e
             try:
                 ast.literal_eval(node.value)
             except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError) as e:

--- a/tests/test_pdep/test_explorer_input_file.py
+++ b/tests/test_pdep/test_explorer_input_file.py
@@ -1407,6 +1407,36 @@ class TestGeneratedFileCannotBeInjectedThrough:
                 'network(isomers=["a"])\npressureDependence(method="MSC")\nexplorer(source=["a"])\n')
         _validate_generated_statements(tree=ast.parse(text), text=text, dest_path='/nonexistent/input.py')
 
+    @pytest.mark.parametrize('line', [
+        "modelChemistry = LevelOfTheory(method='wb97xd', basis='def2tzvp')",
+        "modelChemistry = LevelOfTheory(method='wb97xd', basis='def2tzvp', software='qchem')",
+        "modelChemistry = CompositeLevelOfTheory("
+        "freq=LevelOfTheory(method='wb97xd'), energy=LevelOfTheory(method='dlpno'))",
+    ])
+    def test_the_self_check_accepts_the_model_chemistry_line_the_source_guard_accepts(self, line):
+        """
+        The symmetric-guard fix: the ``modelChemistry = LevelOfTheory(...)`` directive is spliced
+        verbatim from an already-validated source, so the outbound self-check must re-admit exactly
+        what the inbound source guard admits. Before the fix this line failed its own self-check even
+        though the source guard accepted it, so the file was never written. Mirrors the source-side
+        acceptance test so a future divergence between the two fails here.
+        """
+        text = f'{line}\ndatabase(thermoLibraries=[])\nexplorer(source=["a"])\n'
+        _validate_generated_statements(tree=ast.parse(text), text=text, dest_path='/nonexistent/input.py')
+
+    @pytest.mark.parametrize('line', [
+        "modelChemistry = compute_level()",              # a call, but not a known LevelOfTheory name
+        "modelChemistry = LevelOfTheory(method=().__class__)",  # known name, non-literal argument
+        "notModelChemistry = LevelOfTheory(method='wb97xd')",   # right shape, wrong target name
+    ])
+    def test_the_self_check_still_refuses_a_non_model_chemistry_call_assignment(self, line):
+        """Accept exactly what the source guard accepts, no more: a call assignment that is not a
+        structurally valid ``modelChemistry`` directive stays refused by the self-check, so the
+        modelChemistry exception cannot be a hole for arbitrary computed assignments."""
+        text = f'{line}\ndatabase(thermoLibraries=[])\nexplorer(source=["a"])\n'
+        with pytest.raises(RuntimeError, match='failed its own self-check'):
+            _validate_generated_statements(tree=ast.parse(text), text=text, dest_path='/nonexistent/input.py')
+
     @pytest.mark.parametrize('target', ['explorer', 'database', 'species', 'kinetics', 'network',
                                         'Arrhenius', 'NASA', 'range'])
     def test_a_source_may_not_shadow_a_name_arkane_defines(self, target):
@@ -2185,32 +2215,25 @@ def test_real_hybrid_seed_smiles_resolves_to_the_networks_indexed_label():
 
 def test_real_hybrid_gets_past_seed_validation_through_the_full_writer(tmp_path):
     """End to end on the real seam: with resolution in place, driving the real hybrid through the
-    writer no longer raises the seed-label refusal. It currently stops one step further on, at the
-    generated-side modelChemistry guard (a defect carried forward -- see the xfail test below and
-    Remaining Work); this test pins that the SEED barrier itself is cleared."""
+    writer no longer raises the seed-label refusal. The write now completes (the generated-side
+    modelChemistry guard has been brought back into step with the source-side one -- see the full
+    end-to-end test below); this test pins specifically that the SEED barrier is cleared, i.e. the
+    resolved label reaches the summary rather than a seed-label refusal."""
     dest_path = str(tmp_path / 'input.py')
     kwargs = dict(DEFAULT_KWARGS)
     kwargs['seed_species'] = ('[O]C=O',)
     kwargs['bath_gas'] = {'Ar': 1.0}  # the real hybrid's bath gas, so bath-gas validation is reached
-    with pytest.raises(Exception) as exc_info:
-        write_arkane_explorer_input_file(source_path=REAL_HYBRID_PATH, dest_path=dest_path, **kwargs)
-    # The seed barrier is cleared: whatever stops the write now, it is NOT the seed-label refusal.
-    assert 'Seed species label' not in str(exc_info.value)
-    # And the concrete thing that stops it today is the generated-side modelChemistry guard.
-    assert isinstance(exc_info.value, RuntimeError)
-    assert 'modelChemistry' in str(exc_info.value)
+    summary = write_arkane_explorer_input_file(source_path=REAL_HYBRID_PATH, dest_path=dest_path, **kwargs)
+    # The seed barrier is cleared: the configured SMILES seed resolved to the network's indexed label
+    # rather than being refused as a non-literal label.
+    assert summary.seed_species == ('[O]C=O(1)',)
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "Defect carried forward from the branch below (i018-modelchem): _validate_generated_statements "
-    "rejects the 'modelChemistry = LevelOfTheory(...)' assignment that _validate_source_statements "
-    "now accepts, so the real hybrid does not yet survive the full writer. The modelChemistry "
-    "acceptance was only taught to the source-side guard, never the symmetric generated-side one. "
-    "Remove this marker when that generated-side guard learns the same acceptance."))
 def test_real_hybrid_survives_the_full_writer_and_emits_the_resolved_source(tmp_path):
     """The intended end state: the real hybrid writes a valid explorer input whose source is the
-    resolved label and which carries the modelChemistry directive. Pinned xfail(strict) until the
-    generated-side modelChemistry guard is fixed; it XPASSes (forcing this marker's removal) then."""
+    resolved label and which carries the modelChemistry directive. This is the symmetric-guard fix:
+    the generated-side self-check now accepts the ``modelChemistry = LevelOfTheory(...)`` line that
+    the source-side guard accepts, so the line survives the verbatim splice on the way out."""
     dest_path = str(tmp_path / 'input.py')
     kwargs = dict(DEFAULT_KWARGS)
     kwargs['seed_species'] = ('[O]C=O',)


### PR DESCRIPTION
**Stacked on #199 → #198 → #197.** Base is `i019-seed-label`, so this diff shows only its own change; GitHub retargets as each parent merges. Review in order.

## What this fixes

`t3/pdep/explorer/input_file.py` guards one boundary twice: `_validate_source_statements` on the way **in** (the untrusted network file it reads) and `_validate_generated_statements` on the way **out** (a self-check on the explorer input it is about to write). #198 taught the inbound guard to accept `modelChemistry = LevelOfTheory(...)`; the outbound one was not changed. Since that line is spliced **verbatim** source → generated, it became accepted on entry and refused on exit, so nothing was written at all:

```
RuntimeError: Refusing to write '.../round_0/explorer/input.py': the generated explorer input file
text failed its own self-check. Line 9 is a top-level Assign statement ("modelChemistry =
LevelOfTheory(...") that this module never emits and no validated source statement can become
```

That message's second clause had silently become false — which is the readable tell that the pair had drifted.

## The change

The accept-decision is extracted into one shared helper, `_is_model_chemistry_call_assignment(target, value)`, and **both** guards call it. The inbound guard's private copy is gone. The outbound guard now accepts exactly what the inbound guard accepts and no more: a `modelChemistry` bound to any other value, or a structurally invalid call, still falls through to the `RuntimeError`.

Sharing one helper rather than repeating the exception is the point of the change — an unexplained second copy is how the pair drifted in the first place.

The outbound error message no longer asserts that no validated source statement can become this line, and names the `modelChemistry = LevelOfTheory/CompositeLevelOfTheory(...)` directive as belonging there.

## Testing

- **Driven on the real artifact, end to end.** Seeding a loop run with the pilot's own round-0 hybrid now writes the explorer input (7963 bytes), carrying `modelChemistry = LevelOfTheory(method='wb97xd2023',basis='def2tzvp',software='gaussian')` at line 9 and `explorer(source=['[O]C=O(1)'], ...)` — the seed resolved by #199 — at line 165. No cluster, no quantum chemistry.
- The `xfail(strict=True)` test #199 left pinned to this defect is now an ordinary passing test, marker removed.
- Mutation: forcing the shared helper to return `False` turns nine tests red across both guards, including all three real-artifact tests. Restored, green.
- `tests/test_pdep`: **1929 passed**, 133 s.

## Known next defect, not chased

The run now reaches Arkane itself and stops there: `FileNotFoundError: 'qm/TS2.py'` at `arkane/statmech.py:372`. The hybrid's `transitionState('TS2', 'qm/TS2.py')` is relative to the hybrid's own directory, but the generated explorer input lives elsewhere, and Arkane opens that path against the process working directory. Tracked separately.

Worth noting the loop degrades well here: it reports `status 'failed'` with Arkane's stderr quoted, rather than crashing.