### PR TITLE
feat(pdep): colour the PES diagram by energy provenance

### DIFF
--- a/t3/pdep/diagram.py
+++ b/t3/pdep/diagram.py
@@ -21,11 +21,21 @@ configuration overall, and the diagram data says so via ``reference_kind``.
 from dataclasses import dataclass
 
 import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
 
 from t3.pdep.parser import (PDepNetwork,
                             PDepNetworkE0,
                             parse_pdep_network_e0_file,
                             parse_pdep_network_file)
+from t3.pdep.provenance import (PROVENANCE_CONFIDENCE,
+                                PROVENANCE_FAMILY,
+                                PROVENANCE_GAV,
+                                PROVENANCE_LABELS,
+                                PROVENANCE_LIBRARY,
+                                PROVENANCE_QM,
+                                PROVENANCE_UNKNOWN,
+                                classify_provenance,
+                                combine_channel_provenance)
 
 # The file name the explorer adapter writes the diagram under, inside the exploration run
 # directory (next to Arkane's own input.py/output.py for that run).
@@ -38,23 +48,42 @@ CONFIGURATION_KIND_ISOMER = 'isomer'
 CONFIGURATION_KIND_REACTANT_CHANNEL = 'reactant_channel'
 CONFIGURATION_KIND_PRODUCT_CHANNEL = 'product_channel'
 
-# One categorical hue per configuration role plus one for transition states, assigned in fixed
-# order by the job each color does (identity), all four validated together for colorblind-safe
-# adjacent-pair separation on a white surface (OKLab CVD dE >= 8; the aqua's 2.7:1 surface
-# contrast is relieved by every level carrying a direct text label).
-_COLOR_ISOMER = '#2a78d6'             # blue
-_COLOR_REACTANT_CHANNEL = '#eb6834'   # orange
-_COLOR_PRODUCT_CHANNEL = '#1baf7a'    # aqua
-_COLOR_TRANSITION_STATE = '#4a3aa7'   # violet
+# Every level -- isomer, channel and transition state -- is coloured by the PROVENANCE of its
+# energy, not by its type (type stays readable from position: reactant channels left, isomers
+# centre, product channels right; transition states at midpoints with dotted connectors). The four
+# provenance classes are ordered by decreasing confidence (QM -> library -> family -> GAV) and
+# mapped onto the viridis sequential ramp: viridis is perceptually uniform, CVD-safe for all common
+# colour-vision types, AND monotonic in luminance, so the four classes stay distinguishable in
+# greyscale -- the case that matters when someone PRINTS the diagram to judge whether a surface is
+# trustworthy. QM (highest confidence) is the darkest end and reads as the most solid; GAV the
+# lightest. The samples avoid viridis's extreme-light tail (>0.88) so even the lowest-confidence
+# bar keeps enough contrast on a white surface (every level also carries a direct text label, as in
+# the type-coloured original). "Unknown provenance" sits OUTSIDE the ramp -- a neutral grey drawn
+# DOTTED -- so an honest gap can never be mistaken for one of the four classes.
+_VIRIDIS = plt.get_cmap('viridis')
+
+
+def _hex(rgba) -> str:
+    """Format a matplotlib RGBA tuple as a ``#rrggbb`` string (alpha dropped)."""
+    r, g, b = (int(round(channel * 255)) for channel in rgba[:3])
+    return f'#{r:02x}{g:02x}{b:02x}'
+
+
+_COLOR_PROVENANCE = {
+    PROVENANCE_QM: _hex(_VIRIDIS(0.00)),       # dark violet-blue: most trustworthy, most solid
+    PROVENANCE_LIBRARY: _hex(_VIRIDIS(0.38)),  # teal
+    PROVENANCE_FAMILY: _hex(_VIRIDIS(0.66)),   # green
+    PROVENANCE_GAV: _hex(_VIRIDIS(0.86)),      # yellow-green: least trustworthy, lightest
+    PROVENANCE_UNKNOWN: '#8a8a8a',             # neutral grey, drawn dotted (see below)
+}
+# The linestyle each provenance class draws its level bar in. All four known classes are solid;
+# unknown is dotted so it is distinct from every ramp colour even in greyscale.
+_LINESTYLE_PROVENANCE = {PROVENANCE_UNKNOWN: (0, (1, 1))}
+_DEFAULT_LEVEL_LINESTYLE = 'solid'
+
 _COLOR_BARRIERLESS = '#7a7a7a'        # neutral gray, dashed: "connected, no barrier datum"
 _COLOR_TEXT_PRIMARY = '#0b0b0b'
 _COLOR_TEXT_SECONDARY = '#52514e'
