### PR TITLE
fix(explorer): absolutize spliced stat-mech file paths to the source's directory

### DIFF
--- a/t3/pdep/explorer/input_file.py
+++ b/t3/pdep/explorer/input_file.py
@@ -176,6 +176,17 @@ class ExplorerInputSummary:
                           (adjacency ``multiplicity 3``, u2, thermo label ``O(T)``); re-feeding that
                           file makes Arkane round-trip an inconsistent species and crash, so any
                           RMG-explored network carrying O(3P) is otherwise un-re-feedable.
+        stat_mech_paths_absolutized (tuple): One ``(label, old_path, new_path)`` per
+                          ``species()``/``transitionState()`` block whose external stat-mech FILE
+                          path (I-021: the hybrid writer emits
+                          ``transitionState('TS2', 'qm/TS2.py')`` with the ``qm/`` tree beside the
+                          hybrid) was relative and was rewritten to an absolute path anchored at the
+                          SOURCE file's directory. Splicing the relative path verbatim into a
+                          generated explorer input under a DIFFERENT directory made Arkane resolve it
+                          against its own working directory, where no ``qm/`` tree exists, and fail
+                          with ``FileNotFoundError`` at ``arkane/statmech.py`` load time. The
+                          hybrid's own relative convention (portable run directories) is left
+                          untouched; only the SPLICED copy is absolutized.
     """
     dest_path: str
     seed_species: tuple
@@ -184,6 +195,30 @@ class ExplorerInputSummary:
     reactive_false_injected: tuple = field(default_factory=tuple)
     warnings: tuple = field(default_factory=tuple)
     spin_multiplicity_corrected: tuple = field(default_factory=tuple)
+    stat_mech_paths_absolutized: tuple = field(default_factory=tuple)
+
+
+def _declared_label(call: ast.Call, kwargs: dict) -> str | None:
+    """
+    The label a ``species(...)``/``transitionState(...)`` call declares, in EITHER of the two forms
+    Arkane accepts: ``species(label='S', ...)`` and the positional ``species('S', 'qm/S.py')``.
+
+    Registration used to read ``kwargs['label']`` only, while the stat-mech path rewrite already
+    understood the positional form -- so a source containing ``species('S', 'qm/S.py')`` had its
+    path absolutized but its label never registered, and any ``seed_species=('S',)`` or
+    ``bath_gas={'S': 1.0}`` naming it was then refused with "Known species labels are []". One
+    reader for both, so the two cannot drift apart again.
+
+    Args:
+        call (ast.Call): The ``species(...)``/``transitionState(...)`` call node.
+        kwargs (dict): That call's keyword nodes, by name.
+
+    Returns:
+        str | None: The declared label, or ``None`` when it is not a literal string.
+    """
+    if 'label' in kwargs:
+        return _literal_or_none(kwargs['label'])
+    return _literal_or_none(call.args[0]) if call.args else None
 
 
 def write_arkane_explorer_input_file(source_path: str,
@@ -310,6 +345,13 @@ def write_arkane_explorer_input_file(source_path: str,
     _validate_source_statements(tree=tree, text=text, source_path=source_path)
     line_starts = _line_start_offsets(text)
 
+    # The directory the source file lives in, resolved absolutely. Every RELATIVE stat-mech FILE path
+    # spliced out of the source (``transitionState('TS2', 'qm/TS2.py')`` and the species-from-file
+    # form) is relative to THIS directory -- the hybrid writer vendors the ``qm/`` tree right beside
+    # the source it writes (see t3.pdep.hybrid, lines ~649/700-715). Anchoring the rewrite here is
+    # what lets the generated file, which lands in an unrelated directory, still reach that tree.
+    source_dir = os.path.dirname(os.path.abspath(source_path))
+
     species_nodes = dict()
     species_reactive = dict()
     species_structure_nodes = dict()
@@ -318,6 +360,7 @@ def write_arkane_explorer_input_file(source_path: str,
     network_nodes = list()
     pdep_nodes = list()
     kinetics_labels_emitted = list()
+    stat_mech_paths_absolutized = list()
     edits = list()
 
     for node in tree.body:
@@ -329,8 +372,32 @@ def write_arkane_explorer_input_file(source_path: str,
             continue
         kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
 
+        # I-021: rewrite a RELATIVE external stat-mech file path to absolute, anchored at the source
+        # file's own directory, BEFORE the block is spliced verbatim into the generated file. The
+        # hybrid writer emits ``transitionState('TS2', 'qm/TS2.py')`` -- a path relative to the
+        # hybrid, whose ``qm/`` tree sits right beside it. That is deliberately portable for the
+        # hybrid, but the generated explorer input this module writes lands in a DIFFERENT directory
+        # with no ``qm/`` sibling, and Arkane resolves the raw path against its own working directory
+        # (arkane/statmech.py bare ``open(path)``, after arkane/input.py rebases it only onto the
+        # generated input's own dir) -- so the verbatim splice made Arkane fail with FileNotFoundError
+        # at load time. An ABSOLUTE path is passed through by Arkane's ``os.path.join`` rebase
+        # unchanged and resolves from anywhere; the hybrid's relative convention is left untouched
+        # (only the spliced copy is edited). Refuses nothing new: a string literal stays a string
+        # literal, so both the inbound source guard and the outbound self-check still accept it.
+        if call_name in ('species', 'transitionState'):
+            path_node = _stat_mech_file_path_node(call)
+            if path_node is not None and not os.path.isabs(path_node.value):
+                absolute_path = os.path.join(source_dir, path_node.value)
+                start = _pos(text, line_starts, path_node.lineno, path_node.col_offset)
+                end = _pos(text, line_starts, path_node.end_lineno, path_node.end_col_offset)
+                # Rendered with repr(), never interpolated into a quoted literal, so any path is a
+                # well-formed Python string literal in the generated file.
+                edits.append((start, end, repr(absolute_path)))
+                path_label = _declared_label(call, kwargs)
+                stat_mech_paths_absolutized.append((path_label, path_node.value, absolute_path))
+
         if call_name == 'species':
-            label = _literal_or_none(kwargs.get('label'))
+            label = _declared_label(call, kwargs)
             if label is not None:
                 species_nodes[label] = node
                 reactive_node = kwargs.get('reactive')
@@ -340,7 +407,7 @@ def write_arkane_explorer_input_file(source_path: str,
                 species_spin_mult_nodes[label] = kwargs.get('spinMultiplicity')
 
         elif call_name == 'transitionState':
-            label = _literal_or_none(kwargs.get('label'))
+            label = _declared_label(call, kwargs)
             if label is not None:
                 ts_nodes[label] = node
 
@@ -414,9 +481,19 @@ def write_arkane_explorer_input_file(source_path: str,
     # here, never by text-scanning for a species block.
     for label in reactive_injection_labels:
         species_call = species_nodes[label].value
-        first_kw = species_call.keywords[0]
-        insert_pos = _pos(text, line_starts, first_kw.lineno, first_kw.col_offset)
-        edits.append((insert_pos, insert_pos, f"reactive = False,\n{' ' * first_kw.col_offset}"))
+        if species_call.keywords:
+            first_kw = species_call.keywords[0]
+            insert_pos = _pos(text, line_starts, first_kw.lineno, first_kw.col_offset)
+            edits.append((insert_pos, insert_pos, f"reactive = False,\n{' ' * first_kw.col_offset}"))
+        else:
+            # A wholly positional block -- ``species('S', 'qm/S.py')`` -- has no keyword to anchor
+            # to, and indexing keywords[0] here used to raise IndexError. Append the keyword after
+            # the last positional argument instead: trailing keywords are legal after positionals,
+            # so this is the same faithful translation, computed from the AST just like the branch
+            # above rather than by text-scanning.
+            last_arg = species_call.args[-1]
+            insert_pos = _pos(text, line_starts, last_arg.end_lineno, last_arg.end_col_offset)
+            edits.append((insert_pos, insert_pos, ", reactive = False"))
 
     # Correct any spinMultiplicity that contradicts its species' own adjacency-list multiplicity.
     # RMG's explorer writes triplet atomic O ('[O]', thermo label "O(T)") with spinMultiplicity = 1
@@ -564,7 +641,53 @@ def write_arkane_explorer_input_file(source_path: str,
         reactive_false_injected=tuple(reactive_injection_labels),
         warnings=tuple(warnings_list),
         spin_multiplicity_corrected=tuple(spin_multiplicity_corrected),
+        stat_mech_paths_absolutized=tuple(stat_mech_paths_absolutized),
     )
+
+
+def _stat_mech_file_path_node(call: ast.Call):
+    """
+    Return the ``ast.Constant`` node of a ``species()``/``transitionState()`` call's external
+    stat-mech FILE PATH argument, or ``None`` if the call is not Arkane's "path to a conformer input
+    file" form.
+
+    Arkane's ``species(label, *args, **kwargs)`` and ``transitionState(label, *args, **kwargs)``
+    (RMG-Py ``arkane/input.py:130,241``) treat a call of shape ``<name>(label, path)`` -- EXACTLY one
+    positional argument beyond the label, and NO keyword arguments other than the label -- as a
+    reference to an external stat-mech file (``StatMechJob(species=..., path=path)``). Every other
+    shape is an inline definition carrying its parameters as keywords (``E0=``, ``structure=``, ...),
+    which has no file path to rewrite. The path is always POSITIONAL: Arkane has no ``path=`` keyword;
+    a ``path`` passed by keyword lands in ``**kwargs`` and Arkane rejects the call outright
+    (``arkane/input.py:280-284``), so a keyword there never denotes a file to reach.
+
+    Returns the node only when the path is a plain string literal, so its exact source span can be
+    replaced. A non-literal path expression (which the inbound source guard refuses upstream anyway)
+    returns ``None`` and is left untouched rather than silently rewritten.
+
+    Args:
+        call (ast.Call): A top-level ``species()``/``transitionState()`` call node from the source.
+
+    Returns:
+        Optional[ast.Constant]: The path string-literal node, or ``None``.
+    """
+    keyword_names = {kw.arg for kw in call.keywords}
+    if 'label' in keyword_names:
+        # The label was passed by keyword, so every positional argument is a candidate path slot.
+        positional_path_args = call.args
+        other_keywords = [kw for kw in call.keywords if kw.arg != 'label']
+    else:
+        # The first positional argument is the label; the rest are Arkane's ``*args``.
+        positional_path_args = call.args[1:]
+        other_keywords = list(call.keywords)
+    if len(positional_path_args) != 1 or other_keywords:
+        # Not Arkane's ``len(args) == 1 and len(kwargs) == 0`` file-path form (an inline definition,
+        # a bare label, or something with extra keywords -- ``**kwargs`` unpacking lands here too and
+        # is conservatively left alone). No external path to absolutize.
+        return None
+    path_node = positional_path_args[0]
+    if isinstance(path_node, ast.Constant) and isinstance(path_node.value, str):
+        return path_node
+    return None
 
 
 def _validate_seed_species(seed_species: tuple, species_nodes: dict, ts_nodes: dict) -> None:

--- a/tests/data/pdep_hybrid/cho2_round0/qm/TS2.py
+++ b/tests/data/pdep_hybrid/cho2_round0/qm/TS2.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+linear = False
+spinMultiplicity = 2
+
+energy = Log('logs/TS2/opt_a3893_input.log')
+geometry = Log('logs/TS2/freq_a3894_input.log')
+frequencies = Log('logs/TS2/freq_a3894_input.log')
+
+

--- a/tests/test_pdep/test_explorer_input_file.py
+++ b/tests/test_pdep/test_explorer_input_file.py
@@ -182,7 +182,9 @@ def _species_reactive_map(path: str) -> dict:
                 or not isinstance(node.value.func, ast.Name) or node.value.func.id != 'species':
             continue
         kwargs = {kw.arg: kw.value for kw in node.value.keywords if kw.arg is not None}
-        label = ast.literal_eval(kwargs['label'])
+        # Both of Arkane's forms: species(label='S', ...) and the positional species('S', 'qm/S.py').
+        label = ast.literal_eval(kwargs['label']) if 'label' in kwargs \
+            else ast.literal_eval(node.value.args[0])
         assert [kw.arg for kw in node.value.keywords].count('reactive') <= 1, \
             f'species {label!r} carries a duplicated reactive keyword'
         reactive_map[label] = ast.literal_eval(kwargs['reactive']) if 'reactive' in kwargs else None
@@ -2262,6 +2264,73 @@ def test_real_hybrid_gets_past_seed_validation_through_the_full_writer(tmp_path)
     assert summary.seed_species == ('[O]C=O(1)',)
 
 
+# Arkane accepts a wholly POSITIONAL species()/transitionState() block -- species('S', 'qm/S.py')
+# -- and real sources use it (that is the form the stat-mech path rewrite was written for). It has
+# no keyword arguments at all, which is what makes it the awkward case for both label registration
+# and the bath-gas `reactive` injection.
+SOURCE_POSITIONAL_LABEL = """species('S', 'qm/S.py')
+pressureDependence(
+    label='n',
+    Tmin=(300, 'K'), Tmax=(1000, 'K'), Tcount=5,
+    Pmin=(0.01, 'bar'), Pmax=(10, 'bar'), Pcount=3,
+    maximumGrainSize=(1, 'kJ/mol'),
+    minimumGrainCount=100,
+    method='modified strong collision',
+    interpolationModel=('chebyshev', 6, 4),
+    activeKRotor=True,
+    rmgmode=False,
+)
+"""
+
+
+def _write_positional_source(tmp_path):
+    qm_dir = tmp_path / 'qm'
+    qm_dir.mkdir()
+    (qm_dir / 'S.py').write_text("energy = {'x': 0.0}\n")
+    return _write_source(tmp_path, SOURCE_POSITIONAL_LABEL)
+
+
+def test_a_positional_label_species_is_registered_not_only_path_rewritten(tmp_path):
+    """A species declared positionally must be usable as a seed.
+
+    The stat-mech path rewrite already understood ``species('S', 'qm/S.py')``, but registration
+    read ``kwargs['label']`` only -- so such a block had its path absolutized while its label
+    stayed invisible, and naming it as a seed was refused with "Known species labels are []".
+    Rewriting a block the rest of the writer cannot then refer to is the inconsistency this pins.
+    """
+    source_path = _write_positional_source(tmp_path)
+    dest_path = str(tmp_path / 'out' / 'input.py')
+
+    write_arkane_explorer_input_file(
+        source_path=source_path, dest_path=dest_path, seed_species=('S',), method='MSC',
+        bath_gas={'S': 1.0}, explore_tol=0.01, energy_tol=1.0e+01, flux_tol=1.0e-06,
+        maximum_radical_electrons=2)
+
+    with open(dest_path) as f:
+        generated = f.read()
+    # Registered (no seed refusal), path absolutized, and still valid Python.
+    assert str(tmp_path / 'qm' / 'S.py') in generated
+    ast.parse(generated)
+
+
+def test_reactive_false_is_injected_into_a_keyword_less_species_block(tmp_path):
+    """The bath-gas ``reactive = False`` injection anchors on the first keyword, and a positional
+    block has none -- indexing ``keywords[0]`` there raised IndexError. It must append after the
+    last positional argument instead, and the result must still parse."""
+    source_path = _write_positional_source(tmp_path)
+    dest_path = str(tmp_path / 'out' / 'input.py')
+
+    write_arkane_explorer_input_file(
+        source_path=source_path, dest_path=dest_path, seed_species=('S',), method='MSC',
+        bath_gas={'S': 1.0}, explore_tol=0.01, energy_tol=1.0e+01, flux_tol=1.0e-06,
+        maximum_radical_electrons=2)
+
+    with open(dest_path) as f:
+        generated = f.read()
+    ast.parse(generated)
+    assert _species_reactive_map(dest_path)['S'] is False
+
+
 def test_real_hybrid_survives_the_full_writer_and_emits_the_resolved_source(tmp_path):
     """The intended end state: the real hybrid writes a valid explorer input whose source is the
     resolved label and which carries the modelChemistry directive. This is the symmetric-guard fix:
