### PR TITLE
docs(pdep): name the finite-SA-row precondition at the distrust call site (I-037)

### DIFF
--- a/t3/pdep/pes_loop.py
+++ b/t3/pdep/pes_loop.py
@@ -655,8 +655,20 @@ def run_pes_loop(config: PESLoopConfig, project_directory: str, qm_runner=None,
                 # Rank by distrust (I-032), not by the sensitivity floor: the floor cannot reach the
                 # low bimolecular entrance channels whose sensitivity is a structural zero. The SA
                 # still ran above -- its coefficient is carried onto each survivor for capture and
-                # kept visible in the record (I-031) -- but distrust, not that coefficient, decides
-                # what survives and in what order.
+                # kept visible in the record (I-031). Distrust, not that coefficient's VALUE, sets
+                # the order and picks among the in-window candidates.
+                #
+                # But the coefficient's PRESENCE is still a precondition, so the escape from the
+                # floor lives in the RANKING and is not unconditional (I-037): select_by_distrust
+                # drops any candidate for which this round's Arkane SA left no finite row BEFORE the
+                # distrust window is applied, classifying it SKIP_UNMEASURABLE / SKIP_NO_EVIDENCE,
+                # because t3.pdep.capture refuses an artifact with no coefficient to record. An
+                # ordinary structural zero is a FINITE row (0.0 or ~1e-18) and is kept, so on a
+                # pristine pre-QM surface every entrance channel survives to be ranked (see
+                # tests/test_pdep/test_pes_sa.py::test_run_round_me_sensitivity_runs_real_arkane,
+                # where real Arkane emits a finite row for every TS). Only a NaN/absent row -- a
+                # degenerate ME solve, not the structural-zero case distrust was built for --
+                # reintroduces the floor's blindness for that one in-window candidate.
                 split = select_by_distrust(
                     split, evidence, parse_pdep_network_e0_file(explored_network_path),
                     DistrustParams(energy_window_kj=config.qm.energy_window_kj))


### PR DESCRIPTION
## What

The distrust selector's escape from the master-equation sensitivity **floor** was documented at the `pes_loop` call site as if it were unconditional: *"distrust, not that coefficient, decides what survives and in what order."* This corrects the record. The escape lives in the **ranking** (`compute_distrust` reads no sensitivity value), but selection is **conditional** on Arkane emitting a finite SA row.

Comment-only; no behaviour change.

## Why (I-037)

`select_by_distrust` (`t3/pdep/distrust.py:317`) gates each candidate on `evidence_by_ts_label.get(candidate.ts_label)`. A candidate with no finite row is skipped **before** the distrust energy window is applied — `SKIP_UNMEASURABLE` if structurally unmeasurable, else `SKIP_NO_EVIDENCE` — because `t3.pdep.capture` refuses an artifact with no coefficient to record.

An ordinary structural zero is a **finite** row (`0.0` or `~1e-18`) and is kept, so on a pristine pre-QM surface every bimolecular entrance channel survives to be ranked (confirmed by `test_run_round_me_sensitivity_runs_real_arkane`, where real Arkane emits a finite row for every TS). Only a **NaN/absent** row — a degenerate ME solve, not the structural-zero case distrust was built for — reintroduces the floor's blindness for that one in-window candidate.

## Verifier

A constructed no-row network run through `select_by_distrust`:

| candidate | in window? | Arkane row? | result |
|---|---|---|---|
| TS1 bimolecular entrance | yes | **none** | `SKIP_UNMEASURABLE` |
| TS2 unimolecular | yes | **none** | `SKIP_NO_EVIDENCE` |
| TS3 control | yes | finite | **SELECTED** |

`tests/test_pdep/test_distrust.py tests/test_pdep/test_pes_sa.py tests/test_pdep/test_pes_loop.py` — 80 passed, unchanged.

## Verdict

**Conditional escape**, condition = a finite SA row exists for the candidate. The condition holds on ordinary pre-QM surfaces (finite structural zeros), so this is a documentation matter, not a live defect there. The failure mode (NaN/absent row) is reachable only under a degenerate ME solve; whether real Arkane then writes a NaN row vs. crashing the whole SA job (which the round already catches and fails loudly) is unverified here without running Arkane on such a network.