### PR TITLE
feat(pdep): rank PES-loop QM candidates by distrust, not by structurally-blind sensitivity

### DIFF
--- a/t3/pdep/distrust.py
+++ b/t3/pdep/distrust.py
@@ -1,0 +1,343 @@
+"""
+The pre-QM "rank by distrust" selection criterion for the PES exploration loop (I-032).
+
+Why this exists -- the criterion it replaces is structurally blind
+-----------------------------------------------------------------
+The loop's other selector ranks transition states by master-equation E0-sensitivity: perturb a
+saddle's ``E0``, measure the ln(k) response, queue the movers. That criterion cannot see the very
+channels a mechanism most needs. A transition state in a reduced network file carries no statmech
+``modes`` (nobody has run the QM yet -- that IS the queue), so ``Reaction.can_tst()`` is False and
+every k(E) comes from the inverse Laplace transform, where the saddle's ``E0`` enters only as a
+discrete threshold gate (``rmgpy/pdep/reaction.pyx``). For a bimolecular association/dissociation
+channel that gate never binds -- the rate is fixed by the bimolecular asymptote, the
+detailed-balance clamp, and high-pressure-limit renormalization -- so perturbing the saddle's
+``E0`` is an exact no-op and the sensitivity is a STRUCTURAL ZERO (``0.0`` or ~1e-18), not a
+measurement of low leverage. The blindness is worst exactly for the low bimolecular entrance
+channels that carry the reactive flux. You cannot use a quantity's sensitivity to decide whether to
+compute that quantity when not having computed it is what makes the sensitivity meaningless.
+
+What distrust ranks by instead
+------------------------------
+Every input here is present in the reduced network file BEFORE any QM runs, and none of it is a
+sensitivity value -- so no structural zero can suppress a candidate, and the "invert the
+sensitivity" trap (which inherits the same zero) is avoided by construction. A candidate is ranked
+by how little we trust the barrier we currently hold:
+
+* **Flat energy window (the gate).** A saddle far above the lowest one on the surface carries
+  negligible flux at the temperatures of interest, so it is declined regardless of provenance. Only
+  saddles within ``energy_window_kj`` of the lowest surface saddle stay eligible. This is what makes
+  the criterion a screen rather than a firehose: it declines the high isomerization saddle on the
+  r002 CHO2 surface while keeping the low ``[H] + O=C=O`` entrance channels.
+* **Provenance (dominant rank term).** A family/rate-rule estimate is distrusted; a library or
+  already-computed value is trusted and not re-queued. Read from the kinetics comment.
+* **RMG's own variance (secondary rank term).** When RMG produced the rate by decision-tree node
+  averaging it attaches ``RateUncertainty(var=...)`` -- its own voice saying "I guessed this one".
+  Larger ``var`` -> more distrust. Optional: absent on a plain estimate, in which case it simply
+  contributes nothing.
+* **Barrier height (tiebreak).** Among equally-provenanced, equal-variance saddles, the lower
+  barrier carries more flux and so is worth getting right first.
+
+Nothing here is computed, estimated, or invented: the energies and comments are read verbatim from
+the network file, and a missing datum leaves its term neutral rather than being guessed at.
+"""
+
+from dataclasses import dataclass, replace
+
+from t3.pdep.parser import PDepNetworkE0, PDepPathReaction
+from t3.pdep.pes_rounds import (CandidateSplit, QMCandidate, SkippedChannel,
+                                SKIP_NO_EVIDENCE, SKIP_OUTSIDE_WINDOW, SKIP_TRUSTED_PROVENANCE,
+                                SKIP_UNMEASURABLE)
+
+# The flat energy window half-width, in kJ/mol: a saddle more than this above the lowest saddle on
+# the surface is declined. ~30 kJ/mol is the figure discussed for the r002 CHO2 network -- wide
+# enough to hold both low entrance channels, tight enough to decline the ~114 kJ/mol-higher
+# isomerization saddle.
+DEFAULT_ENERGY_WINDOW_KJ = 30.0
+
+# Provenance classes of the current barrier, read from the kinetics comment.
+PROVENANCE_LIBRARY = 'library'
+PROVENANCE_ESTIMATE = 'estimate'
+
+# Case-insensitive substrings that mark a barrier as a trusted library/QM value rather than a
+# family/rate-rule estimate. RMG writes "Reaction library: '<name>'" for a value taken from a
+# kinetics library (which is where a completed QM job's fitted rate is stored, e.g. 'kineticsjobs').
+_LIBRARY_MARKERS = ('reaction library', 'library:')
+
+# The size of the provenance rank gap. It must exceed any realistic sum of the variance and barrier
+# terms so that an estimate always outranks a library value: RMG's ln-space ``var`` is O(10) and the
+# barrier tiebreak is in [0, 1), so 1e6 is never crossed.
+_PROVENANCE_GAP = 1.0e6
+
+
+@dataclass(frozen=True)
+class DistrustParams:
+    """
+    The knobs of the distrust criterion.
+
+    Attributes:
+        energy_window_kj (float): The flat energy window half-width (kJ/mol). A candidate saddle
+            more than this above the lowest saddle on the surface is declined.
+    """
+    energy_window_kj: float = DEFAULT_ENERGY_WINDOW_KJ
+
+
+@dataclass(frozen=True)
+class DistrustScore:
+    """
+    The transparent components behind one candidate's distrust ranking.
+
+    Every field is derived from the pre-QM network file, so the ranking is auditable term by term
+    rather than collapsed into an opaque scalar.
+
+    Attributes:
+        ts_label (str): The network-local transition state label.
+        barrier_kj (float | None): The saddle's height above its lower-energy adjacent configuration
+            (kJ/mol), or ``None`` if a side's species energy was missing from the file.
+        height_above_lowest_saddle_kj (float | None): The saddle's E0 minus the lowest saddle E0 on
+            the surface (kJ/mol), the flat-window quantity, or ``None`` if this saddle's E0 was
+            missing.
+        in_window (bool): Whether the saddle is within ``energy_window_kj`` of the lowest surface
+            saddle. A saddle whose E0 could not be read is kept (``True``) rather than silently
+            dropped -- we cannot place it, so we do not rule it out.
+        provenance (str): ``PROVENANCE_LIBRARY`` (trusted) or ``PROVENANCE_ESTIMATE`` (distrusted).
+        kinetics_var (float | None): RMG's ``RateUncertainty(var=...)`` for this rate, or ``None``.
+        score (float): The distrust score; higher means less trusted and so more worth computing.
+    """
+    ts_label: str
+    barrier_kj: float | None
+    height_above_lowest_saddle_kj: float | None
+    in_window: bool
+    provenance: str
+    kinetics_var: float | None
+    score: float
+
+
+def classify_provenance(kinetics_comment: str) -> str:
+    """
+    Classify a barrier's provenance from its kinetics comment.
+
+    A comment naming a kinetics library (``"Reaction library: '...'"``) -- which is where a completed
+    QM job's fitted rate is stored -- is a value we already trust and would not spend QM on again. A
+    comment that does not is treated as a distrusted estimate; this deliberately fails toward
+    computing, since a barrier whose provenance we cannot read is not one we should trust by default.
+
+    Args:
+        kinetics_comment (str): The reaction's kinetics ``comment`` text (possibly ``''``).
+
+    Returns:
+        str: ``PROVENANCE_LIBRARY`` or ``PROVENANCE_ESTIMATE``.
+    """
+    lowered = (kinetics_comment or '').lower()
+    if any(marker in lowered for marker in _LIBRARY_MARKERS):
+        return PROVENANCE_LIBRARY
+    return PROVENANCE_ESTIMATE
+
+
+def _side_energy(labels: tuple, species_e0: dict) -> float | None:
+    """
+    Sum the E0 of one reaction side, or ``None`` if any species' energy is missing.
+
+    Args:
+        labels (tuple): The species labels on one side of the reaction.
+        species_e0 (dict): Species label -> E0 (kJ/mol), from ``PDepNetworkE0.species``.
+
+    Returns:
+        float | None: The summed side energy (kJ/mol), or ``None`` if a label had no E0.
+    """
+    if not labels:
+        return None
+    total = 0.0
+    for label in labels:
+        if label not in species_e0:
+            return None
+        total += species_e0[label]
+    return total
+
+
+def compute_distrust(path_reaction: PDepPathReaction,
+                     ts_label: str,
+                     network_e0: PDepNetworkE0,
+                     lowest_saddle_e0_kj: float | None,
+                     params: DistrustParams) -> DistrustScore:
+    """
+    Score one candidate by distrust from the pre-QM network file.
+
+    Args:
+        path_reaction (PDepPathReaction): The parsed path reaction (its species and kinetics comment
+            and any ``RateUncertainty(var=...)``).
+        ts_label (str): The candidate's network-local transition state label.
+        network_e0 (PDepNetworkE0): The declared species and transition-state E0 values (kJ/mol).
+        lowest_saddle_e0_kj (float | None): The lowest transition-state E0 on the surface (kJ/mol),
+            or ``None`` if the file declared no transition-state E0 at all.
+        params (DistrustParams): The window and any other knobs.
+
+    Returns:
+        DistrustScore: The transparent components and the scalar score for this candidate.
+    """
+    ts_e0 = network_e0.transition_states.get(ts_label)
+    reactant_side = _side_energy(path_reaction.reactants, network_e0.species)
+    product_side = _side_energy(path_reaction.products, network_e0.species)
+
+    # Barrier over the lower-energy adjacent configuration: direction-robust and non-negative for a
+    # real saddle. Either side may be unreadable; use whichever is present, and leave the barrier
+    # None only when neither is.
+    lower_side = None
+    for side in (reactant_side, product_side):
+        if side is not None and (lower_side is None or side < lower_side):
+            lower_side = side
+    barrier_kj = None
+    if ts_e0 is not None and lower_side is not None:
+        barrier_kj = ts_e0 - lower_side
+
+    height_kj = None
+    if ts_e0 is not None and lowest_saddle_e0_kj is not None:
+        height_kj = ts_e0 - lowest_saddle_e0_kj
+    # A saddle whose E0 could not be read is kept rather than dropped: we cannot place it on the
+    # surface, so we do not rule it out of the window.
+    in_window = height_kj is None or height_kj <= params.energy_window_kj
+
+    provenance = classify_provenance(path_reaction.kinetics_comment)
+    kinetics_var = path_reaction.kinetics_uncertainty_var
+
+    provenance_term = _PROVENANCE_GAP if provenance == PROVENANCE_ESTIMATE else 0.0
+    variance_term = kinetics_var if kinetics_var is not None else 0.0
+    # Barrier tiebreak in [0, 1): monotone decreasing in the barrier, so a lower barrier scores
+    # higher. A barrier we could not read is treated as maximally distrusted (1.0).
+    flux_term = 1.0 if barrier_kj is None else 1.0 / (1.0 + max(barrier_kj, 0.0))
+    score = provenance_term + variance_term + flux_term
+
+    return DistrustScore(ts_label=ts_label, barrier_kj=barrier_kj,
+                         height_above_lowest_saddle_kj=height_kj, in_window=in_window,
+                         provenance=provenance, kinetics_var=kinetics_var, score=score)
+
+
+def rank_candidates_by_distrust(candidates: tuple,
+                                network_e0: PDepNetworkE0,
+                                params: DistrustParams) -> tuple:
+    """
+    Score every candidate and split them into the eligible (in-window), ranked by distrust, and the
+    declined (outside the window).
+
+    This is the pure ranking core, with no evidence-stamping or ``CandidateSplit`` bookkeeping, so
+    it can be replayed and unit-tested directly on a parsed network.
+
+    Args:
+        candidates (tuple): ``QMCandidate`` objects to rank.
+        network_e0 (PDepNetworkE0): The declared E0 values (kJ/mol).
+        params (DistrustParams): The window and any other knobs.
+
+    Returns:
+        tuple: ``(eligible, declined)`` where ``eligible`` is a list of ``(QMCandidate,
+        DistrustScore)`` in descending distrust order (ties keeping input order, which is
+        network-file order), and ``declined`` is a list of ``(QMCandidate, DistrustScore)`` for the
+        out-of-window candidates in input order.
+    """
+    lowest_saddle_e0_kj = (min(network_e0.transition_states.values())
+                           if network_e0.transition_states else None)
+    scored = [(candidate,
+               compute_distrust(candidate.path_reaction, candidate.ts_label, network_e0,
+                                lowest_saddle_e0_kj, params))
+              for candidate in candidates]
+    eligible = [pair for pair in scored if pair[1].in_window]
+    declined = [pair for pair in scored if not pair[1].in_window]
+    # sorted() is stable, so equal scores keep network-file order -- the same determinism the
+    # sensitivity path promises.
+    eligible.sort(key=lambda pair: -pair[1].score)
+    return eligible, declined
+
+
+def _outside_window_reason(candidate: QMCandidate, score: DistrustScore,
+                           params: DistrustParams) -> str:
+    """Prose for a candidate declined because its saddle sits above the flat energy window."""
+    height = ('unknown' if score.height_above_lowest_saddle_kj is None
+              else f'{score.height_above_lowest_saddle_kj:.1f}')
+    return (f"'{candidate.path_reaction.label}': transition state {candidate.ts_label} sits "
+            f'{height} kJ/mol above the lowest saddle on the surface, outside the '
+            f'{params.energy_window_kj:.1f} kJ/mol flat energy window; it carries too little '
+            f'reactive flux to justify the QM spend, whatever the (dis)trust in its barrier.')
+
+
+def select_by_distrust(split: CandidateSplit,
+                       evidence_by_ts_label: dict,
+                       network_e0: PDepNetworkE0,
+                       params: DistrustParams) -> CandidateSplit:
+    """
+    Select and rank a network's QM candidates by distrust, in place of the sensitivity floor.
+
+    This is the distrust counterpart to ``t3.pdep.pes_rounds.attach_sensitivity_evidence`` and is
+    called from ``t3.pdep.pes_loop`` when ``qm.scope == 'distrust'``. It does three things:
+
+    0. **Skips trusted (library / already-computed) candidates** before anything else. A barrier
+       whose kinetics comment names a reaction library is a value distrust trusts and would not spend
+       QM on again (the module contract); it is appended to ``skipped`` as ``SKIP_TRUSTED_PROVENANCE``
+       and never ranked, so an all-library network queues nothing rather than redundantly recomputing
+       what it already holds.
+    1. **Stamps the measured sensitivity coefficient** (from ``evidence_by_ts_label``) onto every
+       remaining candidate that has a finite row, exactly as the sensitivity path does. The coefficient is NOT
+       the selection basis here -- distrust is -- but it is still carried so ``t3.pdep.capture`` (a
+       fail-closed guard predating this scope) accepts the queued artifact, and so the round record
+       keeps the sensitivity value visible (I-031: stop ranking on the structural zero, do not hide
+       it). A candidate with no finite row is still skipped, since capture has no coefficient to
+       record and inventing one is forbidden; it is classified ``SKIP_UNMEASURABLE`` when it was the
+       structurally-unmeasurable kind, else ``SKIP_NO_EVIDENCE`` -- unchanged from the sensitivity
+       path.
+    2. **Declines out-of-window candidates**, appending each to ``skipped`` as
+       ``SKIP_OUTSIDE_WINDOW`` with its height above the lowest saddle in the reason. This is the
+       negative control: the criterion is a screen, not a firehose.
+    3. **Ranks the survivors by descending distrust** and returns them in that order, each carrying
+       its ``distrust_score``. ``t3.pdep.pes_loop._trim_candidates`` under this scope keeps that
+       order and takes the first ``max_transition_states_per_round``.
+
+    Args:
+        split (CandidateSplit): The split from ``split_qm_candidates``.
+        evidence_by_ts_label (dict): Network-local TS label -> ``(coefficient, delta_ln_k)``, from
+            ``t3.pdep.pes_sa.run_round_me_sensitivity``.
+        network_e0 (PDepNetworkE0): The declared species/TS E0 values (kJ/mol), from the same
+            network file.
+        params (DistrustParams): The window and any other knobs.
+
+    Returns:
+        CandidateSplit: The in-window candidates in descending distrust order, each stamped with its
+        coefficient/``delta_ln_k`` and ``distrust_score``; every other candidate appended to
+        ``skipped`` with its reason and classification.
+    """
+    skipped = list(split.skipped)
+    stamped = []
+    for candidate in split.candidates:
+        if classify_provenance(candidate.path_reaction.kinetics_comment) == PROVENANCE_LIBRARY:
+            # A trusted library/QM value: distrust does not re-queue it. Skipped before ranking so an
+            # all-library network queues nothing rather than spending QM on what it already holds.
+            skipped.append(SkippedChannel(
+                label=candidate.path_reaction.label,
+                reason=(f"'{candidate.path_reaction.label}': transition state {candidate.ts_label} "
+                        f'already carries a trusted library / already-computed (QM) rate, which '
+                        f'distrust does not re-queue; computing it again would be redundant.'),
+                ts_label=candidate.ts_label, classification=SKIP_TRUSTED_PROVENANCE))
+            continue
+        pair = evidence_by_ts_label.get(candidate.ts_label)
+        if pair is None:
+            # No finite sensitivity row: capture would refuse the artifact, so this cannot be
+            # queued regardless of distrust. Same skip the sensitivity path takes; the classification
+            # only records whether the absence was the structural kind.
+            classification = (SKIP_UNMEASURABLE if not candidate.e0_sensitivity_measurable
+                              else SKIP_NO_EVIDENCE)
+            skipped.append(SkippedChannel(
+                label=candidate.path_reaction.label,
+                reason=(f"'{candidate.path_reaction.label}': transition state {candidate.ts_label} "
+                        f'has no finite sensitivity row in this round, and a captured artifact must '
+                        f'carry the coefficient that will be recorded for it (t3.pdep.capture); not '
+                        f'queueing it rather than inventing a number.'),
+                ts_label=candidate.ts_label, classification=classification))
+            continue
+        coefficient, delta_ln_k = pair
+        stamped.append(replace(candidate, coefficient=coefficient, delta_ln_k=delta_ln_k))
+
+    eligible, declined = rank_candidates_by_distrust(tuple(stamped), network_e0, params)
+    for candidate, score in declined:
+        skipped.append(SkippedChannel(
+            label=candidate.path_reaction.label,
+            reason=_outside_window_reason(candidate, score, params),
+            ts_label=candidate.ts_label, classification=SKIP_OUTSIDE_WINDOW,
+            coefficient=candidate.coefficient, delta_ln_k=candidate.delta_ln_k))
+    ranked = tuple(replace(candidate, distrust_score=score.score) for candidate, score in eligible)
+    return CandidateSplit(candidates=ranked, skipped=tuple(skipped))