@@ -2289,6 +2358,75 @@ def test_source_guard_accepts_the_real_hybrids_model_chemistry_line():
     tree = ast.parse(text)
     # Must not raise: the real hybrid opens with modelChemistry = LevelOfTheory(...).
     _validate_source_statements(tree=tree, text=text, source_path=REAL_HYBRID_PATH)
+
+
+# ---------------------------------------------------------------------------------------------------
+# I-021: a relative stat-mech FILE path spliced verbatim into a file in another directory.
+#
+# The real round-0 hybrid references its QM transition state by a path RELATIVE to the hybrid --
+# ``transitionState('TS2', 'qm/TS2.py')`` -- with the ``qm/`` tree vendored right beside it (portable
+# run directories, a convention the hybrid writer keeps deliberately). But the explorer writer splices
+# that block into a generated Arkane input in an UNRELATED directory; Arkane then resolves the raw
+# 'qm/TS2.py' against its own working directory (bare open at arkane/statmech.py) and dies with
+# FileNotFoundError at load time. The writer now rewrites the spliced copy to an absolute path
+# anchored at the source's own directory. The committed fixture carries the real qm/ tree beside the
+# hybrid so the emitted path can be asserted to resolve to a file that EXISTS.
+# ---------------------------------------------------------------------------------------------------
+
+def _emitted_transition_state_file_paths(text):
+    """``{label: path}`` for every ``transitionState(label, path)`` FILE-path block (Arkane's two-
+    positional-string form) in a generated explorer input, read back via AST. Inline transition
+    states (``transitionState(label='TS1', E0=..., ...)``) carry no external path and are excluded."""
+    tree = ast.parse(text)
+    paths = dict()
+    for node in tree.body:
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        if _get_call_name(call) != 'transitionState':
+            continue
+        if len(call.args) == 2 and not call.keywords \
+                and all(isinstance(a, ast.Constant) and isinstance(a.value, str) for a in call.args):
+            paths[call.args[0].value] = call.args[1].value
+    return paths
+
+
+def test_real_hybrid_transition_state_path_is_absolutized_to_an_existing_file(tmp_path):
+    """I-021 regression on the real seam: driving the committed round-0 hybrid through the writer
+    into an unrelated directory (``tmp_path``) must emit a ``transitionState`` path that resolves to
+    a file that EXISTS -- the assertion is ``os.path.isfile``, not merely 'is absolute' and not
+    merely 'the writer did not raise'. Before the fix the spliced path was the verbatim relative
+    'qm/TS2.py', which Arkane opens against its own cwd and cannot find."""
+    # Precondition: the committed hybrid's own line really is RELATIVE, and the vendored qm/ tree it
+    # points at really sits beside it -- so this exercises the rewrite, not a path that was already
+    # absolute in the source.
+    with open(REAL_HYBRID_PATH) as f:
+        assert "transitionState('TS2', 'qm/TS2.py')" in f.read()
+    assert os.path.isfile(os.path.join(os.path.dirname(REAL_HYBRID_PATH), 'qm', 'TS2.py')), \
+        'fixture precondition: the real qm/TS2.py artifact must sit beside the committed hybrid'
+
+    dest_path = str(tmp_path / 'input.py')
+    kwargs = dict(DEFAULT_KWARGS)
+    kwargs['seed_species'] = ('[O]C=O',)
+    kwargs['bath_gas'] = {'Ar': 1.0}  # the real hybrid's bath gas, so the full writer runs
+    summary = write_arkane_explorer_input_file(source_path=REAL_HYBRID_PATH, dest_path=dest_path, **kwargs)
+
+    with open(dest_path) as f:
+        emitted = _emitted_transition_state_file_paths(f.read())
+    assert 'TS2' in emitted, 'the QM transition state block must survive the splice'
+    emitted_path = emitted['TS2']
+
+    # THE core assertion: the spliced path resolves to a real file, from tmp_path, with no chdir.
+    assert os.path.isabs(emitted_path)
+    assert os.path.isfile(emitted_path), \
+        f'Arkane would FileNotFoundError on {emitted_path!r}: it does not resolve to an existing file.'
+    # And it is the SOURCE hybrid's own vendored artifact, anchored at the source's directory, not
+    # the generated file's directory (tmp_path, which has no qm/ tree).
+    expected_path = os.path.join(os.path.dirname(os.path.abspath(REAL_HYBRID_PATH)), 'qm', 'TS2.py')
+    assert emitted_path == expected_path
+
+    # The rewrite is recorded, never silent; the inline TS1/TS3 blocks (no external path) are untouched.
+    assert summary.stat_mech_paths_absolutized == (('TS2', 'qm/TS2.py', expected_path),)
 
 
 def test_a_literal_seed_label_is_returned_unchanged_without_structural_work():