-
-_KIND_COLORS = {
-    CONFIGURATION_KIND_ISOMER: _COLOR_ISOMER,
-    CONFIGURATION_KIND_REACTANT_CHANNEL: _COLOR_REACTANT_CHANNEL,
-    CONFIGURATION_KIND_PRODUCT_CHANNEL: _COLOR_PRODUCT_CHANNEL,
-}
 
 # Horizontal geometry, in column units (one column per configuration).
 _CONFIG_HALF_WIDTH = 0.27
@@ -79,11 +108,17 @@ class PESConfiguration:
         kind (str): One of the ``CONFIGURATION_KIND_*`` constants.
         e0 (float): The configuration E0 (kJ/mol) as declared in the network file.
         relative_e0 (float): The E0 after the normalization shift (kJ/mol).
+        provenance (str): The ``PROVENANCE_*`` class of this configuration's energy -- the worst
+            (lowest-confidence) provenance over its species, since a channel's asymptote energy is
+            only as trustworthy as its least-trustworthy fragment. ``PROVENANCE_UNKNOWN`` for
+            construction sites that predate provenance (default), so the field never has to be
+            passed by callers that do not compute it.
     """
     labels: tuple
     kind: str
     e0: float
     relative_e0: float
+    provenance: str = PROVENANCE_UNKNOWN
 
 
 @dataclass(frozen=True)
@@ -100,12 +135,16 @@ class PESTransitionState:
         relative_e0 (Optional[float]): The E0 after the normalization shift, or ``None``.
         reactants (tuple): The reactant-side configuration key (canonically ordered labels).
         products (tuple): The product-side configuration key (canonically ordered labels).
+        provenance (str): The ``PROVENANCE_*`` class of this transition state's barrier energy,
+            read from the path reaction's ``kinetics`` comment. ``PROVENANCE_UNKNOWN`` default, as
+            for ``PESConfiguration``.
     """
     label: str | None
     e0: float | None
     relative_e0: float | None
     reactants: tuple
     products: tuple
+    provenance: str = PROVENANCE_UNKNOWN
 
 
 @dataclass(frozen=True)