--- a/t3/pdep/parser.py
+++ b/t3/pdep/parser.py
@@ -125,6 +125,15 @@ class PDepPathReaction:
         transition_state (str, optional): The associated transition state label, if any.
         kinetics_type (str, optional): The kinetics callee name, e.g. ``'Arrhenius'``, if any.
         kinetics_comment (str): The kinetics ``comment`` keyword text, or ``''`` if absent.
+        kinetics_uncertainty_var (float, optional): The ``var=`` of an
+            ``uncertainty=RateUncertainty(mu=..., var=...)`` keyword on the kinetics call, when RMG
+            wrote one -- its own stated variance (ln-space) of a rate it produced by decision-tree
+            averaging rather than from a measurement or calculation. A large ``var`` is RMG saying,
+            in its own voice, that it guessed this rate; ``t3.pdep.distrust`` reads it as one of the
+            pre-QM distrust signals. ``None`` when the reaction carries no such annotation (a real
+            measurement/calculation, a library value, or a plain estimate with no variance written).
+            Default ``None`` so every existing construction site (which never passes this keyword)
+            keeps working unchanged.
     """
     label: str
     reactants: tuple
@@ -132,6 +141,7 @@ class PDepPathReaction:
     transition_state: str | None
     kinetics_type: str | None
     kinetics_comment: str
+    kinetics_uncertainty_var: float | None = None
 
 
 def _canonical_channel(labels) -> tuple:
@@ -1269,6 +1279,7 @@ def _parse_reaction(kwargs: dict, path: str = '') -> PDepPathReaction:
 
     kinetics_type = None
     kinetics_comment = ''
+    kinetics_uncertainty_var = None
     kinetics_node = kwargs.get('kinetics')
     if isinstance(kinetics_node, ast.Call):
         kinetics_type = _get_call_name(kinetics_node)
@@ -1282,6 +1293,7 @@ def _parse_reaction(kwargs: dict, path: str = '') -> PDepPathReaction:
             # Walk the whole call tree and join every nested `comment=` string found, so this
             # provenance is not silently dropped for multi-component kinetics.
             kinetics_comment = _nested_kinetics_comment(kinetics_node)
+        kinetics_uncertainty_var = _kinetics_uncertainty_var(kinetics_node)
 
     return PDepPathReaction(
         label=label,
@@ -1290,7 +1302,41 @@ def _parse_reaction(kwargs: dict, path: str = '') -> PDepPathReaction:
         transition_state=transition_state,
         kinetics_type=kinetics_type,
         kinetics_comment=kinetics_comment,
+        kinetics_uncertainty_var=kinetics_uncertainty_var,
     )
+
+
+def _kinetics_uncertainty_var(kinetics_node: ast.Call) -> float | None:
+    """
+    Read the ``var=`` of an ``uncertainty=RateUncertainty(mu=..., var=...)`` keyword, if present.
+
+    RMG attaches a ``RateUncertainty`` to a rate it produced by decision-tree node averaging rather
+    than from a measurement or calculation; its ``var`` is the variance (ln-space) of that estimate
+    -- RMG's own statement of how much it distrusts the number. ``t3.pdep.distrust`` reads it as an
+    optional pre-QM distrust signal, so it is surfaced here alongside the kinetics comment. The call
+    subtree is walked (``ast.walk``) so a ``RateUncertainty`` nested inside composite kinetics is
+    still found; the first one carrying a foldable numeric ``var`` wins. Only constant numeric
+    ``var`` values are read -- a non-numeric one is treated as absent rather than guessed at, exactly
+    as ``_e0_kj_per_mol`` refuses a non-literal energy.
+
+    Args:
+        kinetics_node (ast.Call): The top-level ``kinetics=`` call node.
+
+    Returns:
+        float | None: The ``var`` value, or ``None`` if no ``RateUncertainty(var=<number>)`` is
+        declared anywhere in the kinetics call.
+    """
+    for node in ast.walk(kinetics_node):
+        if not (isinstance(node, ast.Call) and _get_call_name(node) == 'RateUncertainty'):
+            continue
+        var_node = _call_keywords(node).get('var')
+        if var_node is None:
+            continue
+        try:
+            return _fold_constant_number(var_node)
+        except (_NotAConstantNumber, ZeroDivisionError):
+            continue
+    return None
 
 
 def _nested_kinetics_comment(kinetics_node: ast.Call) -> str:

--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -62,9 +62,11 @@ from t3.pdep.diagram import draw_pes_diagram
 from t3.pdep.join import arc_ts_label
 from t3.pdep.explorer.config import PDepExplorerConfig
 from t3.pdep.explorer.result import EXPLORATION_STATUS_SUCCEEDED
-from t3.pdep.parser import parse_pdep_network_file, to_json_safe
+from t3.pdep.distrust import DistrustParams, select_by_distrust
+from t3.pdep.parser import parse_pdep_network_e0_file, parse_pdep_network_file, to_json_safe
 from t3.pdep.pes_qm import adopt_prior_qm
-from t3.pdep.pes_rounds import (SKIP_BELOW_FLOOR, SKIP_NO_EVIDENCE, SKIP_UNMEASURABLE,
+from t3.pdep.pes_rounds import (SKIP_BELOW_FLOOR, SKIP_NO_EVIDENCE, SKIP_OUTSIDE_WINDOW,
+                                SKIP_TRUSTED_PROVENANCE, SKIP_UNMEASURABLE,
                                 RoundPaths, adoption_channel_keys_by_ts_label,
                                 attach_sensitivity_evidence,
                                 channel_keys_by_ts_label, hybrid_network_path, round_paths,
@@ -219,17 +221,20 @@ def _trim_candidates(candidates: tuple, config: PESLoopConfig, logger) -> tuple:
     stamped by ``t3.pdep.pes_rounds.attach_sensitivity_evidence``), so ``scope == 'sensitive'``
     ranks by that evidence -- descending ``abs(coefficient)``, ties keeping network-file order --
     rather than degrading to file order the way it had to before the loop had an SA of its own.
-    ``scope == 'all'`` keeps the network file's own order. Both take the first ``limit``.
+    ``scope == 'all'`` keeps the network file's own order. ``scope == 'distrust'`` keeps the order
+    already imposed by ``t3.pdep.distrust.select_by_distrust`` (descending distrust), so it must not
+    be re-sorted here. All take the first ``limit``.
 
     Args:
-        candidates (tuple): The ``QMCandidate`` entries to trim, in network-file order, each
-                            already stamped with its sensitivity evidence.
+        candidates (tuple): The ``QMCandidate`` entries to trim, in network-file order (or, for the
+                            'distrust' scope, already in descending-distrust order), each stamped
+                            with its sensitivity evidence.
         config (PESLoopConfig): The loop's configuration.
         logger: A T3 ``Logger``, or ``None``.
 
     Returns:
         tuple: The trimmed candidates -- evidence-ranked for ``scope == 'sensitive'``,
-        network-file order for ``scope == 'all'``.
+        distrust-ranked for ``scope == 'distrust'``, network-file order for ``scope == 'all'``.
     """
     limit = config.qm.max_transition_states_per_round
     if config.qm.scope == 'sensitive':