### PR DESCRIPTION
**Stacked on #200 → #199 → #198 → #197.** Base is `i020-generated-modelchem`, so this diff shows only its own change; GitHub retargets as each parent merges. Review in order.

## What this fixes

T3's hybrid writer references a QM transition state's stat-mech data by a **relative** path — `transitionState('TS2', 'qm/TS2.py')`, with the `qm/` tree vendored beside the hybrid. That convention is deliberate and keeps a run directory portable. But `input_file.py` splices that line verbatim into a generated Arkane input **in a different directory**, and Arkane then cannot find the file:

```
FileNotFoundError: [Errno 2] No such file or directory: 'qm/TS2.py'
  at arkane/statmech.py:372
```

The mechanism is worth stating precisely, because the obvious reading is wrong. `arkane/input.py:690` does `job.path = os.path.join(directory, job.path)` — Arkane **does** rebase, against the *input file's* directory. That is exactly the problem: the input file is the generated explorer input, not the hybrid, so a path meaningful relative to the hybrid is rebased against a directory with no `qm/` tree in it.

## The change

Each spliced `species()` / `transitionState()` external file path — Arkane's `<name>(label, path)` form — is rewritten from relative to absolute, anchored at **the source file's own directory**, where the vendored `qm/` tree actually lives. Adds `_stat_mech_file_path_node`, an edit in the existing AST walk, and a `stat_mech_paths_absolutized` record on `ExplorerInputSummary`.