@@ -144,6 +183,17 @@ def compute_pes_diagram_data(network: PDepNetwork, e0: PDepNetworkE0) -> PESDiag
     Returns:
         PESDiagramData: The normalized levels.
     """
+    # Provenance of each species' thermo, classified once from its network-file ``thermo`` comment
+    # (absent comment -> PROVENANCE_UNKNOWN). A configuration's provenance is the worst over its
+    # species (combine_channel_provenance); a transition state's comes from its reaction's kinetics
+    # comment below.
+    species_provenance = {label: classify_provenance(comment)
+                          for label, comment in network.species_thermo_comments.items()}
+
+    def _config_provenance(config_key):
+        return combine_channel_provenance(
+            species_provenance.get(label, PROVENANCE_UNKNOWN) for label in config_key)
+
     configurations = []
     seen_keys = dict()
     for kind, channels in (
@@ -196,6 +246,7 @@ def compute_pes_diagram_data(network: PDepNetwork, e0: PDepNetworkE0) -> PESDiag
             relative_e0=ts_e0 - reference_e0 if ts_e0 is not None else None,
             reactants=sides[0],
             products=sides[1],
+            provenance=classify_provenance(path_reaction.kinetics_comment),
         ))
 
     return PESDiagramData(
@@ -204,7 +255,8 @@ def compute_pes_diagram_data(network: PDepNetwork, e0: PDepNetworkE0) -> PESDiag
         reference_kind=reference_kind,
         configurations=tuple(
             PESConfiguration(labels=key, kind=kind, e0=energy,
-                             relative_e0=energy - reference_e0)
+                             relative_e0=energy - reference_e0,
+                             provenance=_config_provenance(key))
             for key, kind, energy in configurations),
         transition_states=tuple(transition_states),
     )
@@ -288,12 +340,13 @@ def _build_pes_figure(data: PESDiagramData):
 
     fig, ax = plt.subplots(figsize=(max(7.0, 1.9 * len(ordered) + 1.5), 6.5))
 
-    # Configuration level bars with direct labels.
+    # Configuration level bars with direct labels, coloured by energy provenance.
     for config in ordered:
         x = x_by_key[config.labels]
-        color = _KIND_COLORS[config.kind]
+        color = _COLOR_PROVENANCE[config.provenance]
+        linestyle = _LINESTYLE_PROVENANCE.get(config.provenance, _DEFAULT_LEVEL_LINESTYLE)
         ax.hlines(y=config.relative_e0, xmin=x - _CONFIG_HALF_WIDTH, xmax=x + _CONFIG_HALF_WIDTH,
-                  colors=color, linewidth=2.6, zorder=3)
+                  colors=color, linewidth=2.6, linestyles=linestyle, zorder=3)
         ax.annotate(_format_channel_label(config.labels),
                     xy=(x, config.relative_e0), xytext=(0, -10), textcoords='offset points',
                     ha='center', va='top', fontsize=7.5, color=_COLOR_TEXT_PRIMARY, zorder=4,
@@ -328,14 +381,19 @@ def _build_pes_figure(data: PESDiagramData):
         points=tuple((x, ts.relative_e0) for ts, x, _, _ in ts_positions),
         min_dx=2.0 * _TS_SPREAD + 0.01, min_dy=0.05 * span)
     for (ts, x, x1, x2), annotation_level in zip(ts_positions, annotation_levels):
+        ts_color = _COLOR_PROVENANCE[ts.provenance]
+        ts_linestyle = _LINESTYLE_PROVENANCE.get(ts.provenance, _DEFAULT_LEVEL_LINESTYLE)
         ax.hlines(y=ts.relative_e0, xmin=x - _TS_HALF_WIDTH, xmax=x + _TS_HALF_WIDTH,
-                  colors=_COLOR_TRANSITION_STATE, linewidth=2.2, zorder=3)
+                  colors=ts_color, linewidth=2.2, linestyles=ts_linestyle, zorder=3)
         for x_config, key in ((x1, ts.reactants), (x2, ts.products)):
             config_e0 = next(c.relative_e0 for c in ordered if c.labels == key)
             direction = 1 if x_config < x else -1
+            # Connectors are drawn in a neutral grey, not the provenance colour: they carry no
+            # energy of their own, so tinting them would imply a provenance the connection does
+            # not have. The provenance colour lives on the level bars, which are the energies.
             ax.plot([x_config + direction * _CONFIG_HALF_WIDTH, x - direction * _TS_HALF_WIDTH],
                     [config_e0, ts.relative_e0],
-                    color=_COLOR_TRANSITION_STATE, linewidth=0.9, linestyle=':', zorder=2)
+                    color=_COLOR_BARRIERLESS, linewidth=0.9, linestyle=':', zorder=2)
         annotation = f'{ts.label} ({ts.relative_e0:.1f})' if ts.label else f'{ts.relative_e0:.1f}'
         ax.annotate(annotation,
                     xy=(x, ts.relative_e0), xytext=(0, 4 + 11 * annotation_level),
@@ -371,6 +429,21 @@ def _build_pes_figure(data: PESDiagramData):
         ax.spines[spine].set_visible(False)
     ax.yaxis.grid(True, linewidth=0.4, alpha=0.25)
     ax.set_axisbelow(True)
+
+    # Legend: one entry per provenance class ACTUALLY DRAWN (configurations plus transition states
+    # that got an energy level), ordered by decreasing confidence so it reads QM -> ... -> unknown
+    # top to bottom. Only present classes are shown, so a diagram with no estimates does not claim
+    # one exists; "unknown" appears only when a level genuinely could not be classified.
+    present = {config.provenance for config in ordered}
+    present |= {ts.provenance for ts in data.transition_states if ts.relative_e0 is not None}
+    legend_classes = sorted(present, key=lambda p: PROVENANCE_CONFIDENCE[p], reverse=True)
+    handles = [Line2D([0], [0], color=_COLOR_PROVENANCE[p], linewidth=2.6,
+                      linestyle=_LINESTYLE_PROVENANCE.get(p, _DEFAULT_LEVEL_LINESTYLE),
+                      label=PROVENANCE_LABELS[p])
+               for p in legend_classes]
+    ax.legend(handles=handles, title='Energy provenance', loc='best', fontsize=7.5,
+              title_fontsize=8, framealpha=0.9, borderpad=0.6, labelspacing=0.5)
+
     fig.tight_layout()
     return fig
 

--- a/t3/pdep/parser.py
+++ b/t3/pdep/parser.py
@@ -297,6 +297,13 @@ class PDepNetwork:
                                    one to hand ARC a real molecule. Default ``{}`` so every existing
                                    ``PDepNetwork(...)`` construction site (which never passes this
                                    keyword) keeps working unchanged.
+        species_thermo_comments (dict): Species label -> the ``comment`` text of that species'
+                                   ``thermo = NASA(..., comment='''...''')`` keyword, for every
+                                   ``species(...)`` call that carries one. These comments are what
+                                   ``t3.pdep.provenance`` reads to colour a well/channel level on
+                                   the PES diagram by where its energy came from. A species with no
+                                   thermo comment is simply absent from this dict. Default ``{}`` so
+                                   every existing construction site keeps working unchanged.
     """
     network_id: str
     path: str
@@ -310,6 +317,7 @@ class PDepNetwork:
     product_channels_declared: bool = False
     source_hash: str | None = None
     species_structures: dict = field(default_factory=dict)