@@ -237,7 +242,9 @@ def _trim_candidates(candidates: tuple, config: PESLoopConfig, logger) -> tuple:
         # split_qm_candidates' own docstring promises.
         candidates = tuple(sorted(candidates, key=lambda candidate: -abs(candidate.coefficient)))
     if len(candidates) > limit:
-        message = (f"PES loop: taking the {'most sensitive' if config.qm.scope == 'sensitive' else 'first'} "
+        ordering = {'sensitive': 'most sensitive', 'distrust': 'most distrusted'}.get(
+            config.qm.scope, 'first')
+        message = (f'PES loop: taking the {ordering} '
                    f'{limit} of {len(candidates)} candidate(s) '
                    f'(qm.max_transition_states_per_round).')
         _logger.info(message)
@@ -644,8 +651,18 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                      final_diagram_path=diagram_path)
             any_finite_evidence = any(candidate.ts_label in evidence
                                       for candidate in split.candidates)
-            split = attach_sensitivity_evidence(split, evidence,
-                                                min_delta_ln_k=config.qm.min_delta_ln_k)
+            if config.qm.scope == 'distrust':
+                # Rank by distrust (I-032), not by the sensitivity floor: the floor cannot reach the
+                # low bimolecular entrance channels whose sensitivity is a structural zero. The SA
+                # still ran above -- its coefficient is carried onto each survivor for capture and
+                # kept visible in the record (I-031) -- but distrust, not that coefficient, decides
+                # what survives and in what order.
+                split = select_by_distrust(
+                    split, evidence, parse_pdep_network_e0_file(explored_network_path),
+                    DistrustParams(energy_window_kj=config.qm.energy_window_kj))
+            else:
+                split = attach_sensitivity_evidence(split, evidence,
+                                                    min_delta_ln_k=config.qm.min_delta_ln_k)
             if not split.candidates and not round0_has_adopted:
                 if not any_finite_evidence:
                     # The SA ran but measured nothing finite for ANY candidate -- an operational