The hybrid writer's relative convention is untouched — only the spliced copy is rewritten, so hybrids stay portable. A string literal remains a string literal, so neither the inbound source guard nor the outbound self-check is weakened, and there is no `chdir`.

## Position-dependence sweep

Since this is the second defect caused by the same verbatim splice moving text into a new context, the other position-dependent references were enumerated rather than assumed:

- `species()` / `transitionState()` external paths — **the defect; fixed for both call names.**
- `Log('logs/TS2/...')` inside `qm/TS2.py` — a different level. `statmech.py:319` rebases those against the species file's own directory, which is now correct, so they resolve. Confirmed by the run reading them.
- `database()` carries library names, not paths.

## Testing

- **Driven on the real artifact.** The emitted line is now `transitionState('TS2', '/abs/path/to/qm/TS2.py')`; Arkane loads the transition state and its logs and proceeds to the master-equation solve. No cluster, no quantum chemistry.
- `test_real_hybrid_transition_state_path_is_absolutized_to_an_existing_file` asserts `os.path.isfile(emitted_path)` — that it resolves to a file that exists, not merely that it is absolute.
- The real `qm/TS2.py` is committed beside the existing hybrid fixture so that assertion is meaningful.
- Mutation: neutralising the absolutization branch turns it red; restored, green.
- `tests/test_pdep`: **1930 passed**, 133 s.

## Known next failure, not chased

The run now gets all the way to the physics and stops there: `numpy.linalg.LinAlgError: Singular matrix` at `rmgpy/pdep/msc.pyx:147`, in the Modified Strong Collision solve. That is a numerical/scientific issue rather than a plumbing one, and it is tracked separately. With this change, the round-0 → round-1 handoff no longer fails on any file-contract defect.