### PR TITLE
fix(pdep): strip every RMG index group so round-1 re-exploration completes

### DIFF
--- a/t3/pdep/parser.py
+++ b/t3/pdep/parser.py
@@ -186,21 +186,33 @@ def canonical_channel_pair(reactant_labels, product_labels) -> tuple:
 # genuinely single-run pairing as "did not come from one run". Distinct species have distinct base
 # labels (the base is the SMILES), so stripping never merges two real species -- the index only
 # ever disambiguates a base from itself.
-_RMG_INDEX_SUFFIX_RE = re.compile(r'\(\d+\)$')
+#
+# The index ACCUMULATES across the loop's rounds. A hybrid network (t3.pdep.hybrid) declares the
+# previous round's already-indexed labels (``O=C=O(5)``); when the next round explores that hybrid,
+# Arkane appends ANOTHER index to the network file it writes (``O=C=O(5)(3)``) while its
+# ``output.py`` keeps the single-indexed label -- so the two artifacts of THIS round sit one index
+# level apart. Stripping only the last group would leave them apart (``O=C=O`` vs ``O=C=O(5)``) and
+# refuse a genuinely single-run pairing (I-025). Every trailing group is therefore stripped, down to
+# the base label. This never merges two real species for the same reason one strip does not: a
+# SMILES-derived base never itself ends in ``(<int>)`` (charges are ``[..]``, ring bonds are bare
+# digits), so any trailing ``(<int>)`` group is an index, not identity.
+_RMG_INDEX_SUFFIX_RE = re.compile(r'(?:\(\d+\))+$')
 
 
 def strip_rmg_index_suffix(label: str) -> str:
     """
-    Strip RMG's trailing ``(<int>)`` disambiguation index from a species label.
+    Strip RMG's trailing ``(<int>)`` disambiguation index/indices from a species label.
 
-    ``'[O]C=O(1)' -> '[O]C=O'``; ``'O=C=O(5)' -> 'O=C=O'``; a label with no such suffix
-    (``'[C-]#[O+]'``, ``'[O]C=O'``) is returned unchanged.
+    ``'[O]C=O(1)' -> '[O]C=O'``; ``'O=C=O(5)' -> 'O=C=O'``; the accumulated multi-round form
+    ``'O=C=O(5)(3)' -> 'O=C=O'``; a label with no such suffix (``'[C-]#[O+]'``, ``'[O]C=O'``) is
+    returned unchanged.
 
     Args:
         label (str): A species label as written in an RMG network or Arkane output file.
 
     Returns:
-        str: The label with a single trailing ``(<int>)`` index removed, if present.
+        str: The label with EVERY trailing ``(<int>)`` index group removed, if present -- so a
+             label that has accumulated one index per round collapses to its base identity.
     """
     return _RMG_INDEX_SUFFIX_RE.sub('', label)
 

--- a/tests/test_pdep/test_parser.py
+++ b/tests/test_pdep/test_parser.py
@@ -243,6 +243,16 @@ def test_reaction_less_seed_is_accepted_when_reactions_not_required():
     ('[C-]#[O+]', '[C-]#[O+]'),   # no suffix -> unchanged
     ('[O]C=O', '[O]C=O'),         # no suffix -> unchanged
     ('Ar', 'Ar'),
+    # A hybrid round explores a network whose labels ALREADY carry one RMG index (the previous
+    # round's hybrid declares 'O=C=O(5)'); Arkane then appends a SECOND index when it writes that
+    # round's network file ('O=C=O(5)(3)'), while its output.py keeps the single-indexed label.
+    # Both artifacts must normalize to the same base identity, so EVERY trailing index group is
+    # stripped, not just the last one -- otherwise the two sides stay one index level apart and a
+    # genuinely single-run pairing is reported as "did not come from one run" (I-025).
+    ('O=C=O(5)(3)', 'O=C=O'),
+    ('O=[C]O(8)(4)', 'O=[C]O'),
+    ('[O]C=O(1)(1)', '[O]C=O'),
+    ('[H](6)(2)', '[H]'),
 ])
 def test_strip_rmg_index_suffix(label, expected):
     from t3.pdep.parser import strip_rmg_index_suffix