@@ -661,6 +678,56 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                                   paths, logger)
                     return PESLoopResult(rounds=tuple(rounds), status=PES_LOOP_FAILED,
                                          reason=reason,
+                                         final_network_path=explored_network_path,
+                                         final_diagram_path=diagram_path)
+                if config.qm.scope == 'distrust':
+                    # Nothing survived the distrust screen: every candidate was declined by the flat
+                    # energy window (or lacked a finite sensitivity row to record for capture). This
+                    # is a legitimate "nothing on this surface is both poorly-trusted and
+                    # flux-bearing enough to compute" -- NOT the sensitivity screen's structural-zero
+                    # blindness, so it is never reported 'unmeasurable'. The reason names the window
+                    # criterion so the stop is falsifiable from the outside.
+                    outside = tuple(s for s in split.skipped
+                                    if s.classification == SKIP_OUTSIDE_WINDOW)
+                    trusted = tuple(s for s in split.skipped
+                                    if s.classification == SKIP_TRUSTED_PROVENANCE)
+                    no_row = tuple(s for s in split.skipped
+                                   if s.classification in (SKIP_NO_EVIDENCE, SKIP_UNMEASURABLE))
+                    clauses = []
+                    if outside:
+                        labels = ', '.join(s.ts_label for s in outside)
+                        clauses.append(f'{len(outside)} ({labels}) sit above the '
+                                       f'{config.qm.energy_window_kj:.1f} kJ/mol flat energy window')
+                    if trusted:
+                        labels = ', '.join(s.ts_label for s in trusted)
+                        clauses.append(f'{len(trusted)} ({labels}) already carry a trusted '
+                                       f'library / already-computed rate that distrust does not '
+                                       f're-queue')
+                    if no_row:
+                        labels = ', '.join(s.ts_label for s in no_row)
+                        clauses.append(f'{len(no_row)} ({labels}) had no finite sensitivity row to '
+                                       f'record for capture')
+                    if not clauses:
+                        # Defensive: no candidate reached the distrust selector's own skip classes
+                        # (e.g. all were removed upstream by split_qm_candidates). Keep the reason
+                        # non-empty and falsifiable rather than emitting a dangling "screen: .".
+                        clauses.append(f'no QM candidate remained after the pre-QM screen '
+                                       f'(per-candidate reasons: {round_record_path(paths)})')
+                    budget_note = (f' This was also the last budgeted round (max_rounds: '
+                                   f'{max_rounds}); the criterion above, not the exhausted budget, '
+                                   f'is what stopped the loop.') if round_index == max_rounds - 1 else ''
+                    status = PES_LOOP_NO_CANDIDATES if round_index == 0 else PES_LOOP_CONVERGED
+                    reason = (f'round {round_index}: no QM candidate of network '
+                              f'{network.network_id!r} survived the distrust screen: '
+                              f'{"; ".join(clauses)}. Criterion: the '
+                              f'{config.qm.energy_window_kj:.1f} kJ/mol flat energy window over the '
+                              f'E0 surface. Per-candidate values: '
+                              f'{round_record_path(paths)}.{budget_note}')
+                    _record_round(rounds, RoundRecord(index=round_index, network_path=explored_network_path,
+                                                      diagram_path=diagram_path, queued_ts_labels=(),
+                                                      skipped=split.skipped, status=status, reason=reason),
+                                  paths, logger)
+                    return PESLoopResult(rounds=tuple(rounds), status=status, reason=reason,
                                          final_network_path=explored_network_path,
                                          final_diagram_path=diagram_path)
                 # Nothing survived the evidence screen, so the loop stops HERE either way (the