+    species_thermo_comments: dict = field(default_factory=dict)
 
     def expected_net_reaction_count(self) -> int:
         """
@@ -836,6 +844,7 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
 
     species_labels = list()
     species_structures = dict()
+    species_thermo_comments = dict()
     transition_state_labels = list()
     path_reactions = list()
     network_label = None
@@ -861,6 +870,9 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
                 structure = _species_structure(kwargs.get('structure'))
                 if structure is not None:
                     species_structures[label] = structure
+                thermo_comment = _species_thermo_comment(kwargs.get('thermo'))
+                if thermo_comment:
+                    species_thermo_comments[label] = thermo_comment
 
         elif call_name == 'transitionState':
             label = _literal_or_raise(kwargs.get('label'), path=path, keyword='label',
@@ -924,6 +936,7 @@ def parse_pdep_network_text(text: str, network_id: str, path: str = '',
         product_channels_declared=product_channels_declared,
         source_hash=source_hash,
         species_structures=species_structures,
+        species_thermo_comments=species_thermo_comments,
     )
 
 
@@ -1393,6 +1406,29 @@ def _species_structure(node) -> str | None:
     if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
         return arg.value
     return None
+
+
+def _species_thermo_comment(node) -> str:
+    """
+    Extract the ``comment`` text from a species' ``thermo`` keyword value node, if any.
+
+    A ``species(...)`` call's thermo is written as ``thermo = NASA(..., comment='''...''')`` (or
+    ``ThermoData``/``Wilhoit``); the ``comment`` string carries the provenance markers T3 reads to
+    colour the PES diagram (see ``t3.pdep.provenance``). This mirrors how ``_parse_reaction`` reads
+    a reaction's ``kinetics`` ``comment``. Fails open (returns ``''``) for any shape other than a
+    thermo call carrying a literal-string ``comment`` -- a missing comment only leaves that level's
+    provenance unknown, it never changes the reported topology.
+
+    Args:
+        node: The AST value node bound to a ``thermo`` keyword (or ``None``).
+
+    Returns:
+        str: The comment text, or ``''`` if absent/unreadable.
+    """
+    if not isinstance(node, ast.Call):
+        return ''
+    comment = _literal_or_none(_call_keywords(node).get('comment'))
+    return comment if isinstance(comment, str) else ''
 
 
 def _literal_or_none(node):

--- a/t3/pdep/provenance.py
+++ b/t3/pdep/provenance.py
@@ -1,0 +1,154 @@
+"""
+t3 pdep provenance module
+
+Classify WHERE the energy of a stationary point on a P-dep surface came from, so T3's PES diagram
+can colour every level by the trustworthiness of its energy rather than by its type. Four
+provenance classes, ordered by decreasing confidence:
+
+1. ``PROVENANCE_QM``      -- computed by quantum chemistry in this campaign.
+2. ``PROVENANCE_LIBRARY`` -- taken from a curated thermo library, or a kinetics library via ILT.
+3. ``PROVENANCE_FAMILY``  -- estimated from a reaction-family template or tree node (ILT).
+4. ``PROVENANCE_GAV``     -- thermo group-additivity estimation.
+
+plus ``PROVENANCE_UNKNOWN`` for a level whose provenance genuinely cannot be read -- rendered
+distinctly and named in the legend, never silently folded into one of the four.
+
+The classifier reads the ``comment=`` text RMG/Arkane write into a species' ``thermo=NASA(...)`` or
+a reaction's ``kinetics=Arrhenius(...)`` call in the network file. The one trap those comments set
+is that they are **concatenated, not replaced**: an RMG estimate is written first and this run's
+quantum-chemistry result is appended AFTER it and overrides it. Concretely, a QM'd well reads
+
+    Thermo group additivity estimation: group(...)...Thermo library: thermojobs
+
+and is QM, not GAV -- ``thermojobs`` (thermo) and ``kineticsjobs`` (kinetics) are ARC/Arkane's own
+output libraries, this run's quantum chemistry written back as a library. A first-match parse would
+label it GAV, the exact inversion the diagram exists to prevent. So the classifier finds every
+provenance marker in the comment and lets the **last** one (largest start index) win.
+"""
+
+import re
+from collections.abc import Iterable
+
+PROVENANCE_QM = 'qm'
+PROVENANCE_LIBRARY = 'library'
+PROVENANCE_FAMILY = 'family'
+PROVENANCE_GAV = 'gav'
+PROVENANCE_UNKNOWN = 'unknown'
+
+# Higher means more trustworthy. Used to pick the worst-link provenance of a multi-species channel
+# (a bimolecular asymptote's energy is only as trustworthy as its least-trustworthy fragment) and
+# to order the legend. ``PROVENANCE_UNKNOWN`` is the floor so a channel with any unreadable
+# fragment is reported unknown rather than given a fragment's class it does not deserve.
+PROVENANCE_CONFIDENCE = {
+    PROVENANCE_QM: 4,
+    PROVENANCE_LIBRARY: 3,
+    PROVENANCE_FAMILY: 2,
+    PROVENANCE_GAV: 1,
+    PROVENANCE_UNKNOWN: 0,
+}
+
+# Human-readable class names for the diagram legend.
+PROVENANCE_LABELS = {
+    PROVENANCE_QM: 'QM (this campaign)',
+    PROVENANCE_LIBRARY: 'Library',
+    PROVENANCE_FAMILY: 'Family estimate (ILT)',
+    PROVENANCE_GAV: 'GAV estimate',
+    PROVENANCE_UNKNOWN: 'Unknown provenance',
+}
+
+# The library names ARC/Arkane give this run's own quantum-chemistry output when it writes it back
+# into the network file as a "library". A ``Thermo library``/``Reaction library`` marker naming one
+# of these is QM; any other name is a genuinely external, curated library. These are ARC's standard
+# output-library names, independent of T3's configured ``library_name``; extend the set if a
+# campaign is found to use a different one.
+_QM_OUTPUT_LIBRARY_NAMES = frozenset({'thermojobs', 'kineticsjobs'})
+
+# One entry per provenance marker RMG/Arkane emits into a comment: (kind, keyword regex). The
+# regex matches only the marker KEYWORD, never the trailing name -- capturing the name greedily
+# breaks on concatenated comments where the next marker abuts the previous name with no separator
+# (e.g. ``primaryThermoLibraryThermo library: thermojobs``). The name is read separately, only for
+# the marker that wins, by ``_library_name_after``.
+_MARKERS = (
+    (PROVENANCE_GAV, re.compile(r'group additivity estimation')),
+    ('_thermo_library', re.compile(r'Thermo library:')),
+    ('_reaction_library', re.compile(r'Reaction library:')),
+    (PROVENANCE_FAMILY, re.compile(r'Estimated (?:using template|from node)')),
+)
+_LIBRARY_KINDS = ('_thermo_library', '_reaction_library')
+
+
+def _library_name_after(comment: str, marker_end: int) -> str:
+    """
+    Read the library name that follows a ``Thermo library:``/``Reaction library:`` marker.
+
+    The name is the first whitespace/quote-delimited token after the marker keyword; any
+    surrounding quotes (``Reaction library: 'kineticsjobs'``) are stripped. This is only ever
+    called for the LAST marker in the comment, so nothing recognised follows the name.
+
+    Args:
+        comment (str): The full comment text.
+        marker_end (int): The index just past the marker keyword.
+
+    Returns:
+        str: The library name, or ``''`` if none could be read.
+    """
+    match = re.match(r"\s*['\"]?([^\s'\",]+)", comment[marker_end:])
+    return match.group(1) if match else ''
+
+
+def classify_provenance(comment: str | None,
+                        qm_library_names: frozenset[str] = _QM_OUTPUT_LIBRARY_NAMES) -> str:
+    """
+    Classify the provenance of an energy from the RMG/Arkane ``comment`` that produced it.
+
+    Works for both a species' ``thermo`` comment and a reaction's ``kinetics`` comment: the marker
+    set spans both, and no thermo marker collides with a kinetics one. Classification is
+    **last-writer-wins** -- every provenance marker in the (concatenated) comment is located and the
+    one starting latest decides the class, so this run's quantum chemistry (appended last) overrides
+    the RMG estimate it superseded. See the module docstring for the trap this defends against.
+
+    Args:
+        comment (str | None): The ``comment`` text, or ``''``/``None`` when the level carries none.
+        qm_library_names (frozenset[str]): The library names that denote this run's own QM output
+            (see ``_QM_OUTPUT_LIBRARY_NAMES``).
+
+    Returns:
+        str: One of the ``PROVENANCE_*`` constants. ``PROVENANCE_UNKNOWN`` when the comment is
+            empty or carries no recognised marker -- an honest gap, never defaulted into a class.
+    """
+    if not comment or not comment.strip():
+        return PROVENANCE_UNKNOWN
+
+    winner = None  # (start, kind, end) of the latest-starting marker
+    for kind, pattern in _MARKERS:
+        for match in pattern.finditer(comment):
+            if winner is None or match.start() > winner[0]:
+                winner = (match.start(), kind, match.end())
+    if winner is None:
+        return PROVENANCE_UNKNOWN
+
+    _, kind, end = winner
+    if kind in _LIBRARY_KINDS:
+        name = _library_name_after(comment, end)
+        return PROVENANCE_QM if name in qm_library_names else PROVENANCE_LIBRARY
+    return kind  # PROVENANCE_GAV or PROVENANCE_FAMILY
+
+
+def combine_channel_provenance(provenances: Iterable[str]) -> str:
+    """
+    The provenance of a (possibly bimolecular) channel from its fragments' provenances.
+
+    A channel's asymptote energy is the sum over its fragments, so it is only as trustworthy as its
+    least-trustworthy fragment: the worst (lowest-confidence) class wins. An empty channel -- which
+    should never occur -- is ``PROVENANCE_UNKNOWN``.
+
+    Args:
+        provenances (Iterable[str]): The per-fragment ``PROVENANCE_*`` classes.
+
+    Returns:
+        str: The worst-link ``PROVENANCE_*`` class.
+    """
+    classes = list(provenances)
+    if not classes:
+        return PROVENANCE_UNKNOWN
+    return min(classes, key=lambda provenance: PROVENANCE_CONFIDENCE[provenance])

--- a/tests/test_pdep/test_diagram.py
+++ b/tests/test_pdep/test_diagram.py
@@ -237,6 +237,77 @@ class TestDrawPESDiagram:
             head = f.read(200)
         assert b'<svg' in head or b'<?xml' in head
 
+
+# A compact surface whose comments exercise all provenance classes: a QM well (GAV estimate
+# superseded by the QM output library -- the concatenation trap), a curated-library well, a GAV
+# well, a bimolecular reactant channel whose two fragments are QM and GAV (worst-link -> GAV), a
+# QM transition state (kinetics fitted then written back as the QM kinetics library), and a family
+# estimated one. Comments mirror the real markers in the r002_m1-cho2-rerun final network file.
+_PROVENANCE_NETWORK = """species(label='QMwell', E0=(0.0,'kJ/mol'),
+    thermo=NASA(polynomials=[], comment='''Thermo group additivity estimation: group(x)Thermo library: thermojobs'''))
+species(label='LibWell', E0=(5.0,'kJ/mol'),
+    thermo=NASA(polynomials=[], comment='''Thermo library: primaryThermoLibrary'''))
+species(label='A', E0=(30.0,'kJ/mol'),
+    thermo=NASA(polynomials=[], comment='''Thermo library: primaryThermoLibraryThermo library: thermojobs'''))
+species(label='B', E0=(10.0,'kJ/mol'),
+    thermo=NASA(polynomials=[], comment='''Thermo group additivity estimation: group(y)'''))
+transitionState(label='TS_qm', E0=(60.0,'kJ/mol'))
+transitionState(label='TS_fam', E0=(70.0,'kJ/mol'))
+reaction(label='r_qm', reactants=['LibWell'], products=['QMwell'], transitionState='TS_qm',
+    kinetics=Arrhenius(A=(1.0,'s^-1'), n=0.0, Ea=(0.0,'kJ/mol'), comment='''Fitted to 50 data pointsReaction library: 'kineticsjobs' '''))
+reaction(label='r_fam', reactants=['A','B'], products=['QMwell'], transitionState='TS_fam',
+    kinetics=Arrhenius(A=(1.0,'s^-1'), n=0.0, Ea=(0.0,'kJ/mol'), comment='''Estimated using template [x] for rate rule [y]'''))
+network(label='N', isomers=['QMwell','LibWell'], reactants=[('A','B')])
+"""
+
+
+class TestProvenance:
+
+    def _data(self):
+        return _compute_from_text(_PROVENANCE_NETWORK)
+
+    def test_qm_well_survives_the_concatenation_trap(self):
+        # The GAV prefix must NOT win over the trailing QM library -- the inversion this exists to
+        # prevent.
+        data = self._data()
+        assert _config_by_labels(data, ['QMwell']).provenance == 'qm'
+
+    def test_curated_library_well_is_library(self):
+        assert _config_by_labels(self._data(), ['LibWell']).provenance == 'library'
+
+    def test_bimolecular_channel_takes_its_worst_fragment(self):
+        # A (QM) + B (GAV) -> the channel is only as trustworthy as B.
+        assert _config_by_labels(self._data(), ['A', 'B']).provenance == 'gav'
+
+    def test_transition_state_provenance_comes_from_kinetics_comment(self):
+        data = self._data()
+        by_label = {ts.label: ts.provenance for ts in data.transition_states}
+        assert by_label['TS_qm'] == 'qm'
+        assert by_label['TS_fam'] == 'family'
+
+    def test_absent_comment_is_unknown_not_defaulted(self):
+        text = """species(label='I', E0=(0.0,'kJ/mol'))
+species(label='P', E0=(-5.0,'kJ/mol'))
+reaction(label='r', reactants=['I'], products=['P'])
+network(label='N', isomers=['I'], reactants=[])
+"""
+        assert _config_by_labels(_compute_from_text(text), ['I']).provenance == 'unknown'
+
+    def test_legend_lists_only_the_provenance_classes_present(self):
+        fig = _build_pes_figure(self._data())
+        try:
+            legend = fig.axes[0].get_legend()
+            assert legend is not None
+            labels = {text.get_text() for text in legend.get_texts()}
+            # Present: QM, Library, GAV, Family. Absent: Unknown (no unclassifiable level here).
+            assert 'QM (this campaign)' in labels
+            assert 'Library' in labels
+            assert 'GAV estimate' in labels
+            assert 'Family estimate (ILT)' in labels
+            assert 'Unknown provenance' not in labels
+        finally:
+            plt.close(fig)
+
     def test_drawing_a_no_isomer_network_annotates_the_fallback_reference(self, tmp_path):
         text = """species(label='A', E0=(10.0, 'kJ/mol'))
 species(label='B', E0=(20.0, 'kJ/mol'))

--- a/tests/test_pdep/test_provenance.py
+++ b/tests/test_pdep/test_provenance.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""
+t3 tests test_pdep test_provenance module
+
+Tests the energy-provenance classifier (``t3.pdep.provenance``): the last-writer-wins reading of
+RMG/Arkane ``comment`` text that lets T3's PES diagram colour a level by where its energy came
+from. The load-bearing case is the CONCATENATION TRAP -- a QM'd level's comment still carries the
+superseded RMG estimate as a prefix, and a first-match parse would mislabel it (see the module
+docstring). Comments here are taken verbatim from
+``run/round_1/explorer/pdep/final/network0_reduced.py`` of the r002_m1-cho2-rerun run.
+"""
+
+import pytest
+
+from t3.pdep.provenance import (
+    PROVENANCE_FAMILY,
+    PROVENANCE_GAV,
+    PROVENANCE_LIBRARY,
+    PROVENANCE_QM,
+    PROVENANCE_UNKNOWN,
+    classify_provenance,
+    combine_channel_provenance,
+)
+
+# Real comments from the r002_m1-cho2-rerun final network file.
+GAV_THEN_THERMOJOBS = ('Thermo group additivity estimation: group(O2s-(Cds-O2d)H) + '
+                       'group(Cds-OdOsH) + radical((O)CJOH)Thermo library: thermojobs')  # O=[C]O(8)
+LIBRARY_THEN_THERMOJOBS = 'Thermo library: primaryThermoLibraryThermo library: thermojobs'  # [H](6)
+BARE_PRIMARY_LIBRARY = 'Thermo library: primaryThermoLibrary'  # Ar
+BARE_GAV = ('Thermo group additivity estimation: missing(O2d-Cdd) + missing(O2d-Cdd) + '
+            'group(Cdd-OdOd)')
+KINETICSJOBS = ("Fitted to 50 data points; dA = *|/ 12.9343, dn = +|- 0.336317, "
+                "dEa = +|- 1.83023 kJ/molReaction library: 'kineticsjobs'")  # reaction1 / TS1
+FAMILY_TEMPLATE = ('Estimated using template [Cdd_Od;HJ] for rate rule [CO2;HJ]\n'
+                   'Euclidian distance = 1.0\nfamily: R_Addition_MultipleBond')  # reaction4 / TS2
+FAMILY_NODE = ('Estimated from node Backbone0_1 in family Intra_R_Add_Endocyclic.')
+
+
+@pytest.mark.parametrize('comment, expected', [
+    # The trap: a QM'd level carries its superseded RMG estimate first, the QM library last.
+    (GAV_THEN_THERMOJOBS, PROVENANCE_QM),       # GAV prefix + thermojobs -> QM (not GAV)
+    (LIBRARY_THEN_THERMOJOBS, PROVENANCE_QM),   # curated library prefix + thermojobs -> QM
+    (KINETICSJOBS, PROVENANCE_QM),              # kinetics fit + kineticsjobs -> QM
+    # Genuinely external / estimated -- no QM library appended.
+    (BARE_PRIMARY_LIBRARY, PROVENANCE_LIBRARY),
+    (FAMILY_TEMPLATE, PROVENANCE_FAMILY),       # 'Estimated using template ...'
+    (FAMILY_NODE, PROVENANCE_FAMILY),           # 'Estimated from node ... in family ...'
+    (BARE_GAV, PROVENANCE_GAV),
+    # Honest gap -- never defaulted into a class.
+    ('', PROVENANCE_UNKNOWN),
+    (None, PROVENANCE_UNKNOWN),
+    ('   \n  ', PROVENANCE_UNKNOWN),
+    ('some comment with no recognised provenance marker', PROVENANCE_UNKNOWN),
+])
+def test_classify_provenance(comment, expected):
+    assert classify_provenance(comment) == expected
+
+
+def test_reaction_library_quotes_stripped():
+    """A double-quoted QM reaction library reads as QM just like the single-quoted form."""
+    assert classify_provenance('...kJ/molReaction library: "kineticsjobs"') == PROVENANCE_QM
+
+
+def test_curated_reaction_library_is_library_not_qm():
+    """A reaction library that is NOT this run's QM output is a curated library, not QM."""
+    assert classify_provenance("Matched.Reaction library: 'BurkeH2O2'") == PROVENANCE_LIBRARY
+
+
+def test_last_writer_wins_over_three_concatenated_markers():
+    """GAV, then a curated library, then the QM library -- the QM library (last) wins."""
+    comment = ('Thermo group additivity estimation: group(x)'
+               'Thermo library: primaryThermoLibrary'
+               'Thermo library: thermojobs')
+    assert classify_provenance(comment) == PROVENANCE_QM
+
+
+def test_qm_library_names_are_configurable():
+    """A caller can name a different QM output library; the default set no longer counts."""
+    comment = '...kJ/molReaction library: myLocalQMlib'
+    assert classify_provenance(comment) == PROVENANCE_LIBRARY
+    assert classify_provenance(comment,
+                               qm_library_names=frozenset({'myLocalQMlib'})) == PROVENANCE_QM
+
+
+@pytest.mark.parametrize('fragments, expected', [
+    ((PROVENANCE_QM, PROVENANCE_QM), PROVENANCE_QM),           # [H]+O=C=O, both QM
+    ((PROVENANCE_QM, PROVENANCE_GAV), PROVENANCE_GAV),         # worst link wins
+    ((PROVENANCE_QM, PROVENANCE_LIBRARY), PROVENANCE_LIBRARY),
+    ((PROVENANCE_LIBRARY, PROVENANCE_FAMILY), PROVENANCE_FAMILY),
+    ((PROVENANCE_QM, PROVENANCE_UNKNOWN), PROVENANCE_UNKNOWN),  # any unknown fragment -> unknown
+    ((PROVENANCE_QM,), PROVENANCE_QM),                         # unimolecular
+    ((), PROVENANCE_UNKNOWN),
+])
+def test_combine_channel_provenance(fragments, expected):
+    assert combine_channel_provenance(fragments) == expected


### PR DESCRIPTION
## What

T3's PES diagram (`run/round_<N>/pes_diagram.png`) coloured every stationary point by its **type** (isomer / channel / transition state) and said nothing about **where its energy came from**. On the motivating run three transition states drew identically, yet only one was computed by quantum chemistry; the other two were rate-rule estimates. The diagram is what a human reads to judge whether a surface is trustworthy, so this recolours every level by the **provenance** of its energy and adds a legend.

Four classes, ordered by decreasing confidence — **QM (this campaign)**, **Library**, **Family estimate (ILT)**, **GAV estimate** — plus an explicit **Unknown** for a level that genuinely cannot be classified (never silently folded into one of the four).

## How

- **`t3/pdep/provenance.py`** (new) — classifies a species' `thermo` comment or a reaction's `kinetics` comment. RMG/Arkane concatenate these comments rather than replacing them, and this run's QM result is appended **last**; classification is **last-writer-wins**, so a QM'd well whose comment reads `Thermo group additivity estimation: …Thermo library: thermojobs` is correctly **QM**, not GAV (`thermojobs`/`kineticsjobs` are ARC/Arkane's own output libraries). A bimolecular channel takes its worst-link fragment provenance.
- **`t3/pdep/parser.py`** — exposes species thermo comments on `PDepNetwork` (a trailing default field mirroring `species_structures`; backward-compatible). Reaction kinetics comments were already parsed.
- **`t3/pdep/diagram.py`** — maps the four ordered classes onto the **viridis** ramp (CVD-safe and monotonic in luminance, so classes stay distinguishable in greyscale — the case that matters for a printed diagram). Unknown is a neutral grey drawn dotted, outside the ramp. Legend lists only classes actually drawn.

Type stays readable from layout (reactant channels left, isomers centre, product channels right; TSs at midpoints). **No computed value moves — rendering only.**

## A corrected premise

The originating ticket expected, for the final `network0_reduced.py`, that **TS2** is QM and TS1/TS3 are family estimates. Reading the artifact (and cross-checking the hybrid input, where a QM'd reaction has its `kinetics=` dropped and the TS carries real frequencies) shows the opposite in the **final** file: the QM'd reaction is the unimolecular isomerisation `[O]C=O ⇌ O=[C]O`, which is **`reaction1/TS1`**, bearing `Reaction library: 'kineticsjobs'`. Arkane relabels TSs between the hybrid input (where TS2 was the QM one) and the reduced export. The classifier is data-driven; both the comment markers and the hybrid QM topology agree on **TS1 = QM, TS2/TS3 = family**. Everything else in the ticket's expectation matches (wells `O=[C]O(8)` & `[O]C=O(1)` = QM — the concatenation trap; `Ar` = Library).

## Verification

- New classifier unit tests (`tests/test_pdep/test_provenance.py`) cover the concatenation trap and every class; new diagram-level tests assert provenance end-to-end and the legend.
- Regenerated the diagram from the real run artifacts and read it level by level; a mutation check flips a level's colour (`qm` `#440154` ↔ `gav` `#a2da37`) when its comment changes and back when restored — proving the colour is driven by the data.
- `python -m pytest tests/test_pdep/ -q` → **1959 passed**.