--- a/tests/test_pdep/test_pes_loop_source_seed.py
+++ b/tests/test_pdep/test_pes_loop_source_seed.py
@@ -14,14 +14,35 @@ It runs Arkane under ``rmg_env`` via ``run_arkane_job`` (same as ``test_pes_sa.p
 test) and costs ~30 s; it is the single end-to-end explorer test in the suite.
 """
 
+import json
 import os
 
-from t3.pdep.pes_loop import PES_LOOP_DIAGRAM_ONLY, run_pes_loop
+from t3.pdep.hybrid import QMEnergySettings, write_hybrid_network_input_file
+from t3.pdep.pes_loop import PES_LOOP_DIAGRAM_ONLY, PES_LOOP_MAX_ROUNDS, run_pes_loop
+from t3.pdep.pes_qm import _explored_network_path
+from t3.pdep.pes_rounds import hybrid_network_path
 from t3.schema import PESLoopConfig
 
 _SOURCE_SEED_PATH = os.path.join(
     os.path.dirname(__file__), '..', 'data', 'pdep_source_seeds', 'cho2_source',
     'network_cho2_source.py')
+
+# The REAL committed CHO2 round-0 conformer data (Arkane-extracted E0/frequencies/imaginary for
+# both wells and the QM'd transition state, on one self-consistent energy reference), used to
+# replay the QM the pilot run computed on the cluster without submitting anything.
+_CHO2_CONFORMERS_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'data', 'pdep_hybrid', 'cho2_round0', 'conformers.json')
+_CHO2_ENERGY_SETTINGS = QMEnergySettings(
+    model_chemistry="LevelOfTheory(method='wb97xd2023',basis='def2tzvp',software='gaussian')",
+    atom_energies={
+        'Br': -2574.174533595486, 'C': -37.84706210301937, 'Cl': -460.1467876783656,
+        'F': -99.73955550924293, 'H': -0.5006557872395249, 'N': -54.584995947182875,
+        'O': -75.07252406126821, 'S': -398.1105530401693,
+    },
+    tunneling='Eckart',
+)
+_CHO2_QM_TS = 'TS2'
+_CHO2_QM_WELLS = ('O=[C]O(8)', '[O]C=O(1)')
 
 
 def _source_only_config(network_path):
@@ -58,3 +79,53 @@ def test_diagram_only_runs_end_to_end_from_a_source_only_seed(tmp_path):
     assert result.final_network_path is not None
     assert os.path.isfile(result.final_network_path)
     assert os.path.getsize(result.final_network_path) > 0
+
+
+def _replay_qm_runner(candidates, paths, config, network_id, adopted=None):
+    """A ``qm_runner`` that replays the pilot's already-computed QM instead of submitting to the
+    cluster: it folds the REAL committed CHO2 conformers into a hybrid network through the REAL
+    ``write_hybrid_network_input_file`` -- exactly what ``t3.pdep.pes_qm.arc_qm_runner`` does after
+    ARC converges, minus the (gated) cluster submission and capture. The hybrid's source is this
+    round's own explored network, so the labels it carries are the ones the loop itself produced.
+    """
+    with open(_CHO2_CONFORMERS_PATH) as f:
+        conf = json.load(f)
+    write_hybrid_network_input_file(
+        source_path=_explored_network_path(paths, network_id),
+        dest_path=hybrid_network_path(paths, network_id),
+        method='MSC',
+        qm_transition_states={_CHO2_QM_TS: conf[_CHO2_QM_TS]},
+        qm_wells={well: conf[well] for well in _CHO2_QM_WELLS},
+        energy_settings=_CHO2_ENERGY_SETTINGS,
+    )
+    return frozenset({_CHO2_QM_TS}), (_CHO2_QM_TS,)
+
+
+def test_round_one_reexploration_of_a_real_hybrid_completes(tmp_path):
+    """The loop's OWN round-0 -> round-1 path, through the REAL explorer and the REAL committed
+    hybrid data, must complete -- not trip the output-vs-network label check (I-025).
+
+    Round 0 explores the source-only CHO2 seed (real Arkane); a replay ``qm_runner`` folds the real
+    committed QM conformers into a hybrid through the real ``write_hybrid_network_input_file``; the
+    loop then re-explores that hybrid (real Arkane) and runs the real
+    ``_check_final_network_payload``. The hybrid's species labels already carry one RMG index
+    (``O=C=O(5)``) and Arkane appends a second when it writes the round's network file
+    (``O=C=O(5)(3)``) while ``output.py`` keeps the single-indexed label; a normalization that
+    strips only one index level refuses this genuinely single-run pairing. This test is red before
+    the fix (final network stays round 0's pre-QM surface and the reason carries the mismatch) and
+    green after it. Only the cluster submission is replayed -- every explore, the ME sensitivity
+    analysis, the hybrid write and the check run unfaked, against real data.
+    """
+    result = run_pes_loop(_source_only_config(os.path.abspath(_SOURCE_SEED_PATH)),
+                          str(tmp_path), qm_runner=_replay_qm_runner)
+
+    # The guard must NOT refuse this pairing: the two artifacts describe the same network.
+    assert 'do not describe the same network' not in (result.reason or ''), result.reason
+    assert result.status == PES_LOOP_MAX_ROUNDS, (result.status, result.reason)
+
+    # The reported final network is the QM-informed round-1 re-exploration of the hybrid (under
+    # round_1/), not round 0's pre-QM surface -- i.e. the bonus re-exploration was ACCEPTED.
+    assert result.final_network_path is not None, result.reason
+    assert os.path.isfile(result.final_network_path)
+    assert os.path.join('round_1', 'explorer') in result.final_network_path, result.final_network_path
+    assert 'QM-informed re-exploration' in (result.reason or ''), result.reason


### PR DESCRIPTION
Eighth and final defect on the round-0 → round-1 handoff. With the master equation solving, round 1 ran to the end of the physics and then tripped the loop's own output-vs-network consistency check.

## The defect

`strip_rmg_index_suffix` removed a **single** trailing `(<int>)` group. But the index **accumulates across rounds**: a hybrid network declares the previous round's already-indexed labels (`O=C=O(5)`), and when the next round explores that hybrid, Arkane appends *another* index to the network file it writes (`O=C=O(5)(3)`) while its `output.py` keeps the single-indexed form. The two artifacts of one run therefore sit one index level apart, and stripping only the last group left them apart (`O=C=O` vs `O=C=O(5)`) — so a genuinely single-run pairing was refused.

```
-_RMG_INDEX_SUFFIX_RE = re.compile(r'\(\d+\)$')
+_RMG_INDEX_SUFFIX_RE = re.compile(r'(?:\(\d+\))+$')
```

## Why stripping every group is safe

The same argument that licensed stripping one: the index only ever disambiguates a base label from itself, and a SMILES-derived base never itself ends in `(<int>)` — charges are bracketed (`[C-]#[O+]`), ring closures are bare digits. So any trailing `(<int>)` group is an index, not identity, and collapsing all of them cannot merge two distinct species.

This deliberately does **not** loosen the consistency check, which exists because a mismatched pairing genuinely occurred before and produced a silently wrong result. The guard was right; the normalization it relied on was incomplete.

## Verification

Verified independently by regenerating the hybrid through the production entry point and driving the real explorer on it:

- **Round 1 completes** — final network and PES diagram both produced, no failure status.
- **The physics is unchanged, exactly.** Rate coefficients are bit-identical to the pre-fix run: `k_rev (TST) = A=8.73653e+11 s⁻¹, n=0.308264, Ea=106.537 kJ/mol`, and with tunneling `A=0.201422, n=3.90893, Ea=71.7449 kJ/mol`. This change is bookkeeping downstream of the solve and must not move the numbers — it doesn't.
- Zero `Singular matrix` occurrences; both `network0_full.py` and `network0_reduced.py` written.
- Mutation: reverting the regex to the single-strip form turns 5 tests red, including `test_round_one_reexploration_of_a_real_hybrid_completes` — the real-artifact test, not a fixture.
- `tests/test_pdep`: **1915 passed**, up from 1910. Tests added, none removed.

With this, the loop explores a surface, computes a transition state on a cluster, splices it back with matched degrees of freedom, re-explores its own output, and completes round 1 with a real rate coefficient.