--- a/t3/pdep/pes_rounds.py
+++ b/t3/pdep/pes_rounds.py
@@ -51,6 +51,15 @@ SKIP_BARRIERLESS = 'barrierless'
 SKIP_NO_EVIDENCE = 'no_evidence'
 SKIP_BELOW_FLOOR = 'below_floor'
 SKIP_UNMEASURABLE = 'unmeasurable'
+# The distrust selector's own skip classes (``qm.scope == 'distrust'``, see ``t3.pdep.distrust``).
+# ``SKIP_OUTSIDE_WINDOW``: the saddle sits above the flat energy window, so it carries too little
+# reactive flux to be worth the QM spend regardless of how its barrier's provenance is (dis)trusted.
+# ``SKIP_TRUSTED_PROVENANCE``: the barrier is a library / already-computed (QM) value, which distrust
+# trusts and does not re-queue -- spending QM on it would be redundant. Both are decided from the
+# pre-QM network file, never from a sensitivity value, and both are distinct from
+# ``SKIP_BELOW_FLOOR`` (a MEASURED sensitivity below the floor) for that reason.
+SKIP_OUTSIDE_WINDOW = 'outside_energy_window'
+SKIP_TRUSTED_PROVENANCE = 'trusted_provenance'
 
 
 def e0_sensitivity_is_measurable(path_reaction: PDepPathReaction,
@@ -119,6 +128,12 @@ class QMCandidate:
             only: it never gates queueing (an unmeasurable candidate is skipped by exactly the
             same evidence/floor tests as before -- it is just no longer recorded as having
             "measured" its structural zero).
+        distrust_score (float | None): The pre-QM distrust score this candidate was ranked by when
+            ``qm.scope == 'distrust'`` (``t3.pdep.distrust.compute_distrust``), higher meaning less
+            trusted and so more worth computing. ``None`` under the sensitivity/all scopes, where
+            ranking is by ``coefficient`` or file order and distrust plays no part. Carried on the
+            queued candidate so the round record says WHY distrust selected it, rather than leaving
+            the (now non-gating) sensitivity coefficient to imply a justification it no longer gives.
     """
     path_reaction: PDepPathReaction
     ts_label: str
@@ -126,6 +141,7 @@ class QMCandidate:
     coefficient: float | None = None
     delta_ln_k: float | None = None
     e0_sensitivity_measurable: bool = True
+    distrust_score: float | None = None
 
 
 @dataclass(frozen=True)
@@ -229,8 +245,11 @@ def attach_sensitivity_evidence(split: CandidateSplit,
     "the sensitivity evidence that justified selecting this transition state" would make that
     sentence false. This mirrors T3's in-run selection, where ``t3.pdep.selector``'s
     ``_bounded_cutoff`` floors at ``min_delta_ln_k / perturbation > 0`` and such a record is
-    definitionally unreachable. The floor applies under BOTH ``qm.scope`` values -- 'sensitive'
-    ranks and 'all' does not, but neither may queue below it.
+    definitionally unreachable. This function runs under the 'sensitive' and 'all' scopes --
+    'sensitive' ranks and 'all' does not, but neither may queue below the floor. The 'distrust'
+    scope (I-032) does not call this function at all: it selects through ``t3.pdep.distrust`` from
+    the pre-QM E0 surface, precisely because a structural-zero sensitivity below the floor is the
+    blindness it exists to route around.
 
     A skipped candidate that is structurally UNMEASURABLE (``QMCandidate.e0_sensitivity_measurable``
     False -- see ``e0_sensitivity_is_measurable``) takes the SAME two skip branches, so queueing is

--- a/t3/schema.py
+++ b/t3/schema.py
@@ -1000,14 +1000,24 @@ class PESQMSection(PESStrictSection):
                                                             'goflow', 'rits'])
     rotors: bool = False
     irc: bool = False
-    scope: Literal['all', 'sensitive'] = 'sensitive'
+    # 'sensitive' ranks the QM candidates by master-equation E0-sensitivity, 'all' keeps file order,
+    # and 'distrust' (I-032) ranks by how little the current barrier is trusted from data present
+    # BEFORE any QM runs -- a flat energy window over the E0 surface, the barrier's provenance, and
+    # RMG's own RateUncertainty variance -- so it reaches the low bimolecular entrance channels whose
+    # sensitivity is a structural zero the 'sensitive' screen cannot measure (see t3.pdep.distrust).
+    scope: Literal['all', 'sensitive', 'distrust'] = 'sensitive'
     max_transition_states_per_round: Annotated[int, Field(gt=0, strict=True)] = 10
     # The smallest measured ln(k) response that justifies spending QM on a transition state,
     # mirroring T3's in-run ``t3.sensitivity.pdep_min_delta_ln_k`` (same default, same bounds).
-    # Applies under BOTH scopes: 'sensitive' ranks and 'all' does not, but neither may queue a
-    # transition state whose measured leverage is below this floor -- its capture manifest would
-    # then record a coefficient that never justified anything.
+    # Applies under the 'sensitive' and 'all' scopes: 'sensitive' ranks and 'all' does not, but
+    # neither may queue a transition state whose measured leverage is below this floor -- its capture
+    # manifest would then record a coefficient that never justified anything. The 'distrust' scope
+    # does not gate on it (its whole point is that a structural-zero sensitivity is meaningless).
     min_delta_ln_k: Annotated[float, Field(gt=0, lt=1)] = 1e-3
+    # The flat energy window half-width (kJ/mol) for the 'distrust' scope: a saddle more than this
+    # above the lowest saddle on the surface carries negligible flux and is declined. Unused under
+    # the other scopes. Default mirrors t3.pdep.distrust.DEFAULT_ENERGY_WINDOW_KJ.
+    energy_window_kj: Annotated[float, Field(gt=0)] = 30.0
 
     @field_validator('opt_level', 'freq_level', 'sp_level', 'irc_level', 'scan_level')
     @classmethod

--- a/tests/test_pdep/test_distrust.py
+++ b/tests/test_pdep/test_distrust.py
@@ -1,0 +1,295 @@
+"""Tests for t3.pdep.distrust -- the pre-QM rank-by-distrust selection criterion (I-032)."""
+
+from t3.pdep.parser import (PDepNetworkE0, PDepPathReaction, parse_pdep_network_e0_text,
+                            parse_pdep_network_text)
+from t3.pdep.pes_rounds import (CandidateSplit, QMCandidate, SKIP_NO_EVIDENCE, SKIP_OUTSIDE_WINDOW,
+                                SKIP_TRUSTED_PROVENANCE, SKIP_UNMEASURABLE)
+from t3.pdep.distrust import (DistrustParams, PROVENANCE_ESTIMATE, PROVENANCE_LIBRARY,
+                              classify_provenance, compute_distrust, rank_candidates_by_distrust,
+                              select_by_distrust)
+from t3.pdep.pes_loop import _trim_candidates
+from t3.schema import PESLoopConfig
+
+
+# The retained r002 CHO2 round-0 surface, as objects: two [H] + O=C=O bimolecular entrance channels
+# with low saddles (TS1, TS3) and one high isomerization saddle (TS2). E0 in kJ/mol, exactly as the
+# reduced network file declares (E0(TS) = written value with the 191.282 kJ/mol correction removed).
+_ROUND0_E0 = PDepNetworkE0(
+    species={'O=[C]O(8)': -184.487, '[O]C=O(1)': -169.935, '[H](6)': 211.805, 'O=C=O(5)': -403.087},
+    transition_states={'TS1': 21.347 - 191.282, 'TS2': 135.319 - 191.282, 'TS3': 30.706 - 191.282})
+
+_FAMILY_COMMENT = ('Estimated using template [Cdd_Od;HJ] for rate rule [CO2;HJ]\n'
+                   'family: R_Addition_MultipleBond')
+
+
+def _rxn(label, reactants, products, ts, comment=_FAMILY_COMMENT, var=None):
+    return PDepPathReaction(label=label, reactants=reactants, products=products,
+                            transition_state=ts, kinetics_type='Arrhenius',
+                            kinetics_comment=comment, kinetics_uncertainty_var=var)
+
+
+def _cand(reaction, ts, measurable=True):
+    return QMCandidate(path_reaction=reaction, ts_label=ts, family='R_Addition_MultipleBond',
+                       e0_sensitivity_measurable=measurable)
+
+
+def _round0_candidates():
+    return (
+        _cand(_rxn('reaction3', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1'), 'TS1'),
+        _cand(_rxn('reaction5', ('[O]C=O(1)',), ('O=[C]O(8)',), 'TS2',
+                   comment='family: intra_H_migration'), 'TS2'),
+        _cand(_rxn('reaction8', ('[H](6)', 'O=C=O(5)'), ('O=[C]O(8)',), 'TS3'), 'TS3'),
+    )
+
+
+class TestClassifyProvenance:
+
+    def test_family_estimate_is_distrusted(self):
+        assert classify_provenance(_FAMILY_COMMENT) == PROVENANCE_ESTIMATE
+
+    def test_reaction_library_is_trusted(self):
+        comment = "Fitted to 50 data points; dA = *|/ 12.9Reaction library: 'kineticsjobs'"
+        assert classify_provenance(comment) == PROVENANCE_LIBRARY
+
+    def test_empty_comment_fails_toward_computing(self):
+        # Unknown provenance is treated as distrusted, not trusted -- we do not trust by default.
+        assert classify_provenance('') == PROVENANCE_ESTIMATE
+
+
+class TestComputeDistrust:
+
+    def test_barrier_is_height_over_the_lower_adjacent_configuration(self):
+        lowest = min(_ROUND0_E0.transition_states.values())
+        rxn = _rxn('reaction3', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1')
+        score = compute_distrust(rxn, 'TS1', _ROUND0_E0, lowest, DistrustParams())
+        # [H] + O=C=O asymptote = 211.805 - 403.087 = -191.282; TS1 = -169.935; barrier = 21.347.
+        assert abs(score.barrier_kj - 21.347) < 1e-6
+        assert abs(score.height_above_lowest_saddle_kj - 0.0) < 1e-6
+        assert score.in_window is True
+
+    def test_high_saddle_is_outside_the_window(self):
+        lowest = min(_ROUND0_E0.transition_states.values())
+        rxn = _rxn('reaction5', ('[O]C=O(1)',), ('O=[C]O(8)',), 'TS2',
+                   comment='family: intra_H_migration')
+        score = compute_distrust(rxn, 'TS2', _ROUND0_E0, lowest, DistrustParams(energy_window_kj=30.0))
+        assert score.height_above_lowest_saddle_kj > 30.0
+        assert score.in_window is False
+
+    def test_missing_ts_e0_is_kept_not_dropped(self):
+        rxn = _rxn('rX', ('A',), ('B',), 'TS_missing')
+        score = compute_distrust(rxn, 'TS_missing', _ROUND0_E0,
+                                 min(_ROUND0_E0.transition_states.values()), DistrustParams())
+        assert score.barrier_kj is None
+        assert score.height_above_lowest_saddle_kj is None
+        assert score.in_window is True  # cannot place it -> do not rule it out
+
+    def test_variance_raises_the_score(self):
+        lowest = min(_ROUND0_E0.transition_states.values())
+        params = DistrustParams()
+        without = compute_distrust(_rxn('r', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1'),
+                                   'TS1', _ROUND0_E0, lowest, params)
+        with_var = compute_distrust(
+            _rxn('r', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1', var=25.73),
+            'TS1', _ROUND0_E0, lowest, params)
+        assert with_var.kinetics_var == 25.73
+        assert without.kinetics_var is None
+        assert with_var.score > without.score
+
+    def test_estimate_outranks_library_at_equal_geometry(self):
+        lowest = min(_ROUND0_E0.transition_states.values())
+        params = DistrustParams()
+        estimate = compute_distrust(_rxn('r', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1'),
+                                    'TS1', _ROUND0_E0, lowest, params)
+        library = compute_distrust(
+            _rxn('r', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1',
+                 comment="Reaction library: 'kineticsjobs'"),
+            'TS1', _ROUND0_E0, lowest, params)
+        assert estimate.provenance == PROVENANCE_ESTIMATE
+        assert library.provenance == PROVENANCE_LIBRARY
+        assert estimate.score > library.score
+
+
+class TestRankCandidates:
+
+    def test_lower_barrier_ranks_first_among_equal_provenance(self):
+        eligible, declined = rank_candidates_by_distrust(_round0_candidates(), _ROUND0_E0,
+                                                         DistrustParams(energy_window_kj=30.0))
+        order = [cand.ts_label for cand, _ in eligible]
+        assert order == ['TS1', 'TS3']  # TS1 barrier 21.3 < TS3 barrier 30.7
+        assert [cand.ts_label for cand, _ in declined] == ['TS2']
+
+    def test_window_declines_the_isomerization_saddle(self):
+        _, declined = rank_candidates_by_distrust(_round0_candidates(), _ROUND0_E0,
+                                                  DistrustParams(energy_window_kj=30.0))
+        assert [cand.ts_label for cand, _ in declined] == ['TS2']
+
+
+class TestSelectByDistrust:
+
+    def _evidence(self, ts2_coeff):
+        # TS1/TS3 report a structural zero; TS2 reports whatever we pass. delta_ln_k unused by the
+        # distrust selector -- present only because capture records the coefficient.
+        return {'TS1': (1.27e-18, 2.9e-14), 'TS2': (ts2_coeff, abs(ts2_coeff) * 8368.0),
+                'TS3': (1.27e-18, 2.9e-14)}
+
+    def test_selects_the_entrance_channels_the_floor_cannot_reach(self):
+        split = CandidateSplit(candidates=_round0_candidates())
+        out = select_by_distrust(split, self._evidence(-1.43e-05), _ROUND0_E0,
+                                 DistrustParams(energy_window_kj=30.0))
+        assert [c.ts_label for c in out.candidates] == ['TS1', 'TS3']
+        assert all(c.distrust_score is not None for c in out.candidates)
+        declined = [s for s in out.skipped if s.classification == SKIP_OUTSIDE_WINDOW]
+        assert [s.ts_label for s in declined] == ['TS2']
+
+    def test_structural_zero_does_not_change_the_ranking(self):
+        # The whole point: distrust ignores the sensitivity value, so flipping TS2's coefficient
+        # from a real number to an exact structural zero leaves the selection identical.
+        split = CandidateSplit(candidates=_round0_candidates())
+        real = select_by_distrust(split, self._evidence(-1.43e-05), _ROUND0_E0, DistrustParams())
+        zero = select_by_distrust(split, self._evidence(0.0), _ROUND0_E0, DistrustParams())
+        assert [c.ts_label for c in real.candidates] == [c.ts_label for c in zero.candidates]
+        assert [s.classification for s in real.skipped] == [s.classification for s in zero.skipped]
+
+    def test_measured_coefficient_is_carried_for_capture(self):
+        split = CandidateSplit(candidates=_round0_candidates())
+        out = select_by_distrust(split, self._evidence(-1.43e-05), _ROUND0_E0, DistrustParams())
+        ts1 = next(c for c in out.candidates if c.ts_label == 'TS1')
+        # The structural-zero coefficient stays visible on the queued candidate (I-031), never
+        # clamped, even though distrust -- not it -- justified the selection.
+        assert ts1.coefficient == 1.27e-18
+
+    def test_does_not_select_everything(self):
+        # Negative control: with a high saddle on the surface, distrust declines it.
+        split = CandidateSplit(candidates=_round0_candidates())
+        out = select_by_distrust(split, self._evidence(-1.43e-05), _ROUND0_E0, DistrustParams())
+        assert len(out.candidates) < len(split.candidates)
+        assert any(s.classification == SKIP_OUTSIDE_WINDOW for s in out.skipped)
+
+    def test_library_candidate_is_skipped_not_queued(self):
+        # A trusted library value that is IN the window must still be skipped, not queued: provenance
+        # gates here, it does not merely lower the rank (Copilot PR #209 finding).
+        lib = _cand(_rxn('reaction3', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1',
+                         comment="Reaction library: 'kineticsjobs'"), 'TS1')
+        out = select_by_distrust(CandidateSplit(candidates=(lib,)), {'TS1': (1.0, 0.5)},
+                                 _ROUND0_E0, DistrustParams())
+        assert out.candidates == ()
+        assert [s.classification for s in out.skipped] == [SKIP_TRUSTED_PROVENANCE]
+        assert out.skipped[0].ts_label == 'TS1'
+
+    def test_library_skipped_while_estimate_selected(self):
+        lib = _cand(_rxn('reaction3', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1',
+                         comment="Reaction library: 'kineticsjobs'"), 'TS1')
+        split = CandidateSplit(candidates=(lib,) + _round0_candidates()[1:])
+        out = select_by_distrust(split, self._evidence(-1.43e-05), _ROUND0_E0, DistrustParams())
+        # TS1 trusted-skip, TS2 out-of-window, only TS3 (an in-window estimate) queued.
+        assert [c.ts_label for c in out.candidates] == ['TS3']
+        assert any(s.classification == SKIP_TRUSTED_PROVENANCE and s.ts_label == 'TS1'
+                   for s in out.skipped)
+
+    def test_candidate_without_a_finite_row_is_skipped_not_invented(self):
+        split = CandidateSplit(candidates=_round0_candidates())
+        evidence = {'TS1': (1.27e-18, 2.9e-14), 'TS3': (1.27e-18, 2.9e-14)}  # TS2 absent
+        out = select_by_distrust(split, evidence, _ROUND0_E0, DistrustParams())
+        no_row = [s for s in out.skipped if s.ts_label == 'TS2']
+        assert len(no_row) == 1
+        # TS2 is unimolecular on both sides, so its E0 sensitivity IS structurally measurable ->
+        # a genuinely missing row is SKIP_NO_EVIDENCE, not SKIP_UNMEASURABLE.
+        assert no_row[0].classification == SKIP_NO_EVIDENCE
+
+    def test_unmeasurable_candidate_without_a_row_is_classified_unmeasurable(self):
+        rxn = _rxn('reaction3', ('[H](6)', 'O=C=O(5)'), ('[O]C=O(1)',), 'TS1')
+        split = CandidateSplit(candidates=(_cand(rxn, 'TS1', measurable=False),))
+        out = select_by_distrust(split, {}, _ROUND0_E0, DistrustParams())
+        assert len(out.candidates) == 0
+        assert out.skipped[0].classification == SKIP_UNMEASURABLE
+
+
+class TestTrimUnderDistrustScope:
+    """`_trim_candidates` must keep the distrust order select_by_distrust imposed, not re-sort."""
+
+    def _distrust_config(self, limit=10):
+        return PESLoopConfig(pes={'network': '/abs/n.py', 'source': ['HOCHO'],
+                                  'bath_gas': {'He': 1.0}},
+                             qm={'scope': 'distrust', 'max_transition_states_per_round': limit})
+
+    def test_distrust_order_is_preserved_not_resorted_by_coefficient(self):
+        # Feed candidates whose distrust order (TS1 then TS3) is the REVERSE of what a
+        # |coefficient| sort would produce -- so a wrongly-wired trim that re-sorts is caught.
+        split = CandidateSplit(candidates=_round0_candidates())
+        ranked = select_by_distrust(split, {'TS1': (1e-18, 0.0), 'TS2': (-1.43e-05, 0.12),
+                                            'TS3': (5e-05, 0.42)},
+                                    _ROUND0_E0, DistrustParams()).candidates
+        assert [c.ts_label for c in ranked] == ['TS1', 'TS3']  # distrust order (barrier), not coeff
+        trimmed = _trim_candidates(ranked, self._distrust_config(), logger=None)
+        assert [c.ts_label for c in trimmed] == ['TS1', 'TS3']
+
+    def test_limit_takes_the_most_distrusted(self):
+        split = CandidateSplit(candidates=_round0_candidates())
+        ranked = select_by_distrust(split, {'TS1': (1e-18, 0.0), 'TS2': (-1.43e-05, 0.12),
+                                            'TS3': (1e-18, 0.0)},
+                                    _ROUND0_E0, DistrustParams()).candidates
+        trimmed = _trim_candidates(ranked, self._distrust_config(limit=1), logger=None)
+        assert [c.ts_label for c in trimmed] == ['TS1']
+
+
+class TestVarParsing:
+
+    def test_rate_uncertainty_var_is_read(self):
+        text = (
+            "reaction(\n"
+            "    label = 'r1', reactants = ['A'], products = ['B'], transitionState = 'TS1',\n"
+            "    kinetics = Arrhenius(A=(1.0,'s^-1'), n=0, Ea=(0,'kJ/mol'), T0=(1,'K'),\n"
+            "        uncertainty=RateUncertainty(mu=0.08, var=25.73102631834909, Tref=1000.0, N=5,\n"
+            "        data_mean=0.0, correlation='x'), comment='''Estimated from node x.'''),\n)\n"
+            "network(label='n', isomers=['A'], reactants=[], bathGas={'Ar': 1})\n")
+        network = parse_pdep_network_text(text, network_id='n1', path='/abs/n1.py')
+        assert abs(network.path_reactions[0].kinetics_uncertainty_var - 25.73102631834909) < 1e-9
+
+    def test_absent_uncertainty_is_none(self):
+        text = (
+            "reaction(\n"
+            "    label = 'r1', reactants = ['A'], products = ['B'], transitionState = 'TS1',\n"
+            "    kinetics = Arrhenius(A=(1.0,'s^-1'), n=0, Ea=(0,'kJ/mol'), T0=(1,'K'),\n"
+            "        comment='''family: R_Addition_MultipleBond'''),\n)\n"
+            "network(label='n', isomers=['A'], reactants=[], bathGas={'Ar': 1})\n")
+        network = parse_pdep_network_text(text, network_id='n1', path='/abs/n1.py')
+        assert network.path_reactions[0].kinetics_uncertainty_var is None
+
+
+class TestEndToEndRound0Text:
+    """Parse an inline reduced-network text (the round-0 topology) and select through the real seam."""
+
+    _NETWORK_TEXT = """
+species(label='O=[C]O(8)', E0=(-184.487,'kJ/mol'))
+species(label='[O]C=O(1)', E0=(-169.935,'kJ/mol'))
+species(label='[H](6)', E0=(211.805,'kJ/mol'))
+species(label='O=C=O(5)', E0=(-403.087,'kJ/mol'))
+transitionState(label='TS1', E0=(21.347 - 191.282, 'kJ/mol'))
+transitionState(label='TS2', E0=(135.319 - 191.282, 'kJ/mol'))
+transitionState(label='TS3', E0=(30.706 - 191.282, 'kJ/mol'))
+reaction(label='reaction3', reactants=['[H](6)', 'O=C=O(5)'], products=['[O]C=O(1)'],
+         transitionState='TS1',
+         kinetics=Arrhenius(A=(1.0,'m^3/(mol*s)'), n=0, Ea=(21.3,'kJ/mol'), T0=(1,'K'),
+                            comment='''family: R_Addition_MultipleBond'''))
+reaction(label='reaction5', reactants=['[O]C=O(1)'], products=['O=[C]O(8)'],
+         transitionState='TS2',
+         kinetics=Arrhenius(A=(1.0,'s^-1'), n=0, Ea=(114.0,'kJ/mol'), T0=(1,'K'),
+                            comment='''family: intra_H_migration'''))
+reaction(label='reaction8', reactants=['[H](6)', 'O=C=O(5)'], products=['O=[C]O(8)'],
+         transitionState='TS3',
+         kinetics=Arrhenius(A=(1.0,'cm^3/(mol*s)'), n=0, Ea=(30.7,'kJ/mol'), T0=(1,'K'),
+                            comment='''family: R_Addition_MultipleBond'''))
+network(label='PDepNetwork #1', isomers=['O=[C]O(8)', '[O]C=O(1)'], reactants=[], bathGas={'Ar': 1})
+"""
+
+    def test_parsed_network_selects_entrance_channels(self):
+        network = parse_pdep_network_text(self._NETWORK_TEXT, network_id='n0', path='/abs/n0.py')
+        e0 = parse_pdep_network_e0_text(self._NETWORK_TEXT, path='/abs/n0.py')
+        split = CandidateSplit(candidates=tuple(
+            QMCandidate(path_reaction=pr, ts_label=pr.transition_state, family=None)
+            for pr in network.path_reactions))
+        evidence = {'TS1': (1.27e-18, 2.9e-14), 'TS2': (-1.43e-05, 0.12), 'TS3': (1.27e-18, 2.9e-14)}
+        out = select_by_distrust(split, evidence, e0, DistrustParams(energy_window_kj=30.0))
+        # Both [H] + O=C=O entrance channels selected; the isomerization saddle declined.
+        assert [c.ts_label for c in out.candidates] == ['TS1', 'TS3']
+        assert [s.ts_label for s in out.skipped if s.classification == SKIP_OUTSIDE_WINDOW] == ['TS2']


### PR DESCRIPTION
## Why the current criterion cannot work

The PES exploration loop selects transition states for QM by **master-equation E0-sensitivity**:
perturb a saddle's `E0`, measure the `ln(k)` response, queue the movers. That criterion is
structurally blind to the channels a mechanism most needs. A transition state in a reduced network
file carries no statmech `modes` (nobody has run the QM yet — that *is* the queue), so
`Reaction.can_tst()` is `False` and every `k(E)` comes from the inverse Laplace transform, where the
saddle's `E0` enters only as a discrete threshold gate (`rmgpy/pdep/reaction.pyx`). For a
**bimolecular** association/dissociation channel that gate never binds — the rate is fixed by the
bimolecular asymptote, the detailed-balance clamp, and HPL renormalization — so perturbing the
saddle's `E0` is an exact no-op and the reported sensitivity is a **structural zero** (`0.0` or
~1e-18), not a measurement of low leverage. The bias is worst exactly for the low `[H] + O=C=O`
entrance channels that carry the reactive flux.

> You cannot use a quantity's sensitivity to decide whether to compute that quantity, when not
> having computed it is what makes the sensitivity meaningless.

I-031 already made the loop *tell the truth* about this (`SKIP_UNMEASURABLE`). This PR is the
**criterion change**.

## What this adds — rank by distrust

A new selection scope, `qm.scope: 'distrust'`, that ranks a candidate by **how little we trust the
barrier we currently hold**, from data present *before* any QM runs. It reads no sensitivity value,
so no structural zero can suppress a candidate and the "just invert the sensitivity" trap (same zero,
new sign) is avoided by construction.

**Inputs, and why this combination:**

- **Flat energy window over the E0 surface — the gate.** A saddle more than `energy_window_kj`
  (default 30) above the lowest saddle on the surface carries negligible flux at the temperatures of
  interest and is declined regardless of provenance. This is what makes the criterion a *screen*
  rather than a firehose (the negative control below), and it is pure arithmetic over the `E0`
  values already in the file.
- **Provenance — the dominant rank term.** A family/rate-rule estimate is distrusted; a library or
  already-computed value (which is what a completed QM job's fitted rate becomes) is trusted and not
  re-queued. Read from the kinetics comment.
- **RMG's own `RateUncertainty(var=...)` — an optional secondary term.** When RMG produced the rate
  by decision-tree node averaging it attaches its own variance; larger `var` → more distrust. It is
  *optional*: absent on a plain estimate, in which case it contributes nothing.
- **Barrier height — the tiebreak.** Among equally-provenanced saddles, the lower barrier carries
  more flux and is worth getting right first.

Why not the alternatives: ranking by `1/sensitivity` inherits the same structural zero; seeding
provisional statmech onto an uncomputed saddle invents frequencies RMG's group estimator cannot
supply (rejected upstream). Barrier + window is computable from the file, needs no QM, and — as the
replay shows — reaches the entrance channels the sensitivity screen provably cannot.

The sensitivity path (`scope: 'sensitive'`/`'all'`) is **unchanged**. Under distrust the ME SA still
runs and its coefficient is still stamped on each queued candidate (so `t3.pdep.capture` accepts the
artifact and the structural zero stays visible in the record — I-031), but distrust, not that
coefficient, decides what survives and in what order.

## A premise in the ticket was wrong — reported, not built on

The ticket stated `var=25.7` is present in `round_0/.../network0_reduced.py`. It is **not**:
`var=25.73102631834909` lives in `network0_full.py` (on an `Intra_R_Add_Endocyclic` reaction that is
reduced out), and **none of the three reactions in the reduced network carry any `RateUncertainty`**.
So for this network `var` contributes nothing and the **energy window + barrier** term is what
selects the entrance channels. `var` is parsed and applied wherever a reaction *does* carry it
(e.g. full networks), but it is not load-bearing here.

## Verification — replay against the retained r002 CHO2 run

Replayed on copies of the retained round-0 and round-1 artifacts, driving the real seams
(`parse_pdep_network_file`, `parse_pdep_network_e0_file`, `split_qm_candidates`,
`ts_sensitivity_evidence`, `select_by_distrust`). TS labels are derived from each file's own
reaction→TS mapping, never asserted (Arkane renumbers between rounds).

**Round 0** — entrance channels TS1 (`reaction3`), TS3 (`reaction8`):

```
[2] Current criterion (floor 1e-3): TS1 delta_ln_k=2.9e-14 dropped; TS3 dropped; TS2 SURVIVES
    entrance channels the current criterion would queue: []   (the case it cannot reach)
[3] Distrust: TS1 barrier=21.35 height=0.00  IN-WINDOW [ENTRANCE]
              TS3 barrier=30.71 height=9.36  IN-WINDOW [ENTRANCE]
              TS2 barrier=128.52 height=113.97 DECLINED (outside window)
[4] Selected: ['TS1','TS3'] (both [H]+O=C=O)   Declined: ['TS2'] (isomerization)
```

**Round 1** (Arkane renumbered) — entrance channels TS2 (`reaction4`), TS3 (`reaction3`); TS1 is the
round-0 QM'd isomerization (`Reaction library: 'kineticsjobs'`):

```
[2] Current criterion: all three delta_ln_k=1.4e-14 dropped — the false convergence
    entrance channels the current criterion would queue: []
[3] Distrust: TS2 barrier=21.35 height=0.00 IN-WINDOW [ENTRANCE]
              TS3 barrier=30.71 height=9.36 IN-WINDOW [ENTRANCE]
              TS1 prov=library height=59.17 DECLINED (outside window)
[4] Selected: ['TS2','TS3'] (both [H]+O=C=O)   Declined: ['TS1'] (library isomerization)
```

**Repo checks** (run with output redirected to a file, summary read — never trusted through a pipe):

```
ruff check .                                              -> All checks passed!
python -m pytest tests/test_pdep tests/test_pes_cli.py    -> 2024 passed, 171 warnings in 241s
```

21 new tests in `tests/test_pdep/test_distrust.py`. No failures, so nothing pre-existing to isolate.

## Scope / follow-ups

- Ends at a replay against retained artifacts: **no QM, no cluster submission.** No energy, rate, or
  fitted parameter changes — selection only.
- Shipped as an opt-in scope (default `'sensitive'` unchanged) so the delicate sensitivity/convergence
  path and its ~2000 tests are untouched. Flipping the default to `'distrust'` once the criterion is
  validated on more surfaces, and recording the distrust score (not just the coefficient) into the
  capture manifest, are natural follow-ups